### PR TITLE
fix(sidebar): auto-close mobile drawer after navigation item click

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -28,7 +28,8 @@ const menuItems = [
 ];
 
 export function AppSidebar() {
-  const { state } = useSidebar();
+
+  const { state, setOpenMobile, isMobile } = useSidebar(); 
   const location = useLocation();
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -47,13 +48,20 @@ export function AppSidebar() {
     }
   };
 
+  const handleMobileNavClick = () => {
+    if (isMobile && setOpenMobile) {
+      setOpenMobile(false);
+    }
+  };
+
   const getNavCls = ({ isActive }: { isActive: boolean }) =>
     isActive ? "bg-accent text-accent-foreground font-medium" : "hover:bg-accent/50";
 
   return (
     <Sidebar collapsible="icon">
       <div className="flex items-center justify-between p-4 border-b border-sidebar-border">
-        <NavLink to="/" className="flex items-center">
+
+        <NavLink to="/" className="flex items-center" onClick={handleMobileNavClick}>
           {!isCollapsed && (
             <h2 className="text-lg font-semibold text-sidebar-foreground cursor-pointer">
               Health Tracker
@@ -75,7 +83,8 @@ export function AppSidebar() {
               {menuItems.map((item) => (
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton asChild>
-                    <NavLink to={item.url} end className={getNavCls}>
+
+                    <NavLink to={item.url} end className={getNavCls} onClick={handleMobileNavClick}>
                       <item.icon className="h-5 w-5" />
                       {!isCollapsed && <span>{item.title}</span>}
                     </NavLink>


### PR DESCRIPTION
### PR Description

Closes #40 

**What does this PR do?**
This PR fixes a UX bug on mobile viewports where the sidebar navigation drawer remained open after clicking a menu link. It ensures the sidebar automatically collapses to reveal the requested page without requiring manual dismissal by the user.

**Description of changes:**
* Extracted `isMobile` and `setOpenMobile` from the `useSidebar` hook.
* Created a `handleMobileNavClick` helper function that triggers `setOpenMobile(false)` exclusively on mobile devices.
* Attached the `onClick` handler to the main application logo link and all mapped `NavLink` elements within the sidebar menu.
* **Note:** Desktop sidebar collapse/expand mechanics remain entirely unaffected by this change.

**Steps to test:**
1. Open the application in a mobile viewport or DevTools mobile emulator.
2. Expand the sidebar using the toggle button.
3. Click on any navigation link (e.g., Dashboard, AI Assistant, Health Metrics) or the main "Health Tracker" header.
4. Verify that the route changes successfully in the background **and** the sidebar drawer immediately closes.
5. Resize to a desktop viewport and verify that the standard sidebar click mechanics behave normally.