### PR TITLE
Improve sign-in UX with password toggle and better input placeholder

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
-import { Activity, Loader2 } from "lucide-react";
+import { Activity, Loader2, Eye, EyeOff } from "lucide-react";
 import { z } from "zod";
 import { showSuccess, showError } from "@/lib/toast-helpers";
 import { PasswordStrengthMeter } from "@/components/PasswordStrengthMeter";
@@ -30,6 +30,7 @@ const Auth = () => {
 
   const [loading, setLoading] = useState(false);
   const [redirecting, setRedirecting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -168,16 +169,36 @@ const Auth = () => {
                     required
                   />
                 </div>
+
                 <div className="space-y-2">
                   <Label htmlFor="signin-password">Password</Label>
-                  <Input
-                    id="signin-password"
-                    type="password"
-                    value={signInPassword}
-                    onChange={(e) => setSignInPassword(e.target.value)}
-                    required
-                  />
+
+                  <div className="relative">
+                    <Input
+                      id="signin-password"
+                      type={showPassword ? "text" : "password"}
+                      placeholder="Enter your password"
+                      value={signInPassword}
+                      onChange={(e) => setSignInPassword(e.target.value)}
+                      required
+                      className="pr-10"
+                    />
+
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-colors"
+                      aria-label={showPassword ? "Hide password" : "Show password"}
+                    >
+                      {showPassword ? (
+                        <EyeOff size={18} />
+                      ) : (
+                        <Eye size={18} />
+                      )}
+                    </button>
+                  </div>
                 </div>
+
                 <Button type="submit" className="w-full" disabled={loading || redirecting}>
                   {redirecting ? (
                     <>


### PR DESCRIPTION
### PR Title :
Add password visibility toggle to sign-in page

### PR Description : 
This PR adds a password visibility toggle and improves the password input field.

### Changes

- Added show/hide password toggle in input field
- Added placeholder text for password field
- Implemented state handling for password visibility
- Updated UI for better user experience and accessibility

### Testing

- Verified toggle works for both states (show/hide)
- Checked UI responsiveness

### Before
<img width="1356" height="624" alt="image" src="https://github.com/user-attachments/assets/2c87805a-c610-4730-b30a-968662aaff7a" />


### After
<img width="1356" height="616" alt="password toggle after" src="https://github.com/user-attachments/assets/e6c2cf13-c910-4051-9d0a-ac0672707860" />



Closes #111 

@mohdmaazgani Could you please assign the appropriate labels to this PR? Thank you!