### PR TITLE
fix: improve AI assistant response visibility in light mode

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -34,7 +34,7 @@ const ChatMessage = ({ role, content }: ChatMessageProps) => {
   <ReactMarkdown
     components={{
       strong: ({ children }) => (
-        <strong className="font-bold text-white">
+        <strong className="font-bold text-card-foreground">
           {children}
         </strong>
       ),
@@ -46,13 +46,13 @@ const ChatMessage = ({ role, content }: ChatMessageProps) => {
       ),
 
       li: ({ children }) => (
-        <li className="text-white">
+        <li className="text-card-foreground">
           {children}
         </li>
       ),
 
       p: ({ children }) => (
-        <p className="mb-3 text-white">
+        <p className="mb-3 text-card-foreground">
           {children}
         </p>
       ),


### PR DESCRIPTION
## Description

This PR fixes a theme-related visibility issue in the AI Assistant chat interface.

### Problem

Bot responses were difficult to read in Light Mode because markdown-rendered content used hardcoded `text-white` classes, causing poor contrast against light backgrounds.

### Solution

Replaced hardcoded text color styles with theme-aware styling so that assistant messages adapt correctly to both Light and Dark modes.

### Changes Made

* Updated markdown-rendered text components (`strong`, `p`, and `li`)
* Removed hardcoded white text styling
* Ensured compatibility with both themes

### Testing

* Verified bot messages are readable in Light Mode
* Verified bot messages remain readable in Dark Mode
* Tested AI Assistant welcome message rendering

Fixes #162 

BEFORE:
<img width="1919" height="905" alt="Screenshot 2026-05-29 114223" src="https://github.com/user-attachments/assets/1f50779c-78ed-4543-9c6d-ff6ed86f0cf2" />



AFTER FIXING:
<img width="1873" height="915" alt="image" src="https://github.com/user-attachments/assets/0e54732b-8eca-4b1d-ab02-1ec34fde3f5e" />

