### PR TITLE
fix: replace Math.random with crypto.getRandomValues in shuffleArray (#229)

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -19,8 +19,7 @@ export const secureRandomIndex = (limit: number): number => {
 };
 
 /**
- * Shuffles an array using the Fisher-Yates (Knuth) algorithm with Math.random().
- * This provides an unbiased, uniform distribution suitable for games, UI layouts, etc.
+ * Shuffles an array using the Fisher-Yates (Knuth) algorithm with cryptographically secure random indices.
  * 
  * @param array The array to shuffle
  * @returns A new shuffled array
@@ -28,7 +27,7 @@ export const secureRandomIndex = (limit: number): number => {
 export function shuffleArray<T>(array: T[]): T[] {
   const shuffled = [...array];
   for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = secureRandomIndex(i + 1);
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
   return shuffled;


### PR DESCRIPTION
﻿Replaces the remaining Math.random() call in shuffleArray with the existing secureRandomIndex wrapper around crypto.getRandomValues(). The password generator (generateStrongPassword) already uses secureRandomIndex and secureShuffleArray — this fixes the last non-secure shuffle utility in the codebase.

**Changes:**
- shuffleArray now uses secureRandomIndex(i + 1) instead of Math.floor(Math.random() * (i + 1))

Closes #229
