### PR TITLE
fix: resolve landing page redirect loop and enable proper navigation from dashboard

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -52,7 +52,13 @@ export function AppSidebar() {
   return (
     <Sidebar collapsible="icon">
       <div className="flex items-center justify-between p-4 border-b border-sidebar-border">
-        {!isCollapsed && <h2 className="text-lg font-semibold text-sidebar-foreground">Health Tracker</h2>}
+        <NavLink to="/" className="flex items-center">
+          {!isCollapsed && (
+            <h2 className="text-lg font-semibold text-sidebar-foreground cursor-pointer">
+              Health Tracker
+            </h2>
+          )}
+        </NavLink>
         <SidebarTrigger />
       </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,15 +12,6 @@ const Index = () => {
   const [activeTestimonial, setActiveTestimonial] = useState(0);
 
   useEffect(() => {
-    // Check if user is logged in and redirect to dashboard
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session) {
-        navigate("/dashboard");
-      }
-    });
-  }, [navigate]);
-
-  useEffect(() => {
     const interval = setInterval(() => {
       setActiveTestimonial((prev) => (prev + 1) % 3);
     }, 5000);


### PR DESCRIPTION
## What was the issue?
After logging in and accessing the dashboard, navigating back to the landing page caused an immediate redirect back to the dashboard. This created a routing loop where the landing page was not accessible for authenticated users.

Additionally, the dashboard sidebar title was not functioning as a proper navigation link to the landing page.

## What was changed?
- Removed redundant auto-redirect logic from `Index.tsx` that was forcing authenticated users back to `/dashboard`
- This eliminated the routing conflict between landing page and protected route logic
- Added navigation link to sidebar title in `AppSidebar.tsx` to allow users to return to the landing page from dashboard

## Why this fix works
- `ProtectedRoute` already handles route protection for authenticated pages
- Removing duplicate redirect logic prevents navigation override
- Ensures consistent and expected routing behavior across the app

## How to test
1. Login to the application
2. Navigate to Dashboard
3. Click on "Health Tracker" in sidebar
4. Verify it navigates to landing page without redirecting back
5. Confirm dashboard remains accessible via /dashboard route

Closes #10