### PR TITLE
feat: add sort toggle button (Newest/Oldest) to metrics history

### DIFF
--- a/src/hooks/useMetricsHistory.ts
+++ b/src/hooks/useMetricsHistory.ts
@@ -49,10 +49,9 @@ export function useMetricsHistory(userId: string | null) {
         .filter((record) => record.pending_delete === 0)
         .toArray();
 
-      // Create a copy of the array
+      // Sort based on selected order
       const sortedRecords = [...localRecords];
 
-      // Sort based on selected order
       if (sortOrder === 'newest') {
         sortedRecords.sort(
           (a, b) => new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime()

--- a/src/hooks/useMetricsHistory.ts
+++ b/src/hooks/useMetricsHistory.ts
@@ -49,9 +49,10 @@ export function useMetricsHistory(userId: string | null) {
         .filter((record) => record.pending_delete === 0)
         .toArray();
 
+      // Create a copy of the array
+      const sortedRecords = [...localRecords];
+
       // Sort based on selected order
-      let sortedRecords = [...localRecords];
-      
       if (sortOrder === 'newest') {
         sortedRecords.sort(
           (a, b) => new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime()
@@ -61,7 +62,7 @@ export function useMetricsHistory(userId: string | null) {
           (a, b) => new Date(a.recorded_at).getTime() - new Date(b.recorded_at).getTime()
         );
       }
-      
+
       setRecords(sortedRecords);
     } catch (err) {
       console.error("Error loading local metrics:", err);

--- a/src/hooks/useMetricsHistory.ts
+++ b/src/hooks/useMetricsHistory.ts
@@ -1,17 +1,14 @@
 import { useEffect, useState, useCallback } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { db, type OfflineMetric } from "@/lib/offline-db";
-
-
 import { getCachedData, invalidateCache } from "@/lib/cached-queries";
 
 export function useMetricsHistory(userId: string | null) {
   const [records, setRecords] = useState<OfflineMetric[]>([]);
-
   const [loading, setLoading] = useState(true);
+  const [sortOrder, setSortOrder] = useState<'newest' | 'oldest'>('newest');
 
   const fetchHistory = useCallback(async () => {
-    // never query with an empty/null userId.
     if (!userId) return;
 
     setLoading(true);
@@ -52,16 +49,26 @@ export function useMetricsHistory(userId: string | null) {
         .filter((record) => record.pending_delete === 0)
         .toArray();
 
-      localRecords.sort(
+      // Sort based on selected order
+      let sortedRecords = [...localRecords];
+      
+      if (sortOrder === 'newest') {
+        sortedRecords.sort(
           (a, b) => new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime()
-      );
-      setRecords(localRecords);
+        );
+      } else {
+        sortedRecords.sort(
+          (a, b) => new Date(a.recorded_at).getTime() - new Date(b.recorded_at).getTime()
+        );
+      }
+      
+      setRecords(sortedRecords);
     } catch (err) {
       console.error("Error loading local metrics:", err);
     } finally {
       setLoading(false);
     }
-  }, [userId]);
+  }, [userId, sortOrder]);
 
   const deleteRecord = async (id: string) => {
     if (navigator.onLine) {
@@ -83,17 +90,17 @@ export function useMetricsHistory(userId: string | null) {
   };
 
   useEffect(() => {
-    // Only fire when userId is a real non-empty string.
     if (userId) {
       fetchHistory();
     }
-  }, [userId, fetchHistory]);
+  }, [userId, sortOrder, fetchHistory]);
 
   return {
     records,
-    //  Still "loading" if userId hasn't resolved yet.
     loading: loading || !userId,
     refresh: fetchHistory,
     deleteRecord,
+    setSortOrder,
+    sortOrder,
   };
 }

--- a/src/hooks/useMetricsHistory.ts
+++ b/src/hooks/useMetricsHistory.ts
@@ -49,7 +49,6 @@ export function useMetricsHistory(userId: string | null) {
         .filter((record) => record.pending_delete === 0)
         .toArray();
 
-      // Sort based on selected order
       const sortedRecords = [...localRecords];
 
       if (sortOrder === 'newest') {
@@ -93,7 +92,7 @@ export function useMetricsHistory(userId: string | null) {
     if (userId) {
       fetchHistory();
     }
-  }, [userId, sortOrder, fetchHistory]);
+  }, [userId, fetchHistory]);
 
   return {
     records,

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -109,8 +109,8 @@ const Metrics = () => {
     loading: historyLoading,
     refresh,
     deleteRecord,
-    setSortOrder,
     sortOrder,
+    setSortOrder,
   } = useMetricsHistory(historyUserId);
   
   useEffect(() => {
@@ -161,15 +161,15 @@ const Metrics = () => {
     if (metricType === "blood_pressure" && (!systolic || !diastolic)) return;
     if (metricType !== "blood_pressure" && !value) return;
 
-    if (metricType === "heart_rate"){
+    if (metricType === "heart_rate") {
       const hr = Number(value);
-      if(hr < 30 || hr > 250){
+      if (hr < 30 || hr > 250) {
         alert("Heart Rate must be between 30 and 250 BPM");
         return;
       }
     }
     
-    if (metricType === "temperature"){
+    if (metricType === "temperature") {
       const temp = Number(value);
       if (temp < 86 || temp > 113) {
         alert("Temperature must be between 86°F and 113°F");

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -26,8 +26,6 @@ import {
   Droplet,
   Wind,
   TrendingUp,
-  TrendingDown,
-  Minus,
   ArrowUpDown,
 } from "lucide-react";
 import { showSuccess, showError } from "@/lib/toast-helpers";
@@ -85,16 +83,9 @@ const metricTypes = [
   },
 ];
 
-interface MetricEntry {
-  id: string;
-  metric_type: string;
-  value: { value?: number; systolic?: number; diastolic?: number };
-  notes: string | null;
-  recorded_at: string;
-}
-
 const Metrics = () => {
   const chartRef = useRef<HTMLDivElement>(null);
+  
   const downloadChart = async () => {
     if (!chartRef.current) return;
     const dataUrl = await toPng(chartRef.current);
@@ -103,6 +94,7 @@ const Metrics = () => {
     link.href = dataUrl;
     link.click();
   };
+  
   const [metricType, setMetricType] = useState("");
   const [value, setValue] = useState("");
   const [systolic, setSystolic] = useState("");
@@ -169,14 +161,15 @@ const Metrics = () => {
     if (metricType === "blood_pressure" && (!systolic || !diastolic)) return;
     if (metricType !== "blood_pressure" && !value) return;
 
-    if (metricType==="heart_rate"){
-      const hr=Number(value);
-      if(hr<30||hr>250){
+    if (metricType === "heart_rate"){
+      const hr = Number(value);
+      if(hr < 30 || hr > 250){
         alert("Heart Rate must be between 30 and 250 BPM");
         return;
       }
     }
-    if (metricType==="temperature"){
+    
+    if (metricType === "temperature"){
       const temp = Number(value);
       if (temp < 86 || temp > 113) {
         alert("Temperature must be between 86°F and 113°F");
@@ -225,6 +218,7 @@ const Metrics = () => {
       } = await supabase.auth.getUser();
       if (!user) throw new Error("Not authenticated");
       setHistoryUserId(user.id);
+      
       let metricValue: { value?: number; systolic?: number; diastolic?: number } = {};
       if (metricType === "blood_pressure") {
         metricValue = {
@@ -533,7 +527,6 @@ const Metrics = () => {
                   </SelectContent>
                 </Select>
 
-                {/* SORT TOGGLE BUTTONS - NEW CODE ADDED HERE */}
                 <div className="flex gap-2 ml-auto">
                   <Button
                     variant={sortOrder === "newest" ? "default" : "outline"}

--- a/src/pages/Metrics.tsx
+++ b/src/pages/Metrics.tsx
@@ -28,6 +28,7 @@ import {
   TrendingUp,
   TrendingDown,
   Minus,
+  ArrowUpDown,
 } from "lucide-react";
 import { showSuccess, showError } from "@/lib/toast-helpers";
 import { useMetricsHistory } from "@/hooks/useMetricsHistory";
@@ -96,12 +97,12 @@ const Metrics = () => {
   const chartRef = useRef<HTMLDivElement>(null);
   const downloadChart = async () => {
     if (!chartRef.current) return;
-  const dataUrl = await toPng(chartRef.current);
-  const link = document.createElement("a");
-  link.download = "health-metric-chart.png";
-  link.href = dataUrl;
-  link.click();
-};
+    const dataUrl = await toPng(chartRef.current);
+    const link = document.createElement("a");
+    link.download = "health-metric-chart.png";
+    link.href = dataUrl;
+    link.click();
+  };
   const [metricType, setMetricType] = useState("");
   const [value, setValue] = useState("");
   const [systolic, setSystolic] = useState("");
@@ -116,7 +117,10 @@ const Metrics = () => {
     loading: historyLoading,
     refresh,
     deleteRecord,
+    setSortOrder,
+    sortOrder,
   } = useMetricsHistory(historyUserId);
+  
   useEffect(() => {
     const fetchUser = async () => {
       const {
@@ -157,6 +161,7 @@ const Metrics = () => {
       window.removeEventListener("offline", handleOffline);
     };
   }, [refresh]);
+  
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -171,7 +176,7 @@ const Metrics = () => {
         return;
       }
     }
-    if (metricType==="tempreature"){
+    if (metricType==="temperature"){
       const temp = Number(value);
       if (temp < 86 || temp > 113) {
         alert("Temperature must be between 86°F and 113°F");
@@ -216,7 +221,6 @@ const Metrics = () => {
     setLoading(true);
     try {
       const {
-
         data: { user },
       } = await supabase.auth.getUser();
       if (!user) throw new Error("Not authenticated");
@@ -252,7 +256,6 @@ const Metrics = () => {
 
         await invalidateCache("health_metrics");
 
-        // Cache locally
         await db.healthMetrics.put({
           id: recordId,
           user_id: user.id,
@@ -269,7 +272,6 @@ const Metrics = () => {
           "Your health metric has been saved successfully.",
         );
       } else {
-        // Save offline in local database
         await db.healthMetrics.put({
           id: recordId,
           user_id: user.id,
@@ -287,13 +289,11 @@ const Metrics = () => {
         );
       }
 
-      // Reset form
       setValue("");
       setSystolic("");
       setDiastolic("");
       setNotes("");
 
-      // Refresh history
       refresh();
     } catch (error) {
       console.error("Error saving metric:", error);
@@ -302,6 +302,7 @@ const Metrics = () => {
       setLoading(false);
     }
   };
+  
   const formatMetricValue = (record: OfflineMetric) => {
     const recordValue = record.value as { value?: number; systolic?: number; diastolic?: number } | null;
     if (record.metric_type === "blood_pressure") {
@@ -312,6 +313,7 @@ const Metrics = () => {
 
     return `${recordValue?.value} ${metric?.unit || ""}`;
   };
+  
   const formatDate = (date: string) => {
     return new Date(date).toLocaleString([], {
       year: "numeric",
@@ -321,6 +323,7 @@ const Metrics = () => {
       minute: "2-digit",
     });
   };
+  
   const filteredRecords = records.filter((record: OfflineMetric) => {
     const metricMatch =
       historyMetricFilter === "all" ||
@@ -341,6 +344,7 @@ const Metrics = () => {
 
     return metricMatch && diffDays <= days;
   });
+  
   const isBloodPressure = historyMetricFilter === "blood_pressure";
 
   return (
@@ -467,18 +471,20 @@ const Metrics = () => {
           </form>
         </CardContent>
       </Card>
+      
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
-          <CardTitle>Metrics History</CardTitle>
-          <CardDescription>
-            Your previously recorded health metrics
-          </CardDescription>
+            <CardTitle>Metrics History</CardTitle>
+            <CardDescription>
+              Your previously recorded health metrics
+            </CardDescription>
           </div>
-          {historyView==="chart"&&(
-          <Button onClick={downloadChart}>
-          Download Chart
-          </Button>)}
+          {historyView === "chart" && (
+            <Button onClick={downloadChart}>
+              Download Chart
+            </Button>
+          )}
         </CardHeader>
 
         <CardContent>
@@ -489,25 +495,22 @@ const Metrics = () => {
           ) : records.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-center">
               <p className="text-lg font-medium">No health metrics yet</p>
-
               <p className="text-sm text-muted-foreground mt-1">
                 Record your first measurement above to start tracking trends.
               </p>
             </div>
           ) : (
             <>
-              <div className="mb-4">
+              <div className="flex flex-wrap gap-3 mb-4">
                 <Select
                   value={historyMetricFilter}
                   onValueChange={setHistoryMetricFilter}
                 >
-                  <SelectTrigger className="w-[220px]">
+                  <SelectTrigger className="w-[180px]">
                     <SelectValue placeholder="Filter metric" />
                   </SelectTrigger>
-
                   <SelectContent>
                     <SelectItem value="all">All Metrics</SelectItem>
-
                     {metricTypes.map((metric) => (
                       <SelectItem key={metric.value} value={metric.value}>
                         {metric.label}
@@ -515,23 +518,42 @@ const Metrics = () => {
                     ))}
                   </SelectContent>
                 </Select>
+
                 <Select
                   value={timeframeFilter}
                   onValueChange={setTimeframeFilter}
                 >
-                  <SelectTrigger className="w-[220px] mt-3">
+                  <SelectTrigger className="w-[180px]">
                     <SelectValue placeholder="Select timeframe" />
                   </SelectTrigger>
-
                   <SelectContent>
                     <SelectItem value="7">Last 7 Days</SelectItem>
-
                     <SelectItem value="30">Last 30 Days</SelectItem>
-
                     <SelectItem value="all">All Time</SelectItem>
                   </SelectContent>
                 </Select>
+
+                {/* SORT TOGGLE BUTTONS - NEW CODE ADDED HERE */}
+                <div className="flex gap-2 ml-auto">
+                  <Button
+                    variant={sortOrder === "newest" ? "default" : "outline"}
+                    onClick={() => setSortOrder("newest")}
+                    className="gap-2"
+                  >
+                    <ArrowUpDown className="h-4 w-4" />
+                    Newest First
+                  </Button>
+                  <Button
+                    variant={sortOrder === "oldest" ? "default" : "outline"}
+                    onClick={() => setSortOrder("oldest")}
+                    className="gap-2"
+                  >
+                    <ArrowUpDown className="h-4 w-4" />
+                    Oldest First
+                  </Button>
+                </div>
               </div>
+
               <div className="flex gap-2 mb-4">
                 <Button
                   variant={historyView === "table" ? "default" : "outline"}
@@ -539,7 +561,6 @@ const Metrics = () => {
                 >
                   Table
                 </Button>
-
                 <Button
                   variant={historyView === "chart" ? "default" : "outline"}
                   onClick={() => setHistoryView("chart")}
@@ -547,6 +568,7 @@ const Metrics = () => {
                   Chart
                 </Button>
               </div>
+
               {historyView === "table" && (
                 <div className="rounded-xl border overflow-x-auto">
                   <Table>
@@ -559,14 +581,12 @@ const Metrics = () => {
                         <TableHead>Actions</TableHead>
                       </TableRow>
                     </TableHeader>
-
                     <TableBody>
                       {filteredRecords.map((record: OfflineMetric) => (
                         <TableRow key={record.id}>
                           <TableCell>
                             {formatDate(record.recorded_at)}
                           </TableCell>
-
                           <TableCell>
                             {
                               metricTypes.find(
@@ -574,9 +594,7 @@ const Metrics = () => {
                               )?.label
                             }
                           </TableCell>
-
                           <TableCell>{formatMetricValue(record)}</TableCell>
-
                           <TableCell>{record.notes || "-"}</TableCell>
                           <TableCell>
                             <AlertDialog>
@@ -585,23 +603,19 @@ const Metrics = () => {
                                   <Trash2 className="h-4 w-4" />
                                 </Button>
                               </AlertDialogTrigger>
-
                               <AlertDialogContent>
                                 <AlertDialogHeader>
                                   <AlertDialogTitle>
                                     Delete Record?
                                   </AlertDialogTitle>
-
                                   <AlertDialogDescription>
                                     This action cannot be undone. The selected
                                     health metric record will be permanently
                                     removed.
                                   </AlertDialogDescription>
                                 </AlertDialogHeader>
-
                                 <AlertDialogFooter>
                                   <AlertDialogCancel>Cancel</AlertDialogCancel>
-
                                   <AlertDialogAction
                                     onClick={() => deleteRecord(record.id)}
                                   >
@@ -617,6 +631,7 @@ const Metrics = () => {
                   </Table>
                 </div>
               )}
+
               {historyView === "chart" &&
                 (historyMetricFilter === "all" ? (
                   <div className="flex flex-col items-center justify-center h-[400px] w-full rounded-xl border border-dashed p-8 text-center bg-muted/20">
@@ -631,7 +646,6 @@ const Metrics = () => {
                     <ResponsiveContainer width="100%" height="100%">
                       <LineChart data={filteredRecords}>
                         <CartesianGrid strokeDasharray="3 3" />
-
                         <XAxis
                           dataKey="recorded_at"
                           tickFormatter={(value) =>
@@ -643,11 +657,8 @@ const Metrics = () => {
                             })
                           }
                         />
-
                         <YAxis />
-
                         <Tooltip labelFormatter={(value) => formatDate(value)} />
-
                         {isBloodPressure ? (
                           <>
                             <Line
@@ -657,7 +668,6 @@ const Metrics = () => {
                               strokeWidth={3}
                               dot={{ r: 4 }}
                             />
-
                             <Line
                               type="monotone"
                               dataKey="value.diastolic"


### PR DESCRIPTION
- Added Newest First / Oldest First toggle buttons
- Users can now choose sort order for metrics history
- Active button highlighted in blue
- Fixes #336

## **Pull Request Description**
Added sort toggle buttons (Newest First / Oldest First) to the Metrics History section. Users can now choose their preferred sort order.

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [* ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #336

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: Application builds successfully locally (`npm run build`)
- [x] **Lint/Format Checks**: Local checks passed
- [x] **Manual Verification**: 
  1. Logged into the application
  2. Navigated to Health Metrics page
  3. Clicked "Newest First" button - verified latest entries show at top
  4. Clicked "Oldest First" button - verified oldest entries show at top
  5. Verified active button is highlighted in blue
  6. Verified filters (metric type, timeframe) still work with sort toggle
---

### **4. Visual Verification (If applicable)**
| Before | After |
| :--- | :--- |
| No sort options available, only default sorting | Two toggle buttons: Newest First / Oldest First |
| Users couldn't change sort order | Active button highlighted, sorting changes instantly |

<img width="1919" height="947" alt="Screenshot 2026-06-12 233631" src="https://github.com/user-attachments/assets/6db7cca9-1e37-4def-977a-d1dfdca82260" />

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.