### PR TITLE
chore: add prettier configuration and npm scripts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.env
+.env.*
+package-lock.json
+bun.lockb
+supabase/.branches
+supabase/functions/.import_map.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "endOfLine": "lf"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "globals": "^15.15.0",
         "lovable-tagger": "^1.1.11",
         "postcss": "^8.5.6",
+        "prettier": "^3.8.3",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
@@ -7017,6 +7018,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -83,6 +85,7 @@
     "globals": "^15.15.0",
     "lovable-tagger": "^1.1.11",
     "postcss": "^8.5.6",
+    "prettier": "^3.8.3",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",


### PR DESCRIPTION
### Related issue
fixes #119 

### Description

This PR introduces a standardized Prettier configuration file (`.prettierrc`) and configuration ignoring patterns (`.prettierignore`) to enforce uniform code styling rules across all contributors. Additionally, it installs Prettier as a local project devDependency and sets up helper npm scripts to simplify manual checks and formatting.

### Changes Made
- **Created `.prettierrc`**: Specified formatting rules aligning with the current codebase (2 spaces, double quotes, semicolons, trailing commas for ES5, LF line endings).
- **Created `.prettierignore`**: Prevented Prettier from checking dependencies (`node_modules`), builds (`dist`), environment variables (`.env`), and lockfiles.
- **Updated `package.json`**:
  - Installed `prettier` as a `devDependency`.
  - Added script `"format": "prettier --write ."` to format code locally.
  - Added script `"format:check": "prettier --check ."` for code compliance verification.

### Checklist
- [x] Prettier configuration matches the existing `.editorconfig` rules.
- [x] Project build compiles successfully via `npm run build`.
- [x] Local scripts run as expected.
