### PR TITLE
feat: add clear all filters button to Symptom History page

### DIFF
--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -275,6 +275,23 @@ const History = () => {
         </select>
       </div>
 
+      {isFiltering && (
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => { 
+              setSearchQuery(""); 
+              setSeverityFilter("all"); 
+            }}
+            className="gap-2"
+          >
+            <X className="h-4 w-4" />
+            Clear All Filters
+          </Button>
+        </div>
+      )}
+
       {loading ? (
         <p className="text-center text-muted-foreground">Loading history...</p>
       ) : history.length === 0 ? (


### PR DESCRIPTION
## Pull Request Description
Added a "Clear All Filters" button to the Symptom History page that resets both the search query and severity filter with one click.

---

### 1. Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactoring / Performance
- [ ] Documentation Update
- [ ] Other

---

### 2. Related Issue
Fixes #382

---

### 3. How Has This Been Tested?
- [x] **Local Build**: Application builds successfully locally (`npm run build`)
- [x] **Lint/Format Checks**: Local checks passed
- [x] **Manual Verification**: 
  1. Logged into the application
  2. Navigated to History page
  3. Typed "fever" in search box - Clear All Filters button appeared
  4. Selected severity filter - button remained visible
  5. Clicked "Clear All Filters" - search cleared, severity reset to "All"
  6. Button disappeared after clearing

---

### 4. Visual Verification

| Before | After |
| :--- | :--- |
| No clear filters button | "Clear All Filters" button appears when filters active |
| Users had to clear manually | One click resets all filters |

**Screenshot After Changes:**
<img width="1539" height="685" alt="Screenshot 2026-06-17 224702" src="https://github.com/user-attachments/assets/0bfff11a-92ff-4ae4-9bc4-dd2254283905" />


---

### 5. Contributor Quality Checklist
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.