### PR TITLE
fix: add cascade delete foreign key constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+supabase/.branches/
+supabase/.temp/

--- a/supabase/migrations/20260522153000_add_cascade_deletes.sql
+++ b/supabase/migrations/20260522153000_add_cascade_deletes.sql
@@ -1,0 +1,18 @@
+-- 1. Clean up any existing orphaned records first
+DELETE FROM public.profiles WHERE user_id NOT IN (SELECT id FROM auth.users);
+DELETE FROM public.symptom_history WHERE user_id NOT IN (SELECT id FROM auth.users);
+DELETE FROM public.health_metrics WHERE user_id NOT IN (SELECT id FROM auth.users);
+DELETE FROM public.chat_sessions WHERE user_id NOT IN (SELECT id FROM auth.users);
+
+-- 2. Add foreign key constraints with ON DELETE CASCADE
+ALTER TABLE public.profiles 
+  ADD CONSTRAINT fk_profiles_user FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.symptom_history 
+  ADD CONSTRAINT fk_symptom_history_user FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.health_metrics 
+  ADD CONSTRAINT fk_health_metrics_user FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.chat_sessions 
+  ADD CONSTRAINT fk_chat_sessions_user FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Changes

* Added foreign key constraints for user-linked tables
* Added `ON DELETE CASCADE` behavior
* Improved referential integrity and automatic cleanup of orphaned user data

## Tables Updated

* `profiles`
* `symptom_history`
* `health_metrics`
* `chat_sessions`

## Tested

* Successfully ran `supabase db reset` locally
* Migration applied without errors

Closes #45
