### PR TITLE
Bugfix/metrics chart skew

### DIFF
--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -476,57 +476,66 @@ const Metrics = () => {
                   </Table>
                 </div>
               )}
-              {historyView === "chart" && (
-                <div className="h-[400px] w-full rounded-xl border p-4">
-                  <ResponsiveContainer width="100%" height="100%">
-                    <LineChart data={filteredRecords}>
-                      <CartesianGrid strokeDasharray="3 3" />
+              {historyView === "chart" &&
+                (historyMetricFilter === "all" ? (
+                  <div className="flex flex-col items-center justify-center h-[400px] w-full rounded-xl border border-dashed p-8 text-center bg-muted/20">
+                    <TrendingUp className="w-12 h-12 text-muted-foreground mb-4 opacity-60" />
+                    <h3 className="text-lg font-semibold mb-1">Chart View Disabled for "All Metrics"</h3>
+                    <p className="text-sm text-muted-foreground max-w-sm">
+                      Please select a specific metric type from the dropdown filter above to view its trend chart.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="h-[400px] w-full rounded-xl border p-4">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={filteredRecords}>
+                        <CartesianGrid strokeDasharray="3 3" />
 
-                      <XAxis
-                        dataKey="recorded_at"
-                        tickFormatter={(value) =>
-                          new Date(value).toLocaleString([], {
-                            month: "short",
-                            day: "numeric",
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          })
-                        }
-                      />
-
-                      <YAxis />
-
-                      <Tooltip labelFormatter={(value) => formatDate(value)} />
-
-                      {isBloodPressure ? (
-                        <>
-                          <Line
-                            type="monotone"
-                            dataKey="value.systolic"
-                            stroke="#ef4444"
-                            strokeWidth={3}
-                            dot={{ r: 4 }}
-                          />
-
-                          <Line
-                            type="monotone"
-                            dataKey="value.diastolic"
-                            stroke="#3b82f6"
-                            name="Diastolic"
-                          />
-                        </>
-                      ) : (
-                        <Line
-                          type="monotone"
-                          dataKey="value.value"
-                          stroke="#8884d8"
-                          name="Value"
+                        <XAxis
+                          dataKey="recorded_at"
+                          tickFormatter={(value) =>
+                            new Date(value).toLocaleString([], {
+                              month: "short",
+                              day: "numeric",
+                              hour: "2-digit",
+                              minute: "2-digit",
+                            })
+                          }
                         />
-                      )}
-                    </LineChart>
-                  </ResponsiveContainer>
-                </div>
-              )}
+
+                        <YAxis />
+
+                        <Tooltip labelFormatter={(value) => formatDate(value)} />
+
+                        {isBloodPressure ? (
+                          <>
+                            <Line
+                              type="monotone"
+                              dataKey="value.systolic"
+                              stroke="#ef4444"
+                              strokeWidth={3}
+                              dot={{ r: 4 }}
+                            />
+
+                            <Line
+                              type="monotone"
+                              dataKey="value.diastolic"
+                              stroke="#3b82f6"
+                              name="Diastolic"
+                            />
+                          </>
+                        ) : (
+                          <Line
+                            type="monotone"
+                            dataKey="value.value"
+                            stroke="#8884d8"
+                            name="Value"
+                          />
+                        )}
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                ))}
             </>
           )}
         </CardContent>


### PR DESCRIPTION
## **Pull Request Description**

This PR resolves a UX bug where the chart view in `Metrics.tsx` gets skewed when the "All Metrics" filter is active.
Because completely different metrics (e.g., Steps ~ 8000, Temperature ~ 98.6°F, Oxygen ~ 98%) were plotted on a single Y-axis, high values skewed the chart scaling. This flattened other metrics into illegible horizontal lines at the bottom.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [x] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #243 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- Verified build and TypeScript compilation (`npx tsc --noEmit`).
- Verified that switching to chart view under "All Metrics" presents the helpful helper screen, and selecting a specific metric immediately renders the correct graph.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

_No visuals_

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
