### PR TITLE
fix: add distinct variants for showWarning and showInfo toast notifications

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,12 +1,13 @@
+
 import * as React from "react";
 import * as ToastPrimitives from "@radix-ui/react-toast";
 import { cva, type VariantProps } from "class-variance-authority";
 import { X } from "lucide-react";
-
+ 
 import { cn } from "@/lib/utils";
-
+ 
 const ToastProvider = ToastPrimitives.Provider;
-
+ 
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
@@ -21,7 +22,7 @@ const ToastViewport = React.forwardRef<
   />
 ));
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
-
+ 
 const toastVariants = cva(
   "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
@@ -29,6 +30,8 @@ const toastVariants = cva(
       variant: {
         default: "border bg-background text-foreground",
         destructive: "destructive group border-destructive bg-destructive text-destructive-foreground",
+        warning: "border-yellow-400 bg-yellow-50 text-yellow-900 dark:border-yellow-500 dark:bg-yellow-950 dark:text-yellow-200",
+        info: "border-blue-400 bg-blue-50 text-blue-900 dark:border-blue-500 dark:bg-blue-950 dark:text-blue-200",
       },
     },
     defaultVariants: {
@@ -36,7 +39,7 @@ const toastVariants = cva(
     },
   },
 );
-
+ 
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
@@ -44,7 +47,7 @@ const Toast = React.forwardRef<
   return <ToastPrimitives.Root ref={ref} className={cn(toastVariants({ variant }), className)} {...props} />;
 });
 Toast.displayName = ToastPrimitives.Root.displayName;
-
+ 
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
@@ -59,7 +62,7 @@ const ToastAction = React.forwardRef<
   />
 ));
 ToastAction.displayName = ToastPrimitives.Action.displayName;
-
+ 
 const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
@@ -77,7 +80,7 @@ const ToastClose = React.forwardRef<
   </ToastPrimitives.Close>
 ));
 ToastClose.displayName = ToastPrimitives.Close.displayName;
-
+ 
 const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
@@ -85,7 +88,7 @@ const ToastTitle = React.forwardRef<
   <ToastPrimitives.Title ref={ref} className={cn("text-sm font-semibold", className)} {...props} />
 ));
 ToastTitle.displayName = ToastPrimitives.Title.displayName;
-
+ 
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
@@ -93,11 +96,11 @@ const ToastDescription = React.forwardRef<
   <ToastPrimitives.Description ref={ref} className={cn("text-sm opacity-90", className)} {...props} />
 ));
 ToastDescription.displayName = ToastPrimitives.Description.displayName;
-
+ 
 type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
-
+ 
 type ToastActionElement = React.ReactElement<typeof ToastAction>;
-
+ 
 export {
   type ToastProps,
   type ToastActionElement,
@@ -109,3 +112,4 @@ export {
   ToastClose,
   ToastAction,
 };
+ 

--- a/src/lib/toast-helpers.ts
+++ b/src/lib/toast-helpers.ts
@@ -1,5 +1,4 @@
 import { toast } from "@/hooks/use-toast";
-
 export const showSuccess = (title: string, description?: string) => {
   toast({
     title,
@@ -7,7 +6,6 @@ export const showSuccess = (title: string, description?: string) => {
     variant: "default",
   });
 };
-
 export const showError = (title: string, description?: string) => {
   toast({
     title,
@@ -15,21 +13,20 @@ export const showError = (title: string, description?: string) => {
     variant: "destructive",
   });
 };
-
 export const showWarning = (title: string, description?: string) => {
   toast({
     title,
     description,
+    variant: "warning",
   });
 };
-
 export const showInfo = (title: string, description?: string) => {
   toast({
     title,
     description,
+    variant: "info",
   });
 };
-
 export const showLoading = (title: string = "Processing...", description?: string) => {
   const { id, dismiss } = toast({
     title,


### PR DESCRIPTION
Closes #296 

## Problem
`showWarning()` and `showInfo()` both called `toast()` without a variant,
resulting in identical default styling. Users had no visual way to distinguish
between warning and informational notifications.

## Changes
- `src/components/ui/toast.tsx` — added `warning` (yellow) and `info` (blue)
  variants to `toastVariants`
- `src/lib/toast-helpers.ts` — added `variant: "warning"` to `showWarning()`
  and `variant: "info"` to `showInfo()`

## Notes
- `hooks/use-toast.ts` required no changes as it imports `ToastProps` directly
  from `toast.tsx`, so the new variants are automatically available
- `showSuccess`, `showError`, and `showLoading` are untouched