### PR TITLE
fix: resolve off-by-one error and race condition in rate limiter

### DIFF
--- a/supabase/functions/symptom-analyzer/rateLimit.ts
+++ b/supabase/functions/symptom-analyzer/rateLimit.ts
@@ -27,35 +27,18 @@ if (redisUrl && redisToken) {
 
 function memoryRateLimit(ip: string): { success: boolean } {
     const now = Date.now();
-
     const existing = requestStore.get(ip);
 
-    // First request
-    if (!existing) {
-        requestStore.set(ip, {
-            count: 1,
-            timestamp: now,
-        });
-
+    // Initialize or reset expired window
+    if (!existing || now - existing.timestamp > WINDOW_SIZE_MS) {
+        requestStore.set(ip, { count: 1, timestamp: now });
         return { success: true };
     }
 
-    // Reset window
-    if (now - existing.timestamp > WINDOW_SIZE_MS) {
-        requestStore.set(ip, {
-            count: 1,
-            timestamp: now,
-        });
-
-        return { success: true };
-    }
-
-    // Block request
     if (existing.count >= MAX_REQUESTS) {
         return { success: false };
     }
 
-    // Increment safely
     requestStore.set(ip, {
         count: existing.count + 1,
         timestamp: existing.timestamp,
@@ -68,10 +51,17 @@ export async function rateLimit(ip: string): Promise<{ success: boolean }> {
     if (redis) {
         try {
             const key = `ratelimit:${ip}`;
-            const count = await redis.incr(key);
-            if (count === 1) {
-                await redis.expire(key, 60);
-            }
+            // Atomic pipeline: INCR + EXPIRE NX fixes two bugs:
+            // 1. Race condition — a crash between INCR and EXPIRE would leave the key
+            //    without a TTL, permanently rate-limiting that IP.
+            // 2. Off-by-one — the old `count === 1` guard was fragile; EXPIRE NX sets
+            //    the TTL exactly once (when no TTL exists) regardless of count value.
+            const pipeline = redis.pipeline();
+            pipeline.incr(key);
+            pipeline.expire(key, 60, "NX");
+            const results = await pipeline.exec();
+            const count = results[0] as number;
+
             if (count > MAX_REQUESTS) {
                 return { success: false };
             }

--- a/supabase/functions/symptom-analyzer/rateLimit.ts
+++ b/supabase/functions/symptom-analyzer/rateLimit.ts
@@ -59,8 +59,9 @@ export async function rateLimit(ip: string): Promise<{ success: boolean }> {
             const pipeline = redis.pipeline();
             pipeline.incr(key);
             pipeline.expire(key, 60, "NX");
-            const results = await pipeline.exec();
-            const count = results[0] as number;
+            // exec() returns a flat array of deserialized results in command order
+            // (not [error, result] tuples — errors throw immediately instead).
+            const [count] = await pipeline.exec<[number, number]>();
 
             if (count > MAX_REQUESTS) {
                 return { success: false };


### PR DESCRIPTION
Closes #200 


## What & Why

Two bugs in `supabase/functions/symptom-analyzer/rateLimit.ts`:

- **Race condition:** `INCR` and `EXPIRE` were separate round-trips. A crash between them left the Redis key with no TTL, permanently rate-limiting that IP.
- **Off-by-one:** `count === 1` was a fragile proxy for "first request." Any edge case that skipped it would silently drop the TTL.

## Fix

Replace both calls with an atomic Redis pipeline using `INCR` + `EXPIRE NX`. `EXPIRE NX` sets the TTL once (only if not already set), removing the `count === 1` dependency entirely. Also unified two duplicate branches in `memoryRateLimit` into a single guard.