### PR TITLE
fix: remove duplicate password visibility icon

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -195,3 +195,12 @@ body {
     background-color 0.3s ease,
     color 0.3s ease;
 }
+
+/* Hide browser native password reveal button */
+input[type="password"]::-ms-reveal,
+input[type="password"]::-ms-clear,
+input[type="password"]::-webkit-credentials-auto-fill-button {
+  display: none !important;
+  width: 0;
+  height: 0;
+}


### PR DESCRIPTION
## **Pull Request Description**
Fixed the issue where duplicate password visibility (eye) icons were displayed in the password field.

---

### **1. Type of Change**
- Removed duplicate eye icon rendering
- Preserved password visibility toggle functionality
- Improved UI consistency

---
### 2. Related Issue

Fixes #261 
---
### 3. How Has This Been Tested?

- [x] **Manual Verification**: Verified the fix locally.

**Manual Verification Steps**
1. Open the page containing the password field.
2. Verify that only one password visibility icon is displayed.
3. Click the icon to toggle password visibility.
4. Confirm that the password visibility functionality works as expected.

---

### 4. Visual Verification (If applicable)

| Before | After |
| :---: | :---: |
| ![Before](https://i.imgur.com/c782tEq.png) | ![After](https://i.imgur.com/RhtDdzI.png) |

**Issue Fixed:** Duplicate password visibility icons were displayed in the password field. After the fix, only a single visibility toggle icon is rendered and functions correctly.
---

### 5. Contributor Quality Checklist

- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
