### PR TITLE
[Fix] :search_tokens to pending record handling

### DIFF
--- a/src/lib/offline-db.ts
+++ b/src/lib/offline-db.ts
@@ -250,7 +250,7 @@ export const syncOfflineData = async (): Promise<boolean> => {
       .toArray();
 
     for (const record of pendingMetricsInserts) {
-      const { pending_sync, pending_delete, ...supabaseData } = record;
+      const { pending_sync, pending_delete, search_tokens: _st_m, ...supabaseData } = record;
       const { error } = await supabase
         .from("health_metrics")
         .insert(supabaseData);
@@ -286,7 +286,7 @@ export const syncOfflineData = async (): Promise<boolean> => {
       .toArray();
 
     for (const record of pendingSymptomInserts) {
-      const { pending_sync, pending_delete, pending_update, ...supabaseData } = record;
+      const { pending_sync, pending_delete, pending_update, search_tokens: _st_s, ...supabaseData } = record;
       const { error } = await supabase
         .from("symptom_history")
         .insert(supabaseData);
@@ -328,4 +328,3 @@ export const syncOfflineData = async (): Promise<boolean> => {
     return false;
   }
 };
-


### PR DESCRIPTION
## **Pull Request Description**
Metrics insert: `const { pending_sync, pending_delete, search_tokens: _st_m, ...supabaseData }`. Symptom insert: adds `search_tokens: _st_s `to the same destructure. search_tokens is a client-only IndexedDB field and was being sent raw into Supabase inserts, which doesn't have that column.

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ X] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #407 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [ X] **Local Build**: The application builds successfully locally (`npm run build`).
- [ X] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).

---

### **5. Contributor Quality Checklist**
- [ X] My code follows the code style and formatting guidelines of this project.
- [X ] I have performed a self-review of my own code.
- [X ] I have commented my code, particularly in hard-to-understand areas.
- [X ] My changes generate no new warnings or console errors.
- [X ] There is no commented-out code or debug logs left in the codebase.
