### PR TITLE
fix: resolve stale timeout and memory leak in Word Recall Game

### DIFF
--- a/src/pages/BrainGames.tsx
+++ b/src/pages/BrainGames.tsx
@@ -430,9 +430,14 @@ const BrainGames = () => {
   };
 
   const startWordGame = () => {
+    if (wordTimeoutRef.current) {
+      clearTimeout(wordTimeoutRef.current);
+      wordTimeoutRef.current = null;
+    }
+
     const sequence = shuffleArray([...healthWords]).slice(
       0,
-    Math.min(5, healthWords.length)
+      Math.min(5, healthWords.length)
     );
 
     setWordSequence(sequence);
@@ -443,7 +448,7 @@ const BrainGames = () => {
 
     showInfo("Memorize these words!", "You have 10 seconds...");
 
-    setTimeout(() => {
+    wordTimeoutRef.current = window.setTimeout(() => {
       setWordPhase("recall");
       showWarning("Time's up!", "Now recall the words in order");
     }, 10000);


### PR DESCRIPTION
### type: bug, refractor
### level: intermediate

### 📌 Related Issue
Closes #167 

---

### 📝 Description
- **What does this PR do?**
  It fixes a state synchronization bug and memory leak in the **Word Recall Game** (inside `BrainGames.tsx`) by ensuring active timers are correctly cleared when a user resets or restarts the game early.
  
- **Why is this change needed?**
  Previously, when a user restarted a game during the 10-second memorization phase, the old `setTimeout` remained active in the event loop. When it fired, it prematurely forced the new game session into the `"recall"` phase, disrupting the user experience. By storing the timeout ID inside the `wordTimeoutRef` ref and calling `clearTimeout(...)` upon game start, we guarantee that only one game timer is running at any given time.

---

### 📸 Screenshots *(required for UI changes)*

This is a logical state correction, but this is game UI:

Before-
<img width="1478" height="796" alt="image" src="https://github.com/user-attachments/assets/d54c76d6-c2d7-4b3c-bc0a-2f673bd2b3eb" />


---

### ✅ Checklist
- [x] Tested locally with `npm run dev`
- [x] No unrelated files changed
- [x] Follows existing code style (TypeScript + Tailwind)
- [x] PR is linked to an open issue
- [x] No console errors or warnings
- [x] GSSoC issue was assigned to me before I started
