### PR TITLE
Security: Enforce strict column protection trigger and RPC for player XP progress

### DIFF
--- a/src/pages/BrainGames.tsx
+++ b/src/pages/BrainGames.tsx
@@ -200,35 +200,19 @@ const BrainGames = () => {
     fetchUserStats();
   }, []);
 
-  // Save stats when XP changes (after initial load is complete)
-  useEffect(() => {
-    if (!statsLoaded) return;
+  const awardXp = async (pointsToGain: number) => {
+    if (pointsToGain <= 0) return;
+    setXp((prev) => prev + pointsToGain);
 
-    const saveStats = async () => {
-      try {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-        if (!user) return;
-
-        const newLevel = Math.floor(xp / XP_PER_LEVEL) + 1;
-        const { error } = await supabase
-          .from("profiles")
-          .update({
-            xp: xp,
-            level: newLevel,
-            updated_at: new Date().toISOString(),
-          })
-          .eq("user_id", user.id);
-
-        if (error) throw error;
-      } catch (error) {
-        console.error("Error saving user stats:", error);
-      }
-    };
-
-    saveStats();
-  }, [xp, statsLoaded]);
+    try {
+      const { error } = await supabase.rpc("award_user_xp", {
+        points_to_add: pointsToGain,
+      });
+      if (error) throw error;
+    } catch (err) {
+      console.error("Error awarding user XP:", err);
+    }
+  };
 
   const { toast } = useToast();
 
@@ -533,11 +517,9 @@ const BrainGames = () => {
 
         const newScore = patternScore + pointsEarned;
         const newStreak = patternStreak + 1;
-        const newXp = xp + xpEarned;
-
         setPatternScore(newScore);
         setPatternStreak(newStreak);
-        setXp(newXp);
+        awardXp(xpEarned);
 
         if (timeBonus > 0) {
           showSuccess(
@@ -580,7 +562,7 @@ const BrainGames = () => {
 
         // Bonus XP for completing
         const completionBonus = 50;
-        setXp((prev) => prev + completionBonus);
+        awardXp(completionBonus);
         showSuccess("Game Complete!", `+${completionBonus} XP bonus!`);
         return;
       }
@@ -601,7 +583,6 @@ const BrainGames = () => {
       questionTimeLeft,
       patternScore,
       patternStreak,
-      xp,
       toast,
     ]
   );
@@ -809,7 +790,7 @@ const BrainGames = () => {
         if (matchedCards.length + 2 === memoryCards.length) {
           setMemoryGameWon(true);
           const winXp = 30;
-          setXp((prev) => prev + winXp);
+          awardXp(winXp);
           showSuccess(
             "🎉 Congratulations! 🎉",
             `You've matched all pairs! Great memory! (+${winXp} XP)`
@@ -848,7 +829,7 @@ const BrainGames = () => {
       const newScore = mathScore + 1;
       setMathScore(newScore);
       const mathXp = 5;
-      setXp((prev) => prev + mathXp);
+      awardXp(mathXp);
       showSuccess("✓ Correct! ✓", `Score: ${newScore} (+${mathXp} XP)`);
       toast({
         title: "✓ Correct!",
@@ -1817,7 +1798,7 @@ const BrainGames = () => {
                             wordSequence.every((word, i) => word === userSequence[i].word);
                           if (correct) {
                             const recallXp = 40;
-                            setXp((prev) => prev + recallXp);
+                            awardXp(recallXp);
                             showSuccess(
                               "🎉 PERFECT! 🎉",
                               `Exceptional memory recall! (+${recallXp} XP)`

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -89,7 +89,7 @@ const History = () => {
 
           const localEntries = data.map((record: SymptomEntry) => ({
             id: record.id,
-            user_id: (record as any).user_id,
+            user_id: user.id,
             symptoms: record.symptoms,
             severity_level: record.severity_level,
             possible_causes: record.possible_causes,
@@ -201,7 +201,7 @@ const History = () => {
     URL.revokeObjectURL(url);
   };
 
-  const getSeverityColor = (severity: string) => {
+  const getSeverityColor = (severity: string): "destructive" | "default" | "secondary" => {
     switch (severity) {
       case "high": return "destructive";
       case "moderate": return "default";
@@ -305,7 +305,7 @@ const History = () => {
                     </p>
                   </div>
                   <div className="flex flex-wrap items-center gap-2 shrink-0">
-                    <Badge variant={getSeverityColor(entry.severity_level) as any}>
+                    <Badge variant={getSeverityColor(entry.severity_level)}>
                       {entry.severity_level}
                     </Badge>
                     <Button

--- a/supabase/migrations/20260612100000_secure_gamification.sql
+++ b/supabase/migrations/20260612100000_secure_gamification.sql
@@ -1,0 +1,60 @@
+-- 1. Create a function to check and restrict direct updates to 'xp' and 'level' columns by client-side roles
+CREATE OR REPLACE FUNCTION public.check_profile_columns_protection()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- If the transaction is executed by standard client roles, check if protected columns are being modified
+  IF current_user IN ('authenticated', 'anon') THEN
+    IF NEW.xp IS DISTINCT FROM OLD.xp OR NEW.level IS DISTINCT FROM OLD.level THEN
+      RAISE EXCEPTION 'Direct updates to columns (xp, level) are prohibited. Please use the secure rpc.award_user_xp() function.';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 2. Bind the trigger to profiles table
+DROP TRIGGER IF EXISTS tr_protect_profile_gamification ON public.profiles;
+
+CREATE TRIGGER tr_protect_profile_gamification
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.check_profile_columns_protection();
+
+-- 3. Create the secure XP award function
+CREATE OR REPLACE FUNCTION public.award_user_xp(points_to_add INTEGER)
+RETURNS void AS $$
+DECLARE
+  current_user_id UUID;
+  current_xp INTEGER;
+  new_xp INTEGER;
+  new_level INTEGER;
+  XP_PER_LEVEL CONSTANT INTEGER := 100;
+BEGIN
+  -- Extract authenticated user ID from context
+  current_user_id := auth.uid();
+  
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'User must be authenticated to award XP';
+  END IF;
+
+  -- Validate XP increment input (prevent cheating or negative values)
+  IF points_to_add < 0 OR points_to_add > 100 THEN
+    RAISE EXCEPTION 'Invalid XP increment amount';
+  END IF;
+
+  -- Get current XP
+  SELECT COALESCE(xp, 0) INTO current_xp FROM public.profiles WHERE user_id = current_user_id;
+
+  new_xp := current_xp + points_to_add;
+  new_level := (new_xp / XP_PER_LEVEL) + 1;
+
+  -- Perform update (since functions running with SECURITY DEFINER run as the owner - postgres / supabase_admin,
+  -- this bypasses the client-side role check trigger)
+  UPDATE public.profiles
+  SET xp = new_xp,
+      level = new_level,
+      updated_at = NOW()
+  WHERE user_id = current_user_id;
+  
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;


### PR DESCRIPTION
## **Pull Request Description**

This PR resolves a critical security vulnerability where authenticated client-side roles (`authenticated`, `anon`) could write arbitrary values directly to the `xp` and `level` columns in the `profiles` table.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [x] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #321 
---

## **3. How Has This Been Tested?**

### Automated Checks
- Verified compilation and PWA bundles build successfully: `npm run build` -> Built successfully.
- Verified TypeScript code formatting and rule checks: `npm run lint` -> Passed with 0 errors.

### Manual Verification
- Confirmed XP increases normally when completing matching pairs or math puzzles.
- Verified direct console manipulation is blocked:
  `await supabase.from('profiles').update({ xp: 999999 }).eq('user_id', user.id)`
  Returns trigger exception rejecting direct updates.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.


---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
