### PR TITLE
Refactor: implement true database record deletion in symptom history with AlertDialog confirmation

### DIFF
--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -6,6 +6,17 @@ import { Button } from "@/components/ui/button";
 import { CheckCircle, X, Trash2, Eye } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { showSuccess, showError } from "@/lib/toast-helpers";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 interface SymptomEntry {
   id: string;
@@ -18,29 +29,9 @@ interface SymptomEntry {
   created_at: string;
 }
 
-const getStorageKey = (userId: string) => `hidden_symptom_entries_${userId}`;
-
-const loadHiddenIds = (userId: string): Set<string> => {
-  try {
-    const raw = localStorage.getItem(getStorageKey(userId));
-    return raw ? new Set(JSON.parse(raw)) : new Set();
-  } catch {
-    return new Set();
-  }
-};
-
-const saveHiddenIds = (userId: string, ids: Set<string>) => {
-  try {
-    localStorage.setItem(getStorageKey(userId), JSON.stringify([...ids]));
-  } catch {}
-};
-
 const History = () => {
   const [history, setHistory] = useState<SymptomEntry[]>([]);
   const [loading, setLoading] = useState(true);
-  const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
-  const [userId, setUserId] = useState<string | null>(null);
-  const [showHidden, setShowHidden] = useState(false);
   const { toast } = useToast();
 
   useEffect(() => {
@@ -51,10 +42,6 @@ const History = () => {
     try {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
-
-      setUserId(user.id);
-      const stored = loadHiddenIds(user.id);
-      setHiddenIds(stored);
 
       const { data, error } = await supabase
         .from("symptom_history")
@@ -96,23 +83,21 @@ const History = () => {
     }
   };
 
-  const hideEntry = (id: string, symptoms: string) => {
-    if (!userId) return;
-    const updated = new Set(hiddenIds);
-    updated.add(id);
-    setHiddenIds(updated);
-    saveHiddenIds(userId, updated);
-    const label = symptoms.length > 40 ? symptoms.substring(0, 40) + "..." : symptoms;
-    showSuccess("Record hidden", `"${label}" removed from your view`);
-  };
+  const deleteEntry = async (id: string) => {
+    try {
+      const { error } = await supabase
+        .from("symptom_history")
+        .delete()
+        .eq("id", id);
 
-  const restoreEntry = (id: string) => {
-    if (!userId) return;
-    const updated = new Set(hiddenIds);
-    updated.delete(id);
-    setHiddenIds(updated);
-    saveHiddenIds(userId, updated);
-    showSuccess("Record restored", "Entry is visible again");
+      if (error) throw error;
+
+      showSuccess("Record deleted", "The symptom history has been permanently removed.");
+      fetchHistory();
+    } catch (error) {
+      console.error("Error deleting history:", error);
+      showError("Delete failed", "Could not delete this health record.");
+    }
   };
 
   const getSeverityColor = (severity: string) => {
@@ -123,9 +108,6 @@ const History = () => {
     }
   };
 
-  const visibleHistory = history.filter((e) => !hiddenIds.has(e.id));
-  const hiddenHistory = history.filter((e) => hiddenIds.has(e.id));
-
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between flex-wrap gap-3">
@@ -133,41 +115,21 @@ const History = () => {
           <h1 className="text-3xl font-bold text-foreground">Symptom History</h1>
           <p className="text-muted-foreground">Review your past health consultations</p>
         </div>
-
-        {hiddenHistory.length > 0 && (
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-2"
-            onClick={() => setShowHidden((prev) => !prev)}
-          >
-            <Eye className="w-4 h-4" />
-            {showHidden ? "Hide removed" : `Show removed (${hiddenHistory.length})`}
-          </Button>
-        )}
       </div>
 
       {loading ? (
         <p className="text-center text-muted-foreground">Loading history...</p>
-      ) : visibleHistory.length === 0 && !showHidden ? (
+      ) : history.length === 0 ? (
         <Card>
           <CardContent className="pt-6 text-center space-y-2">
             <p className="text-muted-foreground">
-              {history.length === 0
-                ? "No symptom history yet. Start by consulting with the AI Assistant!"
-                : "All records have been removed from view."}
+              No symptom history yet. Start by consulting with the AI Assistant!
             </p>
-            {hiddenHistory.length > 0 && (
-              <Button variant="ghost" size="sm" onClick={() => setShowHidden(true)}>
-                <Eye className="w-4 h-4 mr-2" />
-                Show {hiddenHistory.length} hidden record{hiddenHistory.length > 1 ? "s" : ""}
-              </Button>
-            )}
           </CardContent>
         </Card>
       ) : (
         <div className="space-y-4">
-          {visibleHistory.map((entry) => (
+          {history.map((entry) => (
             <Card key={entry.id} className={entry.resolved ? "opacity-70" : ""}>
               <CardHeader>
                 <div className="flex flex-wrap items-start justify-between gap-2">
@@ -192,15 +154,35 @@ const History = () => {
                         <><CheckCircle className="w-4 h-4 mr-1" />Resolve</>
                       )}
                     </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => hideEntry(entry.id, entry.symptoms)}
-                      className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
-                      title="Remove from view (record is kept safely, can be restored)"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                          title="Permanently delete record"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Delete Symptom History?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            Are you sure you want to permanently delete this health consultation record? This action cannot be undone.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => deleteEntry(entry.id)}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          >
+                            Delete
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
                   </div>
                 </div>
               </CardHeader>
@@ -236,44 +218,6 @@ const History = () => {
               </CardContent>
             </Card>
           ))}
-
-          {showHidden && hiddenHistory.length > 0 && (
-            <>
-              <div className="flex items-center gap-3 pt-2">
-                <div className="flex-1 h-px bg-border" />
-                <p className="text-xs text-muted-foreground whitespace-nowrap">
-                  {hiddenHistory.length} hidden record{hiddenHistory.length > 1 ? "s" : ""}
-                </p>
-                <div className="flex-1 h-px bg-border" />
-              </div>
-
-              {hiddenHistory.map((entry) => (
-                <Card key={entry.id} className="opacity-50 border-dashed">
-                  <CardHeader>
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="flex-1 min-w-0">
-                        <CardTitle className="text-lg line-through text-muted-foreground">
-                          {entry.symptoms}
-                        </CardTitle>
-                        <CardDescription>
-                          {new Date(entry.created_at).toLocaleString()} · hidden
-                        </CardDescription>
-                      </div>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => restoreEntry(entry.id)}
-                        className="flex-shrink-0 gap-1"
-                      >
-                        <Eye className="w-4 h-4" />
-                        Restore
-                      </Button>
-                    </div>
-                  </CardHeader>
-                </Card>
-              ))}
-            </>
-          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
### `Type:Bug` `type:refractor` `type:accessibility`
### `Level:Intermediate`

### 📌 Related Issue
Closes #169 

---

### 📝 Description
- **What does this PR do?**
  It replaces the previous browser-based `localStorage` hiding logic in the **Symptom History** page with true database deletion. It also wraps the deletion action in a confirmation dialog (`AlertDialog`) to prevent accidental deletions.

- **Why is this change needed?**
  The original implementation only marked record IDs as hidden in local storage. This meant a user's hidden records would reappear if they cleared their cookies, changed browsers, or accessed the site from a mobile device. Since the database already has RLS delete policies enabled, executing a true DELETE call provides a cleaner, secure, and device-synced user experience.

- **Key Refactorings:**
  1. **Direct DB Deletion:** Replaced local-storage helper methods with a true Supabase `.delete()` query.
  2. **AlertDialog Integration:** Wrapped the trash icon in a confirmation modal to avoid accidental record deletion.
  3. **Code Cleanup:** Removed unused states (`hiddenIds`, `showHidden`) and local storage serialization boilerplate.

---

## 📸 Screenshots *(required for UI changes)*

## Before
<img width="1501" height="850" alt="WhatsApp Image 2026-05-29 at 10 48 00 PM" src="https://github.com/user-attachments/assets/0c0ffc06-cc7f-40ec-955b-7f9a95ca8610" />


## After
<img width="1863" height="844" alt="image" src="https://github.com/user-attachments/assets/a2929bca-2194-4397-98aa-d7b55dd7ff8b" />

---

### ✅ Checklist
- [x] Tested locally with `npm run dev`
- [x] No unrelated files changed
- [x] Follows existing code style (TypeScript + Tailwind)
- [x] PR is linked to an open issue
- [x] No console errors or warnings
- [x] GSSoC issue was assigned to me before I started
