### PR TITLE
fix: add validation to contact form submission

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,17 +1,65 @@
 import { useState } from "react";
 import { Mail, MessageSquare, Phone, CheckCircle } from "lucide-react";
 
+type ContactForm = {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+};
+
+type ContactFormErrors = Partial<Record<keyof ContactForm, string>>;
+
 const Contact = () => {
   const [submitted, setSubmitted] = useState(false);
-  const [form, setForm] = useState({ name: "", email: "", subject: "", message: "" });
+  const [form, setForm] = useState<ContactForm>({ name: "", email: "", subject: "", message: "" });
+  const [errors, setErrors] = useState<ContactFormErrors>({});
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+    setErrors((currentErrors) => ({ ...currentErrors, [name]: undefined }));
+  };
+
+  const validateForm = () => {
+    const nextErrors: ContactFormErrors = {};
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    if (!form.name.trim()) {
+      nextErrors.name = "Name is required.";
+    }
+
+    if (!form.email.trim()) {
+      nextErrors.email = "Email is required.";
+    } else if (!emailPattern.test(form.email.trim())) {
+      nextErrors.email = "Enter a valid email address.";
+    }
+
+    if (!form.subject) {
+      nextErrors.subject = "Please select a topic.";
+    }
+
+    if (!form.message.trim()) {
+      nextErrors.message = "Message is required.";
+    } else if (form.message.trim().length < 10) {
+      nextErrors.message = "Message must be at least 10 characters.";
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!validateForm()) return;
+
     setSubmitted(true);
+  };
+
+  const resetForm = () => {
+    setSubmitted(false);
+    setForm({ name: "", email: "", subject: "", message: "" });
+    setErrors({});
   };
 
   return (
@@ -59,28 +107,37 @@ const Contact = () => {
               <h3 className="text-xl font-semibold">Message Sent!</h3>
               <p className="text-muted-foreground text-sm">Thanks for reaching out. We'll get back to you within 24 hours.</p>
               <button
-                onClick={() => { setSubmitted(false); setForm({ name: "", email: "", subject: "", message: "" }); }}
+                type="button"
+                onClick={resetForm}
                 className="mt-2 text-sm text-primary hover:underline"
               >
                 Send another message
               </button>
             </div>
           ) : (
-            <div className="space-y-5">
+            <form onSubmit={handleSubmit} className="space-y-5" noValidate>
               <h3 className="text-lg font-semibold">Send us a message</h3>
               <div>
-                <label className="text-sm font-medium block mb-1">Name</label>
-                <input name="name" value={form.name} onChange={handleChange} placeholder="Your full name"
+                <label htmlFor="contact-name" className="text-sm font-medium block mb-1">Name</label>
+                <input id="contact-name" name="name" value={form.name} onChange={handleChange} placeholder="Your full name"
+                  aria-invalid={Boolean(errors.name)}
+                  aria-describedby={errors.name ? "contact-name-error" : undefined}
                   className="w-full rounded-lg border bg-background px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary" />
+                {errors.name && <p id="contact-name-error" className="mt-1 text-sm text-destructive">{errors.name}</p>}
               </div>
               <div>
-                <label className="text-sm font-medium block mb-1">Email</label>
-                <input name="email" type="email" value={form.email} onChange={handleChange} placeholder="you@example.com"
+                <label htmlFor="contact-email" className="text-sm font-medium block mb-1">Email</label>
+                <input id="contact-email" name="email" type="email" value={form.email} onChange={handleChange} placeholder="you@example.com"
+                  aria-invalid={Boolean(errors.email)}
+                  aria-describedby={errors.email ? "contact-email-error" : undefined}
                   className="w-full rounded-lg border bg-background px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary" />
+                {errors.email && <p id="contact-email-error" className="mt-1 text-sm text-destructive">{errors.email}</p>}
               </div>
               <div>
-                <label className="text-sm font-medium block mb-1">Subject</label>
-                <select name="subject" value={form.subject} onChange={handleChange}
+                <label htmlFor="contact-subject" className="text-sm font-medium block mb-1">Subject</label>
+                <select id="contact-subject" name="subject" value={form.subject} onChange={handleChange}
+                  aria-invalid={Boolean(errors.subject)}
+                  aria-describedby={errors.subject ? "contact-subject-error" : undefined}
                   className="w-full rounded-lg border bg-background px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary">
                   <option value="">Select a topic</option>
                   <option value="bug">Bug Report</option>
@@ -88,18 +145,22 @@ const Contact = () => {
                   <option value="account">Account Issue</option>
                   <option value="other">Other</option>
                 </select>
+                {errors.subject && <p id="contact-subject-error" className="mt-1 text-sm text-destructive">{errors.subject}</p>}
               </div>
               <div>
-                <label className="text-sm font-medium block mb-1">Message</label>
-                <textarea name="message" value={form.message} onChange={handleChange} rows={4}
+                <label htmlFor="contact-message" className="text-sm font-medium block mb-1">Message</label>
+                <textarea id="contact-message" name="message" value={form.message} onChange={handleChange} rows={4}
                   placeholder="Describe your issue or question..."
+                  aria-invalid={Boolean(errors.message)}
+                  aria-describedby={errors.message ? "contact-message-error" : undefined}
                   className="w-full rounded-lg border bg-background px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary resize-none" />
+                {errors.message && <p id="contact-message-error" className="mt-1 text-sm text-destructive">{errors.message}</p>}
               </div>
-              <button onClick={handleSubmit}
+              <button type="submit"
                 className="w-full bg-primary text-primary-foreground py-2.5 rounded-lg font-medium hover:bg-primary/90 transition-colors">
                 Send Message
               </button>
-            </div>
+            </form>
           )}
         </div>
       </section>


### PR DESCRIPTION
## **Pull Request Description**

This PR fixes the contact form issue where users could submit an empty form and still see the "Message Sent!" success state.

The contact form now validates required fields before submission, shows field-specific error messages, and only displays the success message after valid input.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #277 

---

### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Tried submitting the contact form with empty fields and verified validation errors are shown.
  2. Filled all required fields with valid input and verified the success message is shown.

---

### **4. Visual Verification (If applicable)**

| Before | After |
| :--- | :--- |
| Empty form showed "Message Sent!" | Empty form shows validation errors |
| <img width="1278" height="619" alt="image" src="https://github.com/user-attachments/assets/75e96eb8-1f93-40c1-9514-7631e2766dd3" /> | <img width="1273" height="630" alt="image" src="https://github.com/user-attachments/assets/761e1a4c-1708-43b0-8524-f363411b678a" /> |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.