### PR TITLE
fix: add favicon using stethoscope icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Smart Health Tracker - AI Symptom Analyzer</title>
     <meta name="description" content="AI-powered symptom checker that provides instant health insights, severity assessment, and self-care recommendations. Get personalized health guidance in seconds." />
     <meta name="author" content="Smart Health Tracker" />
-
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta property="og:title" content="Smart Health Tracker - AI Symptom Analyzer" />
     <meta property="og:description" content="Describe your symptoms and get AI-powered health insights with severity levels and self-care advice." />
     <meta property="og:type" content="website" />

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="50" fill="#0d9488"/>
-  <text x="50" y="68" font-size="60" text-anchor="middle" fill="white">🩺</text>
+  <circle cx="50" cy="50" r="50" fill="#0f172a"/>
+  <text x="50" y="73" font-size="72" text-anchor="middle" fill="#22d3ee">️🩺</text>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#0d9488"/>
+  <text x="50" y="68" font-size="60" text-anchor="middle" fill="white">🩺</text>
+</svg>


### PR DESCRIPTION
## What does this PR do?
The browser tab was showing a blank icon because there was no favicon set up. 
I created a simple SVG favicon using the stethoscope emoji that matches the 
site's health/medical theme and linked it in the HTML head.

## Changes
- Added `public/favicon.svg` with a teal stethoscope icon matching the brand color
- Added `<link rel="icon">` in `index.html` to connect the favicon
