### PR TITLE
Fix False Positive Emergency Detection in `medicalSafety.ts`

### DIFF
--- a/supabase/functions/symptom-analyzer/medicalSafety.ts
+++ b/supabase/functions/symptom-analyzer/medicalSafety.ts
@@ -19,9 +19,11 @@ export function detectEmergencySymptoms(messages: Message[]) {
         .map((msg) => msg.content.toLowerCase())
         .join(" ");
 
-    const matchedKeywords = emergencyKeywords.filter((keyword) =>
-        combinedText.includes(keyword)
-    );
+    const matchedKeywords = emergencyKeywords.filter((keyword) => {
+        const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const pattern = new RegExp(`\\b${escaped}\\b`, "i");
+        return pattern.test(combinedText);
+    });
 
     return {
         isEmergency: matchedKeywords.length > 0,


### PR DESCRIPTION
— Substring matching caused innocent words like `"keystroke"` to trigger a stroke emergency alert, forcing the AI into high-severity mode and surfacing alarming UI to users describing routine symptoms.
 
Replaced `String.includes()` with `\bword\b` word-boundary regex so keywords only match as standalone words.
 **Severity: High** 
---
 
### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature**
- [ ] **Refactoring / Performance**
- [ ] **Documentation Update**
- [ ] **Other**
---
 
### **2. Related Issue**
- Fixes #493 
---
 
### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).

---
 
### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
---