### PR TITLE
[Fix]: Implement per-user PBKDF2 salt for key derivation

### DIFF
--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -68,8 +68,34 @@ function hexToUint8Array(hex: string): Uint8Array {
   return new Uint8Array(pairs.map((h) => parseInt(h, 16)));
 }
 
+// ─── Per-user PBKDF2 Salt ────────────────────────────────────────────────────
+// A random 16-byte salt is generated once per user and stored in localStorage
+// keyed by user ID. This prevents cross-user precomputation attacks that would
+// be possible with a hardcoded global salt.
+
+const SALT_KEY_PREFIX = "symptom_scribe_pbkdf2_salt_";
+
+function getUserSalt(userId: string): Uint8Array {
+  const storageKey = SALT_KEY_PREFIX + userId;
+  const stored = localStorage.getItem(storageKey);
+  if (stored) {
+    const pairs = stored.match(/[\da-f]{2}/gi) || [];
+    return new Uint8Array(pairs.map((h) => parseInt(h, 16)));
+  }
+  const newSalt = crypto.getRandomValues(new Uint8Array(16));
+  const hex = Array.from(newSalt)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  localStorage.setItem(storageKey, hex);
+  return newSalt;
+}
+
+export function clearUserSalt(userId: string): void {
+  localStorage.removeItem(SALT_KEY_PREFIX + userId);
+}
+
 // Key Derivation
-export async function deriveKeyFromToken(token: string): Promise<CryptoKey> {
+export async function deriveKeyFromToken(token: string, userId?: string): Promise<CryptoKey> {
   const encoder = new TextEncoder();
   const tokenBytes = encoder.encode(token);
 
@@ -81,7 +107,11 @@ export async function deriveKeyFromToken(token: string): Promise<CryptoKey> {
     ["deriveKey"]
   );
 
-  const salt = encoder.encode("symptom-scribe-offline-salt");
+  // Use per-user random salt when userId is available; fall back to a
+  // deterministic domain salt for unauthenticated derivation paths.
+  const salt = userId
+    ? getUserSalt(userId)
+    : encoder.encode("symptom-scribe-offline-salt");
 
   return await crypto.subtle.deriveKey(
     {
@@ -100,7 +130,7 @@ export async function deriveKeyFromToken(token: string): Promise<CryptoKey> {
   );
 }
 
-export async function deriveSearchKeyFromToken(token: string): Promise<CryptoKey> {
+export async function deriveSearchKeyFromToken(token: string, userId?: string): Promise<CryptoKey> {
   const encoder = new TextEncoder();
   const tokenBytes = encoder.encode(token);
 
@@ -112,7 +142,9 @@ export async function deriveSearchKeyFromToken(token: string): Promise<CryptoKey
     ["deriveKey"]
   );
 
-  const salt = encoder.encode("symptom-scribe-search-salt");
+  const salt = userId
+    ? getUserSalt(userId)
+    : encoder.encode("symptom-scribe-search-salt");
 
   return await crypto.subtle.deriveKey(
     {
@@ -228,7 +260,7 @@ export function registerEncryptionHooks(callbacks: {
   onTokenRefreshCallback = callbacks.onTokenRefresh;
 }
 
-async function handleSessionChange(session: Session) {
+async function handleSessionChange(session: Session) {  // session carries user.id for per-user salt
   const token = session.access_token;
   if (!token) return;
 
@@ -237,12 +269,13 @@ async function handleSessionChange(session: Session) {
   const prevToken = lastToken || localStorage.getItem("symptom_scribe_last_token");
 
   try {
-    const newKey = await deriveKeyFromToken(token);
-    const newSearchKey = await deriveSearchKeyFromToken(token);
+    const userId = session.user?.id;
+    const newKey = await deriveKeyFromToken(token, userId);
+    const newSearchKey = await deriveSearchKeyFromToken(token, userId);
 
     if (prevToken && prevToken !== token) {
-      const oldKey = await deriveKeyFromToken(prevToken);
-      const oldSearchKey = await deriveSearchKeyFromToken(prevToken);
+      const oldKey = await deriveKeyFromToken(prevToken, userId);
+      const oldSearchKey = await deriveSearchKeyFromToken(prevToken, userId);
       if (onTokenRefreshCallback) {
         await onTokenRefreshCallback(oldKey, newKey, oldSearchKey, newSearchKey);
       }

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -293,6 +293,11 @@ async function handleSessionChange(session: Session) {  // session carries user.
 }
 
 async function handleSessionClear() {
+  // Clear the per-user PBKDF2 salt from localStorage on logout so it does
+  // not persist across sessions. userId must be captured before keys are nulled.
+  const { data: { user } } = await supabase.auth.getUser();
+  if (user?.id) clearUserSalt(user.id);
+
   setKeys(null, null);
   lastToken = null;
   localStorage.removeItem("symptom_scribe_last_token");


### PR DESCRIPTION
## **Pull Request Description**

Added `getUserSalt(userId)` which generates a 16-byte random salt once per user and persists it to localStorage under `symptom_scribe_pbkdf2_salt_{userId`}. Also exports` clearUserSalt(userId)` for logout cleanup. Both` deriveKeyFromToken` and `deriveSearchKeyFromToken` now accept an optional userId parameter and use the per-user salt when provided, falling back to the old domain strings only for unauthenticated paths. `handleSessionChange` extracts `session.user?.id `and passes it to both derive calls.

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ X] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #423 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [X ] **Local Build**: The application builds successfully locally (`npm run build`).
- [X ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).

---

### **5. Contributor Quality Checklist**
- [ X] My code follows the code style and formatting guidelines of this project.
- [ X] I have performed a self-review of my own code.
- [ X] I have commented my code, particularly in hard-to-understand areas.
- [ X] My changes generate no new warnings or console errors.
- [ X] There is no commented-out code or debug logs left in the codebase.
