### PR TITLE
clear Word Recall timeout to prevent stale state and intrusive toast

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,9 +21,9 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
 
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/src/pages/BrainGames.tsx
+++ b/src/pages/BrainGames.tsx
@@ -47,7 +47,8 @@ const BrainGames = () => {
   const [timedMode, setTimedMode] = useState(false);
   const [questionTimeLeft, setQuestionTimeLeft] = useState(15);
   const [showFireStreak, setShowFireStreak] = useState(false);
-  const timerRef = useRef<number | null>(null);  
+  const timerRef = useRef<number | null>(null);
+const wordTimeoutRef = useRef<number | null>(null);  
   const TOTAL_QUESTIONS = 10;
   const XP_PER_QUESTION = 10;
   const XP_PER_LEVEL = 100;
@@ -403,6 +404,10 @@ const BrainGames = () => {
     setWordPhase("memorize");
     setTimeLeft(10);
     setActiveGame("word");
+    wordTimeoutRef.current = window.setTimeout(() => {
+      setWordPhase("recall");
+      showWarning("Time's up!", "Now recall the words in order");
+    }, 10000);
 
     showInfo("Memorize these words!", "You have 10 seconds...");
 
@@ -766,7 +771,14 @@ const BrainGames = () => {
           <CardHeader>
             <CardTitle className="flex items-center justify-between">
               <span>Word Recall Challenge</span>
-              <Button variant="outline" onClick={() => { setActiveGame(null); showInfo("Word Game Exited", "Keep practicing your memory!"); }}>Exit Game</Button>
+              <Button variant="outline" onClick={() => {
+          if (wordTimeoutRef.current) {
+            clearTimeout(wordTimeoutRef.current);
+            wordTimeoutRef.current = null;
+          }
+          setActiveGame(null);
+          showInfo("Word Game Exited", "Keep practicing your memory!");
+        }}>Exit Game</Button>
             </CardTitle>
             <CardDescription>Memorize the words, then recall them in order</CardDescription>
           </CardHeader>

--- a/src/pages/BrainGames.tsx
+++ b/src/pages/BrainGames.tsx
@@ -411,10 +411,7 @@ const wordTimeoutRef = useRef<number | null>(null);
 
     showInfo("Memorize these words!", "You have 10 seconds...");
 
-    setTimeout(() => {
-      setWordPhase("recall");
-      showWarning("Time's up!", "Now recall the words in order");
-    }, 10000);
+
   };
   
   useEffect(() => {
@@ -426,6 +423,14 @@ const wordTimeoutRef = useRef<number | null>(null);
 
     return () => clearInterval(timer);
   }, [wordPhase, timeLeft]);
+
+  // Cleanup timeout when leaving Word game or unmounting
+  useEffect(() => {
+    if (activeGame !== "word" && wordTimeoutRef.current) {
+      clearTimeout(wordTimeoutRef.current);
+      wordTimeoutRef.current = null;
+    }
+  }, [activeGame]);
 
   const generateMathQuestion = () => {
     const num1 = Math.floor(Math.random() * 50) + 10;


### PR DESCRIPTION
closes issue #70 

PURPOSE -

The Word Recall game starts a 10‑second setTimeout for the memorisation phase. If the player exits the game before the timer fires, the timeout remains active and later updates the hidden wordPhase state and shows a “Time’s up!” toast. This results in:

Stale state updates – the lobby’s state is corrupted for the next game session.
Intrusive UI – a toast appears after the user has already left the game.
The PR introduces a dedicated wordTimeoutRef so the timer can be cleared when the game is exited, eliminating the leak and keeping the UI consistent.

HOW TO TEST - 


Start the app (npm run dev).

Navigate to Brain Fitness Center → Word Recall and click Play Now.

While the 10‑second memorisation countdown is running, click Exit Game.

Expectations:

No “Time’s up!” toast appears after leaving the lobby.
The UI returns to the game lobby without any change in wordPhase.
Starting a new Word Recall session works normally (countdown restarts).
Additional sanity check:

Let the timer finish without exiting – the toast should appear and the phase should change to “recall”.


SCREENSHOTS (before and after) -

<img width="1557" height="511" alt="image" src="https://github.com/user-attachments/assets/1d6d9422-4d22-4244-a7b5-5a22ed2e586f" />
<img width="1553" height="562" alt="image" src="https://github.com/user-attachments/assets/fb15bf3c-1ec4-4c84-ade6-0f6c55d7ff64" />
 
