### PR TITLE
Pin Upstash Redis Version in `_shared/redis.ts`

### DIFF
--- a/supabase/functions/_shared/redis.ts
+++ b/supabase/functions/_shared/redis.ts
@@ -1,4 +1,5 @@
-import { Redis } from "https://esm.sh/@upstash/redis";
+// FIX: Added explicit version @1.34.3 to prevent non-reproducible builds.
+import { Redis } from "https://esm.sh/@upstash/redis@1.34.3";
 
 const redisUrl = Deno.env.get("UPSTASH_REDIS_REST_URL");
 const redisToken = Deno.env.get("UPSTASH_REDIS_REST_TOKEN");


### PR DESCRIPTION
 An unpinned `@upstash/redis` import could silently resolve to a breaking version between deployments, crashing all caching and rate limiting across every edge function simultaneously with no warning.
 
**Severity: Medium** 
---
 
### **1. Type of Change**
- [ ] **Bug Fix**
- [ ] **New Feature**
- [x] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update**
- [ ] **Other**
### **2. Related Issue**
- Fixes #495 
### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**:
  1. Cleared Deno module cache and redeployed — confirmed `@upstash/redis@1.34.3` is resolved consistently across runs.
  2. Verified caching and rate limiting work correctly after the version pin — no regressions in `get-cached-data` or `invalidate-cache`.
### **4. Visual Verification (If applicable)**
N/A — backend-only change.
 
### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
---