### PR TITLE
fix: prevent non-medical conversational inputs from being stored in s…

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -162,6 +162,13 @@ const ChatInterface = () => {
             : severityLevel === 'moderate' ? Math.floor(Math.random() * 30) + 40 
             : Math.floor(Math.random() * 30) + 10;
 
+            const isMedicalAnalysis =
+  assistantContent.includes("Possible Causes") ||
+  assistantContent.includes("Severity Level");
+
+if (!isMedicalAnalysis) {
+  return;
+}
           const { error: insertError } = await supabase.from("symptom_history").insert({
             user_id: user.id,
             symptoms: userMessage.content,


### PR DESCRIPTION
## Description

This PR prevents non-medical conversational inputs from being stored in `symptom_history`.

### Changes Made

* Added validation before saving records to `symptom_history`.
* Ensured that only symptom-related analyses are stored.
* Excluded general conversational messages from health records.

### Tested Inputs

Not Stored:

* hello
* ok
* thanks
* remedies
* is english only available

Stored:

* I have fever
* I have headache
* Chest pain and dizziness

### Impact

* Improves quality of symptom history records.
* Reduces noise in health reports.
* Aligns behavior with the expected functionality described in Issue #215.

Fixes #215


<img width="1913" height="888" alt="Screenshot 2026-06-05 163126" src="https://github.com/user-attachments/assets/aa1bbfd0-2ae5-4b32-8759-955c883e8f5e" />
<img width="1868" height="944" alt="Screenshot 2026-06-05 163138" src="https://github.com/user-attachments/assets/f45c5a24-8907-4281-a912-2d291e53dd34" />
<img width="1887" height="897" alt="Screenshot 2026-06-05 163234" src="https://github.com/user-attachments/assets/92b1d834-5fd3-4dd2-b891-c4df2386fa79" />

