### PR TITLE
 implemented active game progress protection to resolve issue #370.

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -63,6 +63,20 @@ export function AppSidebar() {
     }
   };
 
+  const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (typeof window !== "undefined" && (window as any).isGameActive) {
+      const confirmLeave = window.confirm(
+        "Are you sure you want to leave? Your active game progress will be lost."
+      );
+      if (!confirmLeave) {
+        e.preventDefault();
+        return;
+      }
+      (window as any).isGameActive = false;
+    }
+    handleMobileNavClick();
+  };
+
   const handleSignOut = async () => {
     const { error } = await supabase.auth.signOut();
     if (error) {
@@ -82,20 +96,20 @@ export function AppSidebar() {
   return (
     <Sidebar collapsible="icon">
       <div className="flex items-center justify-between p-4 border-b border-sidebar-border">
-        <NavLink to="/" className="flex items-center" onClick={handleMobileNavClick}>
+        <NavLink to="/" className="flex items-center" onClick={handleNavClick}>
           {!isCollapsed && (
             <h2 className="text-lg font-semibold text-sidebar-foreground cursor-pointer">
               Health Tracker
             </h2>
           )}
         </NavLink>
-
+ 
         {/* ✅ Hidden on mobile, visible on laptop/desktop */}
         <div className="hidden md:block">
           <SidebarTrigger />
         </div>
       </div>
-
+ 
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupLabel>Navigation</SidebarGroupLabel>
@@ -104,7 +118,7 @@ export function AppSidebar() {
               {menuItems.map((item) => (
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton asChild>
-                    <NavLink to={item.url} end className={getNavCls} onClick={handleMobileNavClick}>
+                    <NavLink to={item.url} end className={getNavCls} onClick={handleNavClick}>
                       <item.icon className="h-5 w-5" />
                       {!isCollapsed && <span>{item.title}</span>}
                     </NavLink>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -64,7 +64,7 @@ export function AppSidebar() {
   };
 
   const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (typeof window !== "undefined" && (window as any).isGameActive) {
+    if (typeof window !== "undefined" && window.isGameActive) {
       const confirmLeave = window.confirm(
         "Are you sure you want to leave? Your active game progress will be lost."
       );
@@ -72,7 +72,7 @@ export function AppSidebar() {
         e.preventDefault();
         return;
       }
-      (window as any).isGameActive = false;
+      window.isGameActive = false;
     }
     handleMobileNavClick();
   };

--- a/src/pages/BrainGames.tsx
+++ b/src/pages/BrainGames.tsx
@@ -353,7 +353,66 @@ const BrainGames = () => {
       clearTimeout(wordTimeoutRef.current);
       wordTimeoutRef.current = null;
     }
+    return () => {
+      if (wordTimeoutRef.current) {
+        clearTimeout(wordTimeoutRef.current);
+      }
+    };
   }, [activeGame]);
+
+  // Synchronize game active state with window and history hash for route protection
+  useEffect(() => {
+    const isGameActive = !!(
+      (activeGame === "memory" && memoryCards.length > 0 && !memoryGameWon) ||
+      (activeGame === "math") ||
+      (activeGame === "word" && wordSequence.length > 0) ||
+      (activeGame === "pattern" && currentQuestion !== null && !gameCompleted)
+    );
+
+    (window as any).isGameActive = isGameActive;
+
+    if (isGameActive) {
+      if (!window.location.hash.includes("game-active")) {
+        window.history.pushState(null, "", window.location.pathname + "#game-active");
+      }
+    } else {
+      if (window.location.hash.includes("game-active")) {
+        window.history.replaceState(null, "", window.location.pathname);
+      }
+    }
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (isGameActive) {
+        e.preventDefault();
+        e.returnValue = "";
+        return "";
+      }
+    };
+
+    const handlePopState = () => {
+      if (isGameActive && !window.location.hash.includes("game-active")) {
+        const confirmLeave = window.confirm(
+          "Are you sure you want to leave? Your active game progress will be lost."
+        );
+        if (confirmLeave) {
+          (window as any).isGameActive = false;
+          setActiveGame(null);
+          window.history.back();
+        } else {
+          window.history.pushState(null, "", window.location.pathname + "#game-active");
+        }
+      }
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      window.removeEventListener("popstate", handlePopState);
+      (window as any).isGameActive = false;
+    };
+  }, [activeGame, memoryCards.length, memoryGameWon, wordSequence.length, currentQuestion, gameCompleted]);
 
   // ─── Pattern Recognition Game ──────────────────────────────────────────────
 

--- a/src/pages/BrainGames.tsx
+++ b/src/pages/BrainGames.tsx
@@ -369,7 +369,7 @@ const BrainGames = () => {
       (activeGame === "pattern" && currentQuestion !== null && !gameCompleted)
     );
 
-    (window as any).isGameActive = isGameActive;
+    window.isGameActive = isGameActive;
 
     if (isGameActive) {
       if (!window.location.hash.includes("game-active")) {
@@ -395,7 +395,7 @@ const BrainGames = () => {
           "Are you sure you want to leave? Your active game progress will be lost."
         );
         if (confirmLeave) {
-          (window as any).isGameActive = false;
+          window.isGameActive = false;
           setActiveGame(null);
           window.history.back();
         } else {
@@ -410,7 +410,7 @@ const BrainGames = () => {
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
       window.removeEventListener("popstate", handlePopState);
-      (window as any).isGameActive = false;
+      window.isGameActive = false;
     };
   }, [activeGame, memoryCards.length, memoryGameWon, wordSequence.length, currentQuestion, gameCompleted]);
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  isGameActive?: boolean;
+}


### PR DESCRIPTION
## **Pull Request Description**

This PR resolves #370 (UX: Loss of Active Brain Games Progress on Route Navigation) by introducing route protection and exit confirmation dialogs when a user is actively playing a game in the Brain Fitness Center.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [x] **Other** (please specify): security

---

### **2. Related Issue**
- Fixes #370 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- **TypeScript**: Verified compilation builds cleanly (`npm run build`).
- **Tests**: Ran full vitest suite (`npm test`), all 47 tests passed successfully.
- **Manual Verification**:
  - Accidental clicking of sidebar links (Dashboard, Profile) successfully prompts confirmation.
  - Page refresh/unload during Quick Math triggers browser-native confirmation prompt.
  - Browser back button navigation successfully intercepts and prompts to discard progress or stay.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
