### PR TITLE
Fix dashboard logo redirect behavior

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -53,10 +53,10 @@ export function AppSidebar() {
   return (
     <Sidebar collapsible="icon">
       <div className="flex items-center justify-between p-4 border-b border-sidebar-border">
-        <NavLink to="/" className="flex items-center">
+        <NavLink to="/dashboard" className="flex items-center">
           {!isCollapsed && (
             <h2 className="text-lg font-semibold text-sidebar-foreground cursor-pointer">
-              Health Tracker
+              Health Tracker 
             </h2>
           )}
         </NavLink>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -56,7 +56,7 @@ export function AppSidebar() {
         <NavLink to="/dashboard" className="flex items-center">
           {!isCollapsed && (
             <h2 className="text-lg font-semibold text-sidebar-foreground cursor-pointer">
-              Health Tracker 
+              Health Tracker
             </h2>
           )}
         </NavLink>


### PR DESCRIPTION
### Description

This PR fixes the dashboard sidebar logo navigation behavior.

Previously, clicking on the "Health Tracker" text/logo in the sidebar redirected authenticated users to the public landing page, which interrupted the dashboard flow.

### Changes Made
Updated the sidebar logo navigation to redirect users to the dashboard
Ensured authenticated users remain inside the dashboard experience

### Testing
Verified the application runs successfully locally
Tested logo click behavior from dashboard
Confirmed users are redirected to /dashboard instead of the landing page

### Fixes #109 

@mohdmaazgani Could you please assign the appropriate labels to this PR? Thank you!