### PR TITLE
Fix: Replace hardcoded colors with design tokens in ResetPassword

### DIFF
--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -32,13 +32,13 @@ const ResetPassword = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-950">
-      <div className="w-full max-w-md rounded-2xl bg-slate-900 p-8 shadow-xl border border-slate-800">
-        <h1 className="text-3xl font-bold text-white mb-2">
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="w-full max-w-md rounded-2xl bg-card p-8 shadow-xl border border-border">
+        <h1 className="text-3xl font-bold text-foreground mb-2">
           Reset Password
         </h1>
 
-        <p className="text-slate-400 mb-6">
+        <p className="text-muted-foreground mb-6">
           Enter your new password below.
         </p>
 
@@ -47,13 +47,13 @@ const ResetPassword = () => {
           placeholder="New Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="w-full rounded-xl border border-slate-700 bg-slate-800 text-white p-3 mb-4 outline-none"
+          className="w-full rounded-xl border border-border bg-muted text-foreground p-3 mb-4 outline-none"
         />
 
         <button
           onClick={handleReset}
           disabled={loading}
-          className="w-full rounded-xl bg-cyan-500 hover:bg-cyan-600 text-white p-3 font-semibold"
+          className="w-full rounded-xl bg-primary hover:bg-primary/90 text-foreground p-3 font-semibold"
         >
           {loading ? "Updating..." : "Update Password"}
         </button>


### PR DESCRIPTION

## Pull Request Description
Replaces all hardcoded Tailwind colour classes in `ResetPassword.tsx` with the project's semantic design tokens . This brings the page in line with the rest of the app, which already uses semantic tokens everywhere else (e.g. Auth, Settings).


## 1. Type of Change
- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactoring / Performance (non-breaking code improvements)
- [ ] Documentation Update (changes to README, guides, or comments)



## 2. Related Issue
Fixes #429

## 3. How Has This Been Tested?
- [x] Local Build: The application builds successfully locally (`npm run build`)
- [x] Lint/Format Checks: Local checks passed (`npm run lint` / `npm run format:check`)
- [x] Manual Verification: Briefly list the steps/features verified manually.
  1. Ran `npm run dev`, opened `/reset-password` locally. Confirmed the page renders identically to before in the app's default (dark) theme — no visual regressions from swapping hardcoded classes to design tokens.
  2. Searched the file for `slate`, `text-white`, and `bg-cyan` — confirmed zero matches remain after the fix.
  3. Ran `npm run lint` — 0 errors, 10 pre-existing warnings unrelated to this change (all in shared UI components, flagged for `react-refresh/only-export-components`). `ResetPassword.tsx` has zero lint warnings.
  4. Note: tested the app's theme toggle and confirmed it does not currently switch any page (including `/auth` and `/settings`) to a real light theme — this is a pre-existing, app-wide behavior unrelated to this fix, not something introduced by this PR.



## 4. Visual Verification (If applicable)
 
| Before | After |
|---|---|
| Hardcoded `slate-950`/`slate-900`/`white` classes | Semantic `background`/`card`/`foreground` tokens — visually identical in dark mode, ready to support light mode once the app-wide theming is wired up |
 
##Screenshot 1 — Proof of no leftover hardcoded classes
<img width="773" height="124" alt="Screenshot 2026-06-20 at 6 01 42 PM" src="https://github.com/user-attachments/assets/6c458456-f612-4530-b123-87227254120a" />
<img width="769" height="172" alt="Screenshot 2026-06-20 at 6 02 26 PM" src="https://github.com/user-attachments/assets/017dca27-e712-48e0-b437-0f345c484563" />
<img width="764" height="162" alt="Screenshot 2026-06-20 at 6 03 35 PM" src="https://github.com/user-attachments/assets/9c53b898-c9db-4a91-8c2b-1b50cc07872f" />
##Screenshot 2 — After 
<img width="739" height="442" alt="Screenshot 2026-06-20 at 5 59 31 PM" src="https://github.com/user-attachments/assets/0b560f17-a95d-4e6a-845a-aed2d4a338a2" />



## 5. Contributor Quality Checklist
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
 
