### PR TITLE
fix: remove redundant SidebarTrigger from AppSidebar

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -11,7 +11,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
 
@@ -51,7 +50,7 @@ export function AppSidebar() {
 
   return (
     <Sidebar collapsible="icon">
-      <div className="flex items-center justify-between p-4 border-b border-sidebar-border">
+      <div className="h-14 flex items-center px-4 border-b border-sidebar-border">
         <NavLink to="/" className="flex items-center">
           {!isCollapsed && (
             <h2 className="text-lg font-semibold text-sidebar-foreground cursor-pointer">
@@ -59,7 +58,6 @@ export function AppSidebar() {
             </h2>
           )}
         </NavLink>
-        <SidebarTrigger />
       </div>
 
       <SidebarContent>


### PR DESCRIPTION
###  Related Issue
Closes #24

---

###  Description
- Removed the duplicate `<SidebarTrigger />` component from `AppSidebar.tsx`.
- Adjusted header styles (`h-14 flex items-center px-4`) to ensure smooth visual spacing without the button.
- Cleaned up the unused `SidebarTrigger` import to prevent TypeScript/Vite build warnings.
- Preserved the primary sidebar toggle in `Layout.tsx` for clean global control.

---
###  Screenshots 

| Before | After |
|--------|-------|
| <img width="833" height="748" alt="Screenshot 2026-05-19 at 10 45 59 PM" src="https://github.com/user-attachments/assets/5b2787ad-5740-4d33-8648-681147b9a58a" /> | <img width="829" height="754" alt="Screenshot 2026-05-19 at 10 46 08 PM" src="https://github.com/user-attachments/assets/b5e55c85-1877-4ad1-94fc-21d91dc3fca2" /> |

---