### PR TITLE
fix: replace Math.random with crypto.getRandomValues in shuffleArray

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,10 +1,8 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
-
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
 /**
  * Generates a cryptographically secure random index in the range [0, limit - 1] using window.crypto.getRandomValues().
  * This is used for security-sensitive operations such as password generation.
@@ -17,10 +15,9 @@ export const secureRandomIndex = (limit: number): number => {
   window.crypto.getRandomValues(array);
   return array[0] % limit;
 };
-
 /**
- * Shuffles an array using the Fisher-Yates (Knuth) algorithm with Math.random().
- * This provides an unbiased, uniform distribution suitable for games, UI layouts, etc.
+ * Shuffles an array using the Fisher-Yates (Knuth) algorithm with cryptographically secure random indices.
+ * This is used for security-sensitive shuffling such as passwords and any other shuffle operations.
  * 
  * @param array The array to shuffle
  * @returns A new shuffled array
@@ -28,12 +25,11 @@ export const secureRandomIndex = (limit: number): number => {
 export function shuffleArray<T>(array: T[]): T[] {
   const shuffled = [...array];
   for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = secureRandomIndex(i + 1);
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
   return shuffled;
 }
-
 /**
  * Shuffles an array using the Fisher-Yates (Knuth) algorithm with cryptographically secure random indices.
  * This is used for security-sensitive shuffling such as passwords.


### PR DESCRIPTION
Closes #229
Problem
shuffleArray was using Math.random() which is not cryptographically secure and should not be used for security-sensitive operations like password generation.
Solution
Replaced Math.floor(Math.random() * (i + 1)) with secureRandomIndex(i + 1) in shuffleArray which uses crypto.getRandomValues() for cryptographically secure randomness.
Changes

src/lib/utils.ts: Updated shuffleArray to use secureRandomIndex() instead of Math.random()

Type of Change

 Bug Fix (non-breaking change which fixes an issue)

Checklist

 No unrelated files changed
 Follows existing code style (TypeScript + Tailwind)
 PR is linked to an open issue