### PR TITLE
fix: sync AnimatedThemeToggler with next-themes to fix theme persistence (#396)

### DIFF
--- a/src/components/AnimatedThemeToggler.tsx
+++ b/src/components/AnimatedThemeToggler.tsx
@@ -1,43 +1,36 @@
 import { useEffect, useState } from 'react';
 import { flushSync } from 'react-dom';
+import { useTheme } from 'next-themes';
 import { Sun, Moon } from 'lucide-react';
-import { getSafeLocalStorage, setSafeLocalStorage } from '@/lib/storage';
 import './animated-theme-toggler.css';
 
 export function AnimatedThemeToggler({ className = '' }) {
-  const [theme, setTheme] = useState(() => {
-    return getSafeLocalStorage('theme', 'light');
-  });
+  // next-themes is the single source of truth for theme state/persistence.
+  // `resolvedTheme` is what's actually applied (system -> light/dark).
+  const { resolvedTheme, setTheme } = useTheme();
 
-  const isDark = theme === 'dark';
-  const duration = 400;
-
+  // next-themes' inline script sets the `dark` class on <html> before
+  // React mounts (preventing a page-wide flash). Seed local mount state
+  // from that class so the icon itself doesn't flash to the wrong state
+  // during the brief window before `resolvedTheme` is available.
+  const [mounted, setMounted] = useState(false);
+  const [preMountIsDark, setPreMountIsDark] = useState(false);
   useEffect(() => {
-    // Initial theme setup on mount without animation
-    if (theme === 'dark') {
-      document.documentElement.classList.add('dark');
-      document.documentElement.dataset.theme = 'dark';
-    } else {
-      document.documentElement.classList.remove('dark');
-      document.documentElement.dataset.theme = 'light';
-    }
-  }, []); // Run only once to apply existing theme on mount
+    setPreMountIsDark(document.documentElement.classList.contains('dark'));
+    setMounted(true);
+  }, []);
+
+  const isDark = mounted ? resolvedTheme === 'dark' : preMountIsDark;
+  const duration = 400;
 
   const handleToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
     const button = e.currentTarget;
     const nextTheme = isDark ? 'light' : 'dark';
 
     const applyTheme = () => {
+      // Delegate entirely to next-themes: it updates the `class`
+      // attribute on <html> and writes to localStorage itself.
       setTheme(nextTheme);
-      setSafeLocalStorage('theme', nextTheme);
-
-      if (nextTheme === 'dark') {
-        document.documentElement.classList.add('dark');
-        document.documentElement.dataset.theme = 'dark';
-      } else {
-        document.documentElement.classList.remove('dark');
-        document.documentElement.dataset.theme = 'light';
-      }
     };
 
     if (!button) {


### PR DESCRIPTION
## Summary

Closes #396

The theme toggle button (`AnimatedThemeToggler`) was maintaining its own private theme state, completely independent from the `next-themes` provider already wrapping the app. This caused the theme to become inconsistent or revert after a page refresh, since two separate systems were fighting to control the same `dark` class on `<html>`.

## Root Cause

The app has two theme systems running in parallel:

1. **`next-themes` (via `ThemeProvider`)** — the "official" system. Persists to `localStorage` under the key `symptom-scribe-theme`, supports light/dark/system, and includes an anti-flash inline script.
2. **`AnimatedThemeToggler`** — kept its own `useState`, read/wrote to a *different* `localStorage` key (`'theme'`, not even using the project's `STORAGE_KEYS` registry), and manually toggled `classList`/`dataset.theme` on `document.documentElement` directly.

On every mount, both of these tried to set the theme class. Whichever one's effect ran last won — which is why the bug was inconsistent rather than 100% reproducible, and why "System" theme never worked correctly (the toggler had no concept of `system` at all, only `light`/`dark`).

## Fix

`AnimatedThemeToggler` no longer owns any theme state or touches `localStorage`/`classList` directly. It now consumes `next-themes`' own `useTheme()` hook:

- Reads `resolvedTheme` (the actual applied theme, with `system` already resolved to `light`/`dark`) instead of a separately-tracked `useState`.
- Calls `setTheme()` from `next-themes` on toggle, which handles updating the DOM class and persisting to `localStorage` itself, correctly, in one place.
- Removed the manual mount `useEffect` that was force-applying the class from the wrong storage key.
- Added a small `mounted` / `preMountIsDark` guard so the sun/moon icon reflects the correct state immediately on load, instead of briefly flashing the wrong icon before `next-themes` finishes resolving (the page background itself never flashed, since `next-themes`' inline script already handled that — this just syncs the icon to match).

The view-transition circular reveal animation (`startViewTransition`, `flushSync`) is untouched — `setTheme` from `next-themes` is synchronous enough for `flushSync` to work exactly as before.

## Changes

- `src/components/AnimatedThemeToggler.tsx`
  - Removed: private `useState` theme tracking, `getSafeLocalStorage`/`setSafeLocalStorage` calls, manual `classList`/`dataset.theme` mutation in both the mount effect and `applyTheme()`.
  - Added: `useTheme()` from `next-themes`, mount-safety state for icon flash prevention.

No other files were changed — confirmed no other component in the codebase references the old `'theme'` localStorage key.

## Testing

- ✅ `npx tsc --noEmit` — no type errors
- ✅ `npm run build` — builds clean
- ✅ Tested in dev (`npm run dev`) and **production build** (`npm run build` + `npm run preview`):
  - Toggle light → dark → hard refresh (Ctrl+Shift+R) — theme persists correctly
  - Toggle dark → light → hard refresh — theme persists correctly
  - Navigate to a different route and back — theme unchanged
  - Verified `localStorage` key `symptom-scribe-theme` updates on toggle and is read correctly on reload
  - No flash of incorrect theme on initial load

## Acceptance Criteria 

- [x] Theme preference persists across page refreshes
- [x] Theme preference persists across route navigation
- [x] Light theme works correctly
- [x] Dark theme works correctly
- [x] System theme works correctly (now resolved via `next-themes`' `resolvedTheme`, previously unsupported by the toggler)
- [x] Theme state is synchronized with `next-themes`
- [x] No flash of incorrect theme on initial page load
- [x] Verified in both development and production builds


https://github.com/user-attachments/assets/a6deb7c2-13f4-44c9-8f10-3af9b6a33539

