### PR TITLE
fix: add max date validation to Date of Birth input

### DIFF
--- a/src/components/registration/MultiStepSignUp.tsx
+++ b/src/components/registration/MultiStepSignUp.tsx
@@ -1,3 +1,4 @@
+
 import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { z } from "zod";
@@ -331,12 +332,13 @@ const PersonalStep = ({ data, update }: StepProps) => (
     </div>
     <div className="space-y-2">
       <Label htmlFor="signup-dob">Date of Birth</Label>
-      <Input
-        id="signup-dob"
-        type="date"
-        value={data.date_of_birth}
-        onChange={(e) => update({ date_of_birth: e.target.value })}
-      />
+    <Input
+     id="signup-dob"
+     type="date"
+     max={new Date().toISOString().split("T")[0]}
+     value={data.date_of_birth}
+     onChange={(e) => update({ date_of_birth: e.target.value })}
+     />
     </div>
     <div className="space-y-2">
       <Label htmlFor="signup-gender">Gender</Label>


### PR DESCRIPTION


Closes #228

## Problem
The Date of Birth input field had no `max` attribute, allowing users to select future dates which is invalid for a date of birth.

## Solution
Added `max={new Date().toISOString().split("T")[0]}` to the date input, restricting selection to today or any past date.

## Changes
- `src/components/registration/MultiStepSignUp.tsx`: Added `max` attribute to Date of Birth input field

## Type of Change
- [x] Bug Fix (non-breaking change which fixes an issue)

## Checklist
- [x] No unrelated files changed
- [x] Follows existing code style (TypeScript + Tailwind)
- [x] PR is linked to an open issue

