### PR TITLE
Surface Readable Errors from Edge Functions in `cached-queries.ts`

### DIFF
--- a/src/lib/cached-queries.ts
+++ b/src/lib/cached-queries.ts
@@ -1,39 +1,65 @@
+import { FunctionsHttpError } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 
 export type CachedTable = "profiles" | "symptom_history" | "health_metrics" | "chat_sessions";
 
-/**
- * Fetches cached query results for the current user and the specified table.
- */
-export async function getCachedData<T = unknown>(table: CachedTable): Promise<{ data: T | null; error: unknown }> {
+async function extractFunctionError(error: unknown): Promise<string> {
+  if (error instanceof FunctionsHttpError) {
+    try {
+      const body = await error.context.json();
+      return body?.error ?? error.message ?? "Unknown error from edge function";
+    } catch {
+      return error.message ?? "Unknown error from edge function";
+    }
+  }
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+
+export async function getCachedData<T = unknown>(
+  table: CachedTable
+): Promise<{ data: T | null; error: string | null }> {
   try {
-    const { data, error } = await supabase.functions.invoke(
-      "get-cached-data",
-      {
-        body: { table },
-      }
-    );
-    return { data: data as T, error };
+    const { data, error } = await supabase.functions.invoke("get-cached-data", {
+      body: { table },
+    });
+
+    if (error) {
+      const message = await extractFunctionError(error);
+      console.error(`get-cached-data error for table ${table}:`, message);
+      return { data: null, error: message };
+    }
+
+    return { data: data as T, error: null };
   } catch (err) {
-    console.error(`Error invoking get-cached-data for table ${table}:`, err);
-    return { data: null, error: err };
+    const message = await extractFunctionError(err);
+    console.error(`Error invoking get-cached-data for table ${table}:`, message);
+    return { data: null, error: message };
   }
 }
 
 /**
  * Invalidates the Redis cache for the current user and the specified table.
  */
-export async function invalidateCache(table: CachedTable): Promise<{ success: boolean; error: unknown }> {
+export async function invalidateCache(
+  table: CachedTable
+): Promise<{ success: boolean; error: string | null }> {
   try {
-    const { data, error } = await supabase.functions.invoke(
-      "invalidate-cache",
-      {
-        body: { table },
-      }
-    );
-    return { success: !error && data?.success, error };
+    const { data, error } = await supabase.functions.invoke("invalidate-cache", {
+      body: { table },
+    });
+
+    if (error) {
+      const message = await extractFunctionError(error);
+      console.error(`invalidate-cache error for table ${table}:`, message);
+      return { success: false, error: message };
+    }
+
+    return { success: Boolean(data?.success), error: null };
   } catch (err) {
-    console.error(`Error invoking invalidate-cache for table ${table}:`, err);
-    return { success: false, error: err };
+    const message = await extractFunctionError(err);
+    console.error(`Error invoking invalidate-cache for table ${table}:`, message);
+    return { success: false, error: message };
   }
 }


### PR DESCRIPTION
 `getCachedData` and `invalidateCache` returned raw opaque `FunctionsHttpError` objects to all callers. Every consumer across Dashboard, History, Metrics, and Profile pages received a non-descriptive error with no actionable message, making failures completely invisible to users and developers alike.
 Severity: Medium
 
---
 
### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature**
- [ ] **Refactoring / Performance**
- [ ] **Documentation Update**
- [ ] **Other**
### **2. Related Issue**
- Fixes #496 
### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**:
  1. Called `getCachedData` while unauthenticated — confirmed the returned error string is `"Missing authorization header"` instead of an opaque object.
  2. Triggered a rate limit — confirmed callers receive `"Rate limit exceeded. Please try again later."` as a readable string.
### **4. Visual Verification (If applicable)**
N/A — backend-only change.
 
### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.