### PR TITLE
Feature : add CSV export functionality for symptom history

### DIFF
--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -100,6 +100,26 @@ const History = () => {
     }
   };
 
+ const exportCSV = () => {
+    const headers = ["Date", "Symptoms", "Severity", "Risk Score", "Resolved"];
+    const rows = history.map((entry) => [
+      new Date(entry.created_at).toLocaleDateString(),
+      `"${entry.symptoms.replace(/"/g, '""')}"`,
+      entry.severity_level,
+      entry.risk_score,
+      entry.resolved ? "Yes" : "No",
+    ]);
+    const csv = [headers, ...rows].map((r) => r.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "symptom-history.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+
   const getSeverityColor = (severity: string) => {
     switch (severity) {
       case "high": return "destructive";
@@ -115,6 +135,11 @@ const History = () => {
           <h1 className="text-3xl font-bold text-foreground">Symptom History</h1>
           <p className="text-muted-foreground">Review your past health consultations</p>
         </div>
+        {history.length > 0 && (
+          <Button onClick={exportCSV} variant="outline" size="sm">
+            Export CSV
+          </Button>
+        )}
       </div>
 
       {loading ? (


### PR DESCRIPTION
Closes #180

## What's changed
Added a CSV export button to the History page that allows users to 
download their complete symptom history as a CSV file.

## Features added
- "Export CSV" button appears when history records exist
- Exports: Date, Symptoms, Severity, Risk Score, Resolved Status
- Handles special characters in symptom text
- Pure frontend implementation using Blob + URL.createObjectURL
- No backend changes or extra API calls required

## Changes made
- `src/pages/History.tsx` — added `exportCSV` function and Export CSV button

## Before
<img width="1909" height="908" alt="Screenshot 2026-05-31 133634" src="https://github.com/user-attachments/assets/afba74ad-d4fc-4720-90e0-f96188d63cd8" />

## After
<img width="1886" height="885" alt="image" src="https://github.com/user-attachments/assets/d43b1cb2-c4e7-455a-afd2-b3ffa1065d9f" />

https://github.com/user-attachments/assets/a0a79320-e364-453f-860f-7addf2f4455e


## Testing
- Clicked Export CSV → file downloads instantly ✅
- CSV opens correctly in Excel/Google Sheets ✅
- Button only appears when records exist ✅
- Special characters handled correctly ✅