### PR TITLE
[Fix]: Manage ping and cleanup intervals with IDs

### DIFF
--- a/src/lib/mesh-network.ts
+++ b/src/lib/mesh-network.ts
@@ -29,6 +29,8 @@ class MeshNetworkManager {
   private nodeId: string = "";
   private nodeName: string = "";
   private listeners: Set<() => void> = new Set();
+  private pingIntervalId: ReturnType<typeof setInterval> | null = null;
+  private cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
   private isOfflineSimulated: boolean = false;
 
   constructor() {
@@ -50,6 +52,9 @@ class MeshNetworkManager {
       if (this.isOnline()) {
         this.syncMeshAlerts();
       }
+
+      // Tear down intervals and channel when the tab closes
+      window.addEventListener("beforeunload", () => this.destroy());
     }
   }
 
@@ -115,16 +120,32 @@ class MeshNetworkManager {
     };
 
     ping();
-    setInterval(ping, 10000);
+    this.pingIntervalId = setInterval(ping, 10000);
 
     // Housekeeping cleanup every 5 seconds
-    setInterval(() => {
+    this.cleanupIntervalId = setInterval(() => {
       const activePeersCountBefore = this.peers.size;
       this.getPeers(); // triggers cleanup
       if (this.peers.size !== activePeersCountBefore) {
         this.notifyListeners();
       }
     }, 5000);
+  }
+
+  public destroy() {
+    if (this.pingIntervalId !== null) {
+      clearInterval(this.pingIntervalId);
+      this.pingIntervalId = null;
+    }
+    if (this.cleanupIntervalId !== null) {
+      clearInterval(this.cleanupIntervalId);
+      this.cleanupIntervalId = null;
+    }
+    if (this.channel) {
+      this.channel.close();
+      this.channel = null;
+    }
+    this.listeners.clear();
   }
 
   private postMessage(msg: MeshMessage) {


### PR DESCRIPTION
## **Pull Request Description**
Added two private fields `pingIntervalId` and` cleanupIntervalId`. Both setInterval calls now store their return value. Added a public `destroy() `method that clears both intervals and closes the BroadcastChannel. Constructor now registers `window.beforeunload` to call `destroy()` automatically.

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ X] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #409 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [ X] **Local Build**: The application builds successfully locally (`npm run build`).
- [ X] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).

---

### **5. Contributor Quality Checklist**
- [X ] My code follows the code style and formatting guidelines of this project.
- [ X] I have performed a self-review of my own code.
- [X ] I have commented my code, particularly in hard-to-understand areas.
- [X ] My changes generate no new warnings or console errors.
- [ X] There is no commented-out code or debug logs left in the codebase.
