### PR TITLE
fix: resolve double insert profile race condition on user signup

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -190,13 +190,6 @@ const Auth = () => {
     if (error) {
       showError("Sign Up Failed", error.message);
     } else {
-      if (data.user) {
-        await supabase.from("profiles").insert({
-          user_id: data.user.id,
-          full_name: fullName,
-        });
-      }
-
       showSuccess(
         "Account Created!",
         "You can now sign in with your credentials."


### PR DESCRIPTION
### type
`type:refractor` `type:performance` `type:bug`

### level
`level:advance`

### 📌 Related Issue
Closes #175 
---

### 📝 Description
- **What does this PR do?**
  It resolves a race condition and console error during the user sign-up flow by removing a redundant frontend insert statement.
  
- **Why is this change needed?**
  Previously, when a new user signed up, the frontend tried to manually insert a profile record into the `profiles` table after the signup completed. However, the database is already configured with an `AFTER INSERT` trigger (`on_auth_user_created`) on the `auth.users` table that automatically performs this insert. As a result, the frontend insert failed with a unique key constraint violation on the `user_id` column, throwing console/database errors. Removing the client-side insert allows the server-side database trigger to create the profile record cleanly without conflict.

---

### 📸 Screenshots *(required for UI changes)*

This is a logical state correction.

---

### ✅ Checklist
- [x] Tested locally with `npm run dev`
- [x] No unrelated files changed
- [x] Follows existing code style (TypeScript + Tailwind)
- [x] PR is linked to an open issue
- [x] No console errors or warnings
- [x] GSSoC issue was assigned to me before I started
