### PR TITLE
fix: implement permanent user account deletion via admin edge function

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -134,14 +134,14 @@ const Settings = () => {
         return;
       }
 
-      // Delete account
-      const { error } = await supabase.auth.signOut();
+      // Call Edge Function to perform deletion via Admin API
+      const { error: deleteFuncError } = await supabase.functions.invoke("delete-user-account");
 
-      if (error) {
-        showError("Logout Failed", error.message);
+      if (deleteFuncError) {
+        showError("Deletion Failed", deleteFuncError.message);
       } else {
-        // For production, you'd call an edge function or admin API to delete the user
-        // For now, we just sign out and redirect
+        // Log out locally (clear session)
+        await supabase.auth.signOut();
         showSuccess("Account Deleted", "Your account has been deleted successfully");
         
         // Clear storage and redirect

--- a/supabase/functions/delete-user-account/index.ts
+++ b/supabase/functions/delete-user-account/index.ts
@@ -1,0 +1,93 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.7.1";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: "No authorization header" }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // 1. Get user details from the client-provided token to identify who is making the request
+    const client = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      {
+        global: {
+          headers: { Authorization: authHeader },
+        },
+      }
+    );
+
+    const {
+      data: { user },
+      error: userError,
+    } = await client.auth.getUser();
+
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({ error: "Invalid authorization token" }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // 2. Initialize the admin client with the service role key to delete the user
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    );
+
+    const { error: deleteError } = await supabaseAdmin.auth.admin.deleteUser(
+      user.id
+    );
+
+    if (deleteError) {
+      console.error("Error deleting user:", deleteError);
+      return new Response(
+        JSON.stringify({ error: "Failed to delete user account" }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ message: "Account successfully deleted" }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  } catch (err) {
+    console.error("Delete user error:", err);
+    return new Response(
+      JSON.stringify({
+        error: err instanceof Error ? err.message : "Internal server error",
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+});


### PR DESCRIPTION
### 📌 Related Issue
Closes #190

---

### 📝 Description
- **What does this PR do?**
  It replaces the placeholder "Delete Account" sign-out mock on the Settings page with a fully functional backend deletion flow.

- **Why is this change needed?**
  Previously, when a user requested to delete their account under the Settings tab, the app merely logged them out (`supabase.auth.signOut()`), leaving their credentials and health data intact in the database. This was a critical compliance and privacy issue. 
  
  This PR establishes a backend edge function that deletes the user from the Supabase auth table using the `service_role` admin client, which in turn triggers PostgreSQL cascade deletes to wipe all of their profile and symptom logs.

- **Key Enhancements:**
  1. **Supabase Edge Function (`delete-user-account`):** Verifies the user's caller token and calls the admin delete client safely.
  2. **Database Cascade Deletion:** Leverages existing database constraints to wipe all user metrics, chats, and histories.
  3. **Frontend Integration:** Calls `supabase.functions.invoke(...)` upon password validation inside `Settings.tsx`.

---

### 📸 Screenshots *(required for UI changes)*
No structural layout changes
---

### ✅ Checklist
- [x] Tested locally with `npm run dev`
- [x] No unrelated files changed
- [x] Follows existing code style (TypeScript + Tailwind)
- [x] PR is linked to an open issue
- [x] No console errors or warnings
- [x] GSSoC issue was assigned to me before I started
