### PR TITLE
feat: add welcome workflow for first-time contributors (#236)

### DIFF
--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -1,0 +1,28 @@
+name: Welcome New Contributors
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  welcome:
+    if: github.event.pull_request.merged == true && github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post welcome comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const message = `🎉 Thank you for contributing to the project! 🌟
+
+            If you find the repository helpful, please consider giving it a star ⭐ — it really helps support and motivate the project.
+
+            Happy Contributing 🚀`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            });


### PR DESCRIPTION
﻿Creates a GitHub Actions workflow that automatically posts a welcome comment when a first-time contributor's PR is merged.

**Changes:**
- New .github/workflows/welcome-new-contributors.yml
- Triggered on pull_request_target with closed type
- Checks for merged == true and uthor_association == 'FIRST_TIME_CONTRIBUTOR'
- Posts appreciation message using ctions/github-script@v7

Closes #236
