### PR TITLE
Feature : add search and severity filter to symptom history page

### DIFF
--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -3,7 +3,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { CheckCircle, X, Trash2, Eye } from "lucide-react";
+import { CheckCircle, X, Trash2, Eye, Search } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { showSuccess, showError } from "@/lib/toast-helpers";
 import {
@@ -32,6 +32,8 @@ interface SymptomEntry {
 const History = () => {
   const [history, setHistory] = useState<SymptomEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [severityFilter, setSeverityFilter] = useState("all");
   const { toast } = useToast();
 
   useEffect(() => {
@@ -117,6 +119,29 @@ const History = () => {
         </div>
       </div>
 
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search symptoms..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full pl-9 pr-4 py-2 rounded-md border border-input bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+        <select
+          value={severityFilter}
+          onChange={(e) => setSeverityFilter(e.target.value)}
+          className="px-3 py-2 rounded-md border border-input bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="all">All Severities</option>
+          <option value="low">Low</option>
+          <option value="moderate">Moderate</option>
+          <option value="high">High</option>
+        </select>
+      </div>
+
       {loading ? (
         <p className="text-center text-muted-foreground">Loading history...</p>
       ) : history.length === 0 ? (
@@ -129,7 +154,12 @@ const History = () => {
         </Card>
       ) : (
         <div className="space-y-4">
-          {history.map((entry) => (
+          {history
+            .filter((entry) =>
+              entry.symptoms.toLowerCase().includes(searchQuery.toLowerCase()) &&
+              (severityFilter === "all" || entry.severity_level === severityFilter)
+            )
+            .map((entry) => (
             <Card key={entry.id} className={entry.resolved ? "opacity-70" : ""}>
               <CardHeader>
                 <div className="flex flex-wrap items-start justify-between gap-2">


### PR DESCRIPTION
Closes #179

## What's changed
Added client-side search and severity filter to the History page.

## Features added
- Search input to filter records by symptom keyword
- Severity dropdown with options: All / Low / Moderate / High
- Both filters work together on already-fetched data (no extra API calls)

## Changes made
- `src/pages/History.tsx` — added search input, severity dropdown, and filter logic

## Before
<img width="1909" height="908" alt="Screenshot 2026-05-31 133634" src="https://github.com/user-attachments/assets/255da653-782e-4e18-9497-a3d6e55f4583" />

## After
https://github.com/user-attachments/assets/eb918087-2da3-4b06-b22b-0fa8f0dc4286


## Testing
- Searched by keyword → matching records appear ✅
- Filtered by severity → correct records show ✅
- Both filters work together ✅
- Empty state still shows correctly when no records ✅