### PR TITLE
fix: render self-care recommendations in symptom history

### DIFF
--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -147,6 +147,17 @@ const History = () => {
                       </ul>
                     </div>
                   )}
+                  {entry.recommendations && entry.recommendations.length > 0 && (
+                    <div className="mt-2">
+                      <p className="text-sm font-semibold mb-1">Recommendations:</p>
+
+                      <ul className="text-sm text-muted-foreground list-disc list-inside">
+                        {entry.recommendations.map((rec, idx) => (
+                          <li key={idx}>{rec}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
                   {entry.risk_score !== null && (
                     <div className="flex items-center gap-2">
                       <p className="text-sm font-semibold">Risk Score:</p>


### PR DESCRIPTION
## Summary

Added rendering support for `recommendations` in the Symptom History page.

Previously, the `recommendations` field was correctly fetched from Supabase but never displayed in the UI. This update adds a conditional Recommendations section below Possible Causes in each history card.

## Changes Made

* Added conditional rendering for `entry.recommendations`
* Matched existing styling used for `possible_causes`
* Verified empty recommendation arrays do not render broken sections
* Confirmed no regression to existing history UI

## Testing

* Tested with records containing recommendations
* Tested with older records having empty/missing recommendations
* Verified responsive layout and styling consistency

## Screenshots

<img width="1115" height="338" alt="Screenshot 2026-05-27 080011" src="https://github.com/user-attachments/assets/6dffa7cd-52f3-4c2e-bef8-0f29b2537ca1" />

<img width="836" height="282" alt="Screenshot 2026-05-27 080205" src="https://github.com/user-attachments/assets/92451b8c-320d-4c11-b25d-48bc8f643dbe" />

Closes #117 
