### PR TITLE
fix(docs): correct broken README table of contents links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,23 @@ Symptom Scribe is an AI-powered health and wellness platform designed to help us
 
 # 📑 Table of Contents
 
-* Project Overview
-* Objectives
-* Key Features
-* Technology Stack
-* Screenshots
-* Installation & Setup
-* Environment Variables
-* Supabase Edge Function Setup
-* API & Backend Services
-* Project Structure
-* Usage Guide
-* Troubleshooting
-* FAQ
-* Contributing
-* Future Enhancements
-* License
-* Author
+- [Project Overview](#-project-overview)
+- [Objectives](#-objectives)
+- [Key Features](#-key-features)
+- [Technology Stack](#%EF%B8%8F-technology-stack)
+- [Screenshots](#-screenshots)
+- [Installation & Setup](#-installation--setup)
+- [Environment Variables](#-environment-variables)
+- [Supabase Edge Function Setup](#%EF%B8%8F-supabase-edge-function-setup)
+- [API & Backend Services](#-api--backend-services)
+- [Project Structure](#-project-structure)
+- [Usage Guide](#-usage-guide)
+- [Troubleshooting](#%EF%B8%8F-troubleshooting)
+- [FAQ](#-faq)
+- [Contributing](#-contributing)
+- [Future Enhancements](#-future-enhancements)
+- [License](#-license)
+- [Author](#%E2%80%8D-author)
 
 ---
 


### PR DESCRIPTION
## **Pull Request Description**
Fixed broken Table of Contents links in the README by updating the anchor references to match GitHub's auto-generated heading IDs. This ensures all TOC entries correctly navigate to their respective sections.
---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [x] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #365 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Opened the README file on GitHub preview/local Markdown preview.
  2. Clicked each Table of Contents link and verified navigation to the correct section.
  3. Confirmed all anchor links match their corresponding section headings.

---

### **4. Visual Verification (If applicable)**

N/A

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
