### PR TITLE
feat: add blog post detail pages with full navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import HealthLibrary from "./pages/HealthLibrary";
 import Blog from "./pages/Blog";
 import Contact from "./pages/Contact";
 import ScrollToTop from "@/components/ScrollToTop";
+import BlogPostPage from "@/pages/BlogPostPage";
 const queryClient = new QueryClient();
 
 const App = () => (
@@ -154,6 +155,7 @@ const App = () => (
           />
           <Route path="/health-library" element={<HealthLibrary />} />
           <Route path="/blog" element={<Blog />} />
+          <Route path="/blog/:slug" element={<BlogPostPage />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/data/blogData.ts
+++ b/src/data/blogData.ts
@@ -1,0 +1,204 @@
+export interface BlogPost {
+  id: string;
+  slug: string;
+  category: string;
+  date: string;
+  readTime: string;
+  title: string;
+  excerpt: string;
+  content: Section[];
+  prevPost?: { title: string; slug: string };
+  nextPost?: { title: string; slug: string };
+}
+
+export interface Section {
+  heading?: string;
+  body: string;
+}
+
+export const blogPosts: BlogPost[] = [
+  {
+    id: "1",
+    slug: "5-daily-habits-long-term-health",
+    category: "Wellness",
+    date: "May 20, 2026",
+    readTime: "4 min read",
+    title: "5 Daily Habits That Improve Your Long-Term Health",
+    excerpt: "Small, consistent actions compound over time. Here are five science-backed habits that make a real difference.",
+    content: [
+      {
+        body: "Good health isn't built in a single day — it's the result of small, consistent habits practiced over time. Here are five evidence-based daily habits that can significantly improve your long-term health.",
+      },
+      {
+        heading: "1. Move for at Least 30 Minutes",
+        body: "Physical activity is one of the most powerful things you can do for your health. Even a brisk 30-minute walk each day reduces the risk of heart disease, type 2 diabetes, and certain cancers. You don't need a gym — dancing, cycling, or even gardening counts.",
+      },
+      {
+        heading: "2. Prioritize Sleep",
+        body: "Sleep is when your body repairs itself. Adults need 7-9 hours per night. Poor sleep is linked to obesity, heart disease, and impaired immune function. Try to go to bed and wake up at the same time every day, even on weekends.",
+      },
+      {
+        heading: "3. Eat More Whole Foods",
+        body: "Processed foods are convenient but often packed with added sugars, unhealthy fats, and excess sodium. Focus on whole foods — fruits, vegetables, legumes, nuts, and whole grains. These provide essential nutrients and fiber that support gut health and reduce inflammation.",
+      },
+      {
+        heading: "4. Stay Hydrated",
+        body: "Your body is about 60% water. Even mild dehydration can cause fatigue, headaches, and difficulty concentrating. Aim for 8 glasses of water a day, and more if you're active or in a hot climate.",
+      },
+      {
+        heading: "5. Manage Stress Proactively",
+        body: "Chronic stress is a silent killer. It raises cortisol levels, disrupts sleep, and weakens immunity. Build stress management into your daily routine — meditation, journaling, deep breathing, or simply spending time in nature can all help.",
+      },
+      {
+        heading: "The Bottom Line",
+        body: "You don't need to overhaul your life overnight. Pick one habit, practice it for a month, then add another. Consistency beats intensity every time.",
+      },
+    ],
+    nextPost: {
+      title: "Understanding Your Symptom Data: What the Numbers Mean",
+      slug: "understanding-your-symptom-data",
+    },
+  },
+  {
+    id: "2",
+    slug: "understanding-your-symptom-data",
+    category: "Health Tips",
+    date: "May 12, 2026",
+    readTime: "6 min read",
+    title: "Understanding Your Symptom Data: What the Numbers Mean",
+    excerpt: "Your health metrics tell a story. We break down how to interpret common patterns in your symptom logs.",
+    content: [
+      {
+        body: "When you log symptoms consistently, patterns begin to emerge. Understanding what those patterns mean can help you make better decisions about your health and have more informed conversations with your doctor.",
+      },
+      {
+        heading: "Why Tracking Matters",
+        body: "Symptom data gives you a historical view of your health. A single data point means little — but weeks of logs can reveal triggers, cycles, and trends that would otherwise go unnoticed.",
+      },
+      {
+        heading: "Reading Frequency Patterns",
+        body: "If a symptom appears consistently at the same time of day or week, that timing is meaningful. Morning headaches may suggest sleep issues or dehydration. Evening fatigue could point to blood sugar dips or stress accumulation.",
+      },
+      {
+        heading: "Severity Scores",
+        body: "Most tracking apps use a 1–10 severity scale. Don't fixate on individual scores — look at averages and trends. A gradual upward trend in severity over two weeks is more concerning than a single spike.",
+      },
+      {
+        heading: "Correlating Symptoms with Lifestyle",
+        body: "The most valuable insight comes from connecting symptoms to lifestyle factors: sleep quality, diet, stress levels, and physical activity. When you track these alongside symptoms, you start to see cause-and-effect relationships.",
+      },
+      {
+        heading: "When to Talk to a Doctor",
+        body: "Use your data as a conversation starter, not a diagnosis. Bring your symptom log to appointments — it gives your doctor a clearer picture than memory alone and can speed up diagnosis significantly.",
+      },
+      {
+        heading: "The Bottom Line",
+        body: "Your symptom data is only as useful as your ability to interpret it. Focus on trends, correlations, and context — not individual readings. Over time, you'll develop a clearer picture of what your body is telling you.",
+      },
+    ],
+    prevPost: {
+      title: "5 Daily Habits That Improve Your Long-Term Health",
+      slug: "5-daily-habits-long-term-health",
+    },
+    nextPost: {
+      title: "How Brain Games Improve Cognitive Function",
+      slug: "how-brain-games-improve-cognitive-function",
+    },
+  },
+  {
+    id: "3",
+    slug: "how-brain-games-improve-cognitive-function",
+    category: "Brain Health",
+    date: "April 30, 2026",
+    readTime: "5 min read",
+    title: "How Brain Games Improve Cognitive Function",
+    excerpt: "Research suggests targeted cognitive exercises can improve memory and focus. Here's what the science says.",
+    content: [
+      {
+        body: "The idea that you can train your brain like a muscle has gained significant scientific support. Targeted cognitive exercises — commonly called brain games — have been shown to improve specific mental functions when practiced consistently.",
+      },
+      {
+        heading: "What the Research Shows",
+        body: "Studies from neuroscience labs worldwide suggest that certain types of mental exercises can strengthen neural pathways. Working memory tasks, pattern recognition, and processing speed exercises have the most evidence behind them.",
+      },
+      {
+        heading: "Memory and Recall",
+        body: "Games that challenge you to remember sequences, faces, or patterns can improve short-term memory capacity. This type of training works best when the exercises are slightly beyond your comfort zone — a principle called 'desirable difficulty.'",
+      },
+      {
+        heading: "Focus and Attention",
+        body: "Tasks requiring sustained concentration — like dual n-back training or timed problem-solving — strengthen your ability to filter distractions. Regular practice can improve both focus duration and task-switching efficiency.",
+      },
+      {
+        heading: "Processing Speed",
+        body: "Reaction-time games and rapid decision-making tasks have been linked to improvements in how quickly the brain processes information. This benefit has real-world applications in driving, sports, and everyday decision-making.",
+      },
+      {
+        heading: "The Transfer Problem",
+        body: "One important caveat: getting better at a brain game doesn't automatically mean you'll get better at unrelated tasks. The most effective cognitive training targets skills that directly overlap with activities you care about improving.",
+      },
+      {
+        heading: "The Bottom Line",
+        body: "Brain games work best as one part of a broader cognitive health strategy — alongside physical exercise, quality sleep, social engagement, and a nutrient-rich diet. Play consistently, challenge yourself, and don't expect overnight miracles.",
+      },
+    ],
+    prevPost: {
+      title: "Understanding Your Symptom Data: What the Numbers Mean",
+      slug: "understanding-your-symptom-data",
+    },
+    nextPost: {
+      title: "When to See a Doctor vs. Monitor Symptoms at Home",
+      slug: "when-to-see-a-doctor-vs-monitor-symptoms",
+    },
+  },
+  {
+    id: "4",
+    slug: "when-to-see-a-doctor-vs-monitor-symptoms",
+    category: "Guidance",
+    date: "April 18, 2026",
+    readTime: "7 min read",
+    title: "When to See a Doctor vs. Monitor Symptoms at Home",
+    excerpt: "Not every symptom requires an emergency visit. Learn how to make that call confidently.",
+    content: [
+      {
+        body: "One of the most common health decisions people face isn't which treatment to choose — it's whether to seek care at all. Knowing when to see a doctor versus when to watch and wait can save you time, money, and unnecessary anxiety.",
+      },
+      {
+        heading: "The General Rule of Thumb",
+        body: "If a symptom is severe, sudden, or accompanied by other warning signs, always seek care promptly. When symptoms are mild, familiar, and improving over time, home monitoring is usually appropriate.",
+      },
+      {
+        heading: "Red Flags: Go See a Doctor",
+        body: "Certain symptoms should never be ignored: chest pain or pressure, difficulty breathing, sudden severe headache, high fever (above 39.5°C / 103°F), signs of stroke (facial drooping, arm weakness, speech difficulty), or any symptom that feels dramatically different from what you've experienced before.",
+      },
+      {
+        heading: "Yellow Flags: Monitor Closely",
+        body: "Symptoms like a mild sore throat, low-grade fever, minor muscle aches, or a new but manageable rash often resolve on their own within a few days. Track their progression — if they worsen after 48–72 hours or new symptoms appear, escalate to a doctor.",
+      },
+      {
+        heading: "Green Flags: Home Care is Fine",
+        body: "The common cold, minor cuts and scrapes, mild indigestion, tension headaches, and seasonal allergies are generally safe to manage at home with rest, hydration, and over-the-counter remedies.",
+      },
+      {
+        heading: "How Symptom Tracking Helps",
+        body: "Logging your symptoms over time removes guesswork from this decision. A symptom diary shows you patterns — whether things are trending better or worse — and gives you concrete information to share with a healthcare provider if you do need to go in.",
+      },
+      {
+        heading: "When in Doubt, Call First",
+        body: "Many clinics and healthcare providers offer nurse helplines or telehealth consultations. These are excellent middle-ground options when you're unsure — you get professional guidance without the time and cost of an in-person visit.",
+      },
+      {
+        heading: "The Bottom Line",
+        body: "Trust your instincts, but back them up with information. Symptom tracking, awareness of red flags, and access to telehealth make it easier than ever to make smart, confident decisions about your care.",
+      },
+    ],
+    prevPost: {
+      title: "How Brain Games Improve Cognitive Function",
+      slug: "how-brain-games-improve-cognitive-function",
+    },
+  },
+];
+
+export function getPostBySlug(slug: string): BlogPost | undefined {
+  return blogPosts.find((p) => p.slug === slug);
+}

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,68 +1,102 @@
-import { Calendar, Clock, ArrowRight } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Calendar, Clock, ArrowRight, ArrowLeft, Sparkles } from "lucide-react";
+import { blogPosts } from "@/data/blogData";
 
-const posts = [
-  {
-    title: "5 Daily Habits That Improve Your Long-Term Health",
-    excerpt: "Small, consistent actions compound over time. Here are five science-backed habits that make a real difference.",
-    date: "May 20, 2025",
-    readTime: "4 min read",
-    category: "Wellness",
-  },
-  {
-    title: "Understanding Your Symptom Data: What the Numbers Mean",
-    excerpt: "Your health metrics tell a story. We break down how to interpret common patterns in your symptom logs.",
-    date: "May 12, 2025",
-    readTime: "6 min read",
-    category: "Health Tips",
-  },
-  {
-    title: "How Brain Games Improve Cognitive Function",
-    excerpt: "Research suggests targeted cognitive exercises can improve memory and focus. Here's what the science says.",
-    date: "April 30, 2025",
-    readTime: "5 min read",
-    category: "Brain Health",
-  },
-  {
-    title: "When to See a Doctor vs. Monitor Symptoms at Home",
-    excerpt: "Not every symptom requires an emergency visit. Learn how to make that call confidently.",
-    date: "April 18, 2025",
-    readTime: "7 min read",
-    category: "Guidance",
-  },
-];
+const categoryColors: Record<string, { border: string; bg: string; text: string; dot: string }> = {
+  Wellness:      { border: "border-emerald-500/40", bg: "bg-emerald-900/20", text: "text-emerald-300", dot: "bg-emerald-400" },
+  "Health Tips": { border: "border-cyan-500/40",    bg: "bg-cyan-900/20",    text: "text-cyan-300",   dot: "bg-cyan-400"    },
+  "Brain Health":{ border: "border-violet-500/40",  bg: "bg-violet-900/20",  text: "text-violet-300", dot: "bg-violet-400"  },
+  Guidance:      { border: "border-amber-500/40",   bg: "bg-amber-900/20",   text: "text-amber-300",  dot: "bg-amber-400"   },
+};
+
+const defaultColor = { border: "border-cyan-500/40", bg: "bg-cyan-900/20", text: "text-cyan-300", dot: "bg-cyan-400" };
 
 const Blog = () => {
+  const navigate = useNavigate();
+
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <section className="bg-gradient-to-br from-primary/10 to-primary/5 py-16 px-6 text-center">
-        <div className="max-w-2xl mx-auto">
-          <h1 className="text-4xl font-bold mb-3">Symptom Scribe Blog</h1>
-          <p className="text-muted-foreground text-lg">
-            Health insights, platform updates, and wellness tips — written for real people.
+    <div className="min-h-screen bg-[#0a0f1a] text-gray-200">
+
+      {/* Sticky top nav */}
+      <div className="border-b border-white/[0.06] bg-[#0a0f1a]/80 backdrop-blur-sm sticky top-0 z-10">
+        <div className="max-w-4xl mx-auto px-6 py-4 flex items-center justify-between">
+          <button
+            onClick={() => navigate("/")}
+            className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors text-sm group"
+          >
+            <ArrowLeft className="w-4 h-4 group-hover:-translate-x-0.5 transition-transform" />
+            Back to Home
+          </button>
+          <span className="text-xs text-gray-600 font-medium tracking-widest uppercase">Symptom Scribe</span>
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-6 py-16">
+
+        {/* Hero header */}
+        <div className="mb-12">
+          <div className="flex items-center gap-2 mb-4">
+            <Sparkles className="w-4 h-4 text-cyan-400" />
+            <span className="text-xs font-semibold tracking-widest text-cyan-400 uppercase">Health Resources</span>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 leading-tight">
+            Our Blog
+          </h1>
+          <p className="text-gray-500 text-lg max-w-xl leading-relaxed">
+            Science-backed insights, practical tips, and expert guidance to help you understand and improve your health.
           </p>
         </div>
-      </section>
 
-      <section className="max-w-4xl mx-auto px-6 py-14 space-y-6">
-        {posts.map((post) => (
-          <article key={post.title} className="rounded-xl border bg-card p-6 hover:shadow-md transition-shadow">
-            <div className="flex items-center gap-3 mb-3 flex-wrap">
-              <span className="text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded-full">{post.category}</span>
-              <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                <Calendar className="h-3 w-3" /> {post.date}
-              </span>
-              <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                <Clock className="h-3 w-3" /> {post.readTime}
-              </span>
-            </div>
-            <h2 className="text-lg font-semibold mb-2">{post.title}</h2>
-            <p className="text-sm text-muted-foreground mb-4">{post.excerpt}</p>
-            <button className="inline-flex items-center gap-1 text-sm text-primary font-medium hover:underline">
-              Read more <ArrowRight className="h-3 w-3" />
-            </button>
-          </article>
-        ))}
-      </section>
+        {/* All posts — uniform cards */}
+        <div className="space-y-5">
+          {blogPosts.map((post) => {
+            const color = categoryColors[post.category] || defaultColor;
+            return (
+              <div
+                key={post.id}
+                onClick={() => navigate(`/blog/${post.slug}`)}
+                className="group cursor-pointer rounded-2xl border border-white/[0.08] bg-white/[0.03] p-7 hover:bg-white/[0.06] hover:border-white/15 transition-all duration-200"
+              >
+                {/* Meta row */}
+                <div className="flex flex-wrap items-center gap-3 mb-3">
+                  <span className={`px-3 py-0.5 rounded-full border ${color.border} ${color.bg} ${color.text} text-xs font-medium flex items-center gap-1.5`}>
+                    <span className={`w-1.5 h-1.5 rounded-full ${color.dot}`} />
+                    {post.category}
+                  </span>
+                  <span className="flex items-center gap-1.5 text-gray-500 text-sm">
+                    <Calendar className="w-3.5 h-3.5" />
+                    {post.date}
+                  </span>
+                  <span className="flex items-center gap-1.5 text-gray-500 text-sm">
+                    <Clock className="w-3.5 h-3.5" />
+                    {post.readTime}
+                  </span>
+                </div>
+
+                {/* Title */}
+                <h2 className="text-xl font-bold text-white mb-2 leading-snug group-hover:text-cyan-50 transition-colors">
+                  {post.title}
+                </h2>
+
+                {/* Excerpt */}
+                <p className="text-gray-500 text-sm leading-relaxed mb-5">
+                  {post.excerpt}
+                </p>
+
+                {/* Read more */}
+                <span className="flex items-center gap-1.5 text-cyan-400 group-hover:text-cyan-300 text-sm font-medium transition-colors w-fit">
+                  Read more <ArrowRight className="w-4 h-4 group-hover:translate-x-0.5 transition-transform" />
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer note */}
+        <div className="mt-16 text-center">
+          <p className="text-gray-700 text-sm">More articles coming soon · Stay tuned</p>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -1,0 +1,185 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { ArrowLeft, ArrowRight, Calendar, Clock, BookOpen, Home } from "lucide-react";
+import { getPostBySlug } from "@/data/blogData";
+
+const categoryColors: Record<string, { border: string; bg: string; text: string; dot: string }> = {
+  Wellness:      { border: "border-emerald-500/40", bg: "bg-emerald-900/20", text: "text-emerald-300", dot: "bg-emerald-400" },
+  "Health Tips": { border: "border-cyan-500/40",    bg: "bg-cyan-900/20",    text: "text-cyan-300",   dot: "bg-cyan-400"    },
+  "Brain Health":{ border: "border-violet-500/40",  bg: "bg-violet-900/20",  text: "text-violet-300", dot: "bg-violet-400"  },
+  Guidance:      { border: "border-amber-500/40",   bg: "bg-amber-900/20",   text: "text-amber-300",  dot: "bg-amber-400"   },
+};
+
+const defaultColor = { border: "border-cyan-500/40", bg: "bg-cyan-900/20", text: "text-cyan-300", dot: "bg-cyan-400" };
+
+const BlogPostPage = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+  const post = getPostBySlug(slug || "");
+  const color = post ? (categoryColors[post.category] || defaultColor) : defaultColor;
+
+  if (!post) {
+    return (
+      <div className="min-h-screen bg-[#0a0f1a] flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-4xl mb-4">🔍</p>
+          <p className="text-white font-bold text-xl mb-2">Post not found</p>
+          <p className="text-gray-500 text-sm mb-6">This article doesn't exist or may have moved.</p>
+          <button
+            onClick={() => navigate("/blog")}
+            className="text-cyan-400 hover:text-cyan-300 flex items-center gap-2 mx-auto transition-colors text-sm"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Blog
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0a0f1a] text-gray-200">
+
+      {/* Sticky top nav */}
+      <div className="border-b border-white/[0.06] bg-[#0a0f1a]/80 backdrop-blur-sm sticky top-0 z-10">
+        <div className="max-w-3xl mx-auto px-6 py-4 flex items-center justify-between">
+          <button
+            onClick={() => navigate("/blog")}
+            className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors text-sm group"
+          >
+            <ArrowLeft className="w-4 h-4 group-hover:-translate-x-0.5 transition-transform" />
+            Back to Blog
+          </button>
+          <button
+            onClick={() => navigate("/")}
+            className="flex items-center gap-1.5 text-gray-500 hover:text-white transition-colors text-sm group"
+          >
+            <Home className="w-3.5 h-3.5" />
+            Home
+          </button>
+        </div>
+      </div>
+
+      <div className="max-w-3xl mx-auto px-6 py-12 md:py-16">
+
+        {/* Article header */}
+        <div className="mb-10">
+          {/* Category + icon */}
+          <div className="flex items-center gap-3 mb-6">
+            <div className="w-11 h-11 rounded-2xl bg-cyan-900/30 border border-cyan-700/30 flex items-center justify-center flex-shrink-0">
+              <BookOpen className="w-5 h-5 text-cyan-400" />
+            </div>
+            <div>
+              <p className="text-xs font-semibold tracking-widest text-cyan-400 uppercase mb-0.5">
+                Resources
+              </p>
+              <span className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full border ${color.border} ${color.bg} ${color.text} text-xs font-medium`}>
+                <span className={`w-1.5 h-1.5 rounded-full ${color.dot}`} />
+                {post.category}
+              </span>
+            </div>
+          </div>
+
+          {/* Title */}
+          <h1 className="text-3xl md:text-4xl font-bold text-white leading-tight mb-4">
+            {post.title}
+          </h1>
+
+          {/* Meta */}
+          <div className="flex flex-wrap items-center gap-4 text-sm text-gray-500">
+            <span className="flex items-center gap-1.5">
+              <Calendar className="w-4 h-4" />
+              {post.date}
+            </span>
+            <span className="flex items-center gap-1.5">
+              <Clock className="w-4 h-4" />
+              {post.readTime}
+            </span>
+            <span className="text-gray-600">·</span>
+            <span className="text-gray-600 text-xs">Last updated: {post.date.split(" ").slice(1).join(" ")}</span>
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div className="h-px bg-gradient-to-r from-transparent via-white/10 to-transparent mb-10" />
+
+        {/* Article body */}
+        <div className="rounded-3xl border border-white/[0.07] bg-white/[0.02] overflow-hidden">
+          <div className="p-8 md:p-10 space-y-8">
+            {post.content.map((section, i) => (
+              <div key={i} className={i > 0 && section.heading ? "pt-2" : ""}>
+                {section.heading && (
+                  <h2 className="text-lg md:text-xl font-bold text-white mb-3 flex items-center gap-2">
+                    <span className={`w-1 h-5 rounded-full ${color.dot} opacity-80`} />
+                    {section.heading}
+                  </h2>
+                )}
+                <p className={`text-gray-400 leading-relaxed ${section.heading ? "pl-3" : ""}`}>
+                  {section.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Prev / Next navigation */}
+        {(post.prevPost || post.nextPost) && (
+          <div className="mt-10 grid grid-cols-2 gap-4">
+            {/* Previous */}
+            <div>
+              {post.prevPost && (
+                <button
+                  onClick={() => navigate(`/blog/${post.prevPost!.slug}`)}
+                  className="group w-full rounded-2xl border border-white/[0.08] bg-white/[0.02] hover:bg-white/[0.05] hover:border-white/15 px-5 py-5 text-left transition-all duration-200"
+                >
+                  <p className="text-xs text-gray-600 flex items-center gap-1 mb-1.5 group-hover:text-gray-500 transition-colors">
+                    <ArrowLeft className="w-3.5 h-3.5" /> Previous article
+                  </p>
+                  <p className="text-sm font-semibold text-white leading-snug group-hover:text-cyan-50 transition-colors line-clamp-2">
+                    {post.prevPost.title}
+                  </p>
+                </button>
+              )}
+            </div>
+
+            {/* Next */}
+            <div>
+              {post.nextPost && (
+                <button
+                  onClick={() => navigate(`/blog/${post.nextPost!.slug}`)}
+                  className="group w-full rounded-2xl border border-white/[0.08] bg-white/[0.02] hover:bg-white/[0.05] hover:border-white/15 px-5 py-5 text-right transition-all duration-200"
+                >
+                  <p className="text-xs text-gray-600 flex items-center justify-end gap-1 mb-1.5 group-hover:text-gray-500 transition-colors">
+                    Next article <ArrowRight className="w-3.5 h-3.5" />
+                  </p>
+                  <p className="text-sm font-semibold text-white leading-snug group-hover:text-cyan-50 transition-colors line-clamp-2">
+                    {post.nextPost.title}
+                  </p>
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Bottom nav */}
+        <div className="mt-10 pt-8 border-t border-white/[0.06] flex items-center justify-between flex-wrap gap-4">
+          <button
+            onClick={() => navigate("/blog")}
+            className="flex items-center gap-2 text-cyan-400 hover:text-cyan-300 transition-colors text-sm group"
+          >
+            <ArrowLeft className="w-4 h-4 group-hover:-translate-x-0.5 transition-transform" />
+            Back to all posts
+          </button>
+          <button
+            onClick={() => navigate("/")}
+            className="flex items-center gap-1.5 text-gray-500 hover:text-white transition-colors text-sm group"
+          >
+            <Home className="w-4 h-4" />
+            Go to Home
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BlogPostPage;


### PR DESCRIPTION
## Summary
Implements fully functional blog post detail pages with content and navigation.

## Changes

### New Files
- `src/data/blogData.ts` — central data file containing all 4 blog posts with content, metadata, and prev/next links
- `src/pages/BlogPostPage.tsx` — blog post detail page component with full article layout

### Modified Files
- `src/pages/Blog.tsx` — fixed Read more links using `navigate(/blog/:slug)`, improved design with category color coding and sticky nav
- `src/App.tsx` — added `/blog/:slug` route pointing to `BlogPostPage`

## What was broken
`Read more →` buttons on the blog list page were not navigating anywhere as the route and detail page component did not exist.

## What's fixed & added
- All 4 blog posts now open as full detail pages
- Sticky navbar with Back to Blog and Home buttons
- Previous / Next article navigation on every post
  - First post → Next only
  - Middle posts → Both Previous and Next
  - Last post → Previous only
- Consistent card design across all posts on the list page
- Color-coded category badges (Wellness, Health Tips, Brain Health, Guidance)

## Testing
- [x] Tested locally with `npm run dev`
- [x] All 4 Read more links open correct post
- [x] Prev/Next navigation works correctly on all posts
- [x] Back to Home navigates to `/`
- [x] Back to Blog navigates to `/blog`
- [x] No console errors or warnings

Closes #160