### PR TITLE
docs: document edge function environment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,22 @@
+# Browser application environment variables
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key
 
-# Temporary fallback for older local setups only.
-# Prefer VITE_SUPABASE_PUBLISHABLE_KEY for new environments.
+# Legacy fallback for older local setups only.
+# Keep VITE_SUPABASE_PUBLISHABLE_KEY as the canonical key for new environments.
 # VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 
-# Edge function configuration used by the symptom analyzer deployment.
+# Supabase edge function secrets used by the symptom analyzer deployment.
+# Required for the symptom-analyzer edge function to call the AI gateway.
 LOVABLE_API_KEY=your_lovable_api_key
 
 # Optional Upstash Redis credentials for distributed rate limiting.
 # The function falls back to in-memory rate limiting when these are absent.
 UPSTASH_REDIS_REST_URL=https://your-upstash-instance.upstash.io
 UPSTASH_REDIS_REST_TOKEN=your_upstash_token
+
+# Supabase runtime secrets for the delete-user-account edge function.
+# Never expose SUPABASE_SERVICE_ROLE_KEY to the browser.
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key

--- a/FAQ.md
+++ b/FAQ.md
@@ -80,6 +80,12 @@ VITE_SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key
 
 If you are still migrating older local setups, `VITE_SUPABASE_ANON_KEY` is accepted as a fallback, but it should be replaced with the publishable key.
 
+### What environment variables do the Supabase edge functions need?
+
+The browser app only needs VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY, with VITE_SUPABASE_ANON_KEY kept as a legacy fallback. The edge functions use a separate runtime secret set: LOVABLE_API_KEY is required for the symptom-analyzer function, UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN are optional for distributed rate limiting, and delete-user-account needs SUPABASE_URL, SUPABASE_ANON_KEY, and SUPABASE_SERVICE_ROLE_KEY.
+
+Browser-loaded variables belong in .env.local, while Supabase runtime secrets should be configured in the Supabase dashboard or with the Supabase CLI before running or deploying edge functions. Never expose SUPABASE_SERVICE_ROLE_KEY to the browser.
+
 **4. Start the development server**
 
 ```bash
@@ -209,6 +215,13 @@ npm install
 
 - Double-check your `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY` in `.env.local`
 - Make sure your Supabase project is active and not paused
+
+### Edge function fails with missing secret errors
+
+- Verify that LOVABLE_API_KEY is configured for the symptom-analyzer edge function
+- Add UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN only if you want Upstash-backed distributed rate limiting; they are optional
+- Confirm that SUPABASE_URL, SUPABASE_ANON_KEY, and SUPABASE_SERVICE_ROLE_KEY are set for delete-user-account
+- Re-run the Supabase secret setup locally or in the dashboard, then redeploy the function if needed
 
 ### TypeScript errors after pulling latest changes
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,38 @@ Create a local env file before starting the app:
 cp .env.example .env.local
 ```
 
-Required frontend variables:
+Required browser variables:
 
 - VITE_SUPABASE_URL
 - VITE_SUPABASE_PUBLISHABLE_KEY
 
 Legacy support is available for VITE_SUPABASE_ANON_KEY, but it should be treated as a temporary fallback only.
+
+### Supabase Edge Function Setup
+
+The browser app and Supabase edge functions use different environment surfaces. Browser variables are loaded into Vite at build time and live in .env.local. Supabase runtime secrets are read by the deployed edge functions or by the Supabase CLI when you run them locally.
+
+Browser environment variables:
+
+- VITE_SUPABASE_URL - used by the frontend to build the Supabase client and function URLs.
+- VITE_SUPABASE_PUBLISHABLE_KEY - canonical browser key for authentication and API access.
+- VITE_SUPABASE_ANON_KEY - legacy fallback only for older local setups.
+
+Edge function secrets:
+
+- LOVABLE_API_KEY - required by supabase/functions/symptom-analyzer to call the AI gateway.
+- UPSTASH_REDIS_REST_URL - optional; enables distributed rate limiting when present.
+- UPSTASH_REDIS_REST_TOKEN - optional; used with UPSTASH_REDIS_REST_URL for Upstash-backed rate limiting.
+- SUPABASE_URL - required by Supabase auth-admin flows such as delete-user-account.
+- SUPABASE_ANON_KEY - required by delete-user-account to validate the caller before using admin privileges.
+- SUPABASE_SERVICE_ROLE_KEY - required by delete-user-account for server-side account deletion; never expose this value to the browser.
+
+Local development setup:
+
+1. Copy .env.example to .env.local for the browser app.
+2. Set browser variables in .env.local with VITE_ prefixed values.
+3. Configure edge-function secrets with the Supabase CLI or the Supabase dashboard secrets settings before running or deploying edge functions.
+4. Keep the service role key out of browser-loaded files and client-side code.
 
 ---
 


### PR DESCRIPTION
## **Pull Request Description**



This pull request improves project documentation related to Supabase Edge Functions and environment configuration.



The changes clarify the distinction between browser environment variables and Supabase runtime secrets, document edge-function-specific requirements, and provide additional local setup and troubleshooting guidance for contributors.



---



### **1. Type of Change**



* [ ] **Bug Fix** (non-breaking change which fixes an issue)

* [ ] **New Feature** (non-breaking change which adds functionality)

* [ ] **Refactoring / Performance** (non-breaking code improvements)

* [x] **Documentation Update** (changes to README, guides, or comments)

* [ ] **Other** (please specify): _________



---



### **2. Related Issue**



* Fixes #225 



---



### **3. How Has This Been Tested?**



Documentation-only change.



Verification performed:



* [x] **Local Build**: The application builds successfully locally (`npm run build`).

* [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).

* [x] **Manual Verification**: Briefly list the steps/features verified manually.



  1. Verified all documented environment variable names match the current implementation.

  2. Verified required vs optional variables are documented correctly.

  3. Verified browser environment variables and Supabase runtime secrets are clearly separated.

  4. Verified legacy `VITE_SUPABASE_ANON_KEY` fallback remains documented as a migration path.

  5. Verified Upstash Redis variables are documented as optional.



---



### **4. Visual Verification (If applicable)**



Not applicable — documentation-only changes.



| Before | After |

| :----- | :---- |

| N/A    | N/A   |



---



### **5. Contributor Quality Checklist**



* [x] My code follows the code style and formatting guidelines of this project.

* [x] I have performed a self-review of my own code.

* [x] I have commented my code, particularly in hard-to-understand areas.

* [x] My changes generate no new warnings or console errors.

* [x] There is no commented-out code or debug logs left in the codebase.