### PR TITLE
feat: add Ctrl+K keyboard shortcut to focus search in History page

### DIFF
--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -60,6 +60,21 @@ const History = () => {
     };
   }, []);
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault();
+        const searchInput = document.getElementById('symptom-search-input');
+        if (searchInput) {
+          searchInput.focus();
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
   const fetchHistory = async () => {
     try {
       const { data: { user } } = await supabase.auth.getUser();
@@ -206,8 +221,6 @@ const History = () => {
     }
   };
 
-  // FIX #3: Derive filteredHistory BEFORE render so we can show the correct
-  // empty state when search/filter produces zero results (vs. genuinely no data).
   const filteredHistory = history.filter(
     (entry) =>
       entry.symptoms.toLowerCase().includes(searchQuery.toLowerCase()) &&
@@ -242,8 +255,9 @@ const History = () => {
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <input
+            id="symptom-search-input"
             type="text"
-            placeholder="Search symptoms..."
+            placeholder="Search symptoms... (Ctrl+K to focus)"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="w-full pl-9 pr-4 py-2 rounded-md border border-input bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
@@ -264,7 +278,6 @@ const History = () => {
       {loading ? (
         <p className="text-center text-muted-foreground">Loading history...</p>
       ) : history.length === 0 ? (
-        // FIX #3: Genuinely no data at all
         <Card>
           <CardContent className="pt-6 text-center space-y-2">
             <p className="text-muted-foreground">
@@ -273,7 +286,6 @@ const History = () => {
           </CardContent>
         </Card>
       ) : filteredHistory.length === 0 ? (
-        // FIX #3: Data exists but filters returned nothing — different message
         <Card>
           <CardContent className="pt-6 text-center space-y-2">
             <p className="text-muted-foreground">
@@ -289,7 +301,6 @@ const History = () => {
           </CardContent>
         </Card>
       ) : (
-        // FIX #3: Render filteredHistory, not history
         <div className="space-y-4">
           {filteredHistory.map((entry) => (
             <Card key={entry.id} className={entry.resolved ? "opacity-70" : ""}>


### PR DESCRIPTION
## Pull Request Description
Added Ctrl+K (Cmd+K on Mac) keyboard shortcut to focus the search input on the Symptom History page. Users can now quickly focus the search box from anywhere on the page without clicking.

---

### 1. Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactoring / Performance
- [ ] Documentation Update
- [ ] Other

---

### 2. Related Issue
Fixes #359 

---

### 3. How Has This Been Tested?
- [x] **Local Build**: Application builds successfully locally (`npm run build`)
- [x] **Lint/Format Checks**: Local checks passed
- [x] **Manual Verification**: 
  1. Logged into the application
  2. Navigated to History page
  3. Pressed Ctrl+K (Windows) / Cmd+K (Mac)
  4. Search input focused successfully
  5. Placeholder shows "(Ctrl+K to focus)"
  6. Typing filters symptoms correctly

---

### 4. Visual Verification

| Before | After |
| :--- | :--- |
| No keyboard shortcut, users had to click search box | Pressing Ctrl+K focuses search input |
| Placeholder: "Search symptoms..." | Placeholder: "Search symptoms... (Ctrl+K to focus)" |

**Screenshot After Changes:**
<img width="1919" height="870" alt="Screenshot 2026-06-15 215232" src="https://github.com/user-attachments/assets/a8d70935-9619-43cf-b79f-b0d2d9316cc9" />


---

### 5. Contributor Quality Checklist
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.