### PR TITLE
Fix: Resolve duplicate sidebar triggers across responsive breakpoints

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -59,7 +59,11 @@ export function AppSidebar() {
             </h2>
           )}
         </NavLink>
-        <SidebarTrigger />
+        
+        {/* ✅ Hidden on mobile, visible on laptop/desktop */}
+        <div className="hidden md:block">
+          <SidebarTrigger />
+        </div>
       </div>
 
       <SidebarContent>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -20,7 +20,11 @@ const Layout = ({ children }: LayoutProps) => {
 
             <div className="ml-auto flex items-center gap-2">
               <AnimatedThemeToggler />
-              <SidebarTrigger />
+              
+              {/* ✅ Visible ONLY on mobile. Hidden on laptop/desktop. */}
+              <div className="md:hidden">
+                <SidebarTrigger />
+              </div>
             </div>
           </header>
           <main className="flex-1 p-6 overflow-auto">


### PR DESCRIPTION
Closes #24

## Description
This PR resolves the visual clutter caused by the `SidebarTrigger` rendering simultaneously in both the application sidebar and the main layout header.

Instead of completely removing one of the triggers, I implemented a responsive visibility toggle to ensure the most intuitive user experience across all devices:
* **Mobile:** The trigger inside the global `Layout.tsx` header is visible, while the sidebar's internal trigger is hidden.
* **Laptop/Desktop:** The global header trigger is hidden, and the trigger within `AppSidebar.tsx` takes over to handle the open/close state natively. 
<img width="1470" height="920" alt="Screenshot 2026-05-20 at 9 41 49 AM" src="https://github.com/user-attachments/assets/9db34d57-9360-4e2b-9c44-4ee41fdc023f" />
<img width="805" height="523" alt="Screenshot 2026-05-20 at 9 42 06 AM" src="https://github.com/user-attachments/assets/417c3ded-a728-40ae-aea7-39c27c0f28e5" />

## Changes Made
- Wrapped the `SidebarTrigger` in `src/components/AppSidebar.tsx` with `<div className="hidden md:block">` so it only displays on larger screens.
- Wrapped the `SidebarTrigger` in `src/components/Layout.tsx` with `<div className="md:hidden">` so it only displays on smaller screens.

## Testing
- Verified on desktop resolution (sidebar trigger is inside the sidebar header, layout header is clean).
- Verified on mobile/tablet resolution (sidebar trigger moves to the layout header, no duplicates are shown when the sidebar is opened).
- Ensured no layout shifting occurs when toggling between breakpoints.