### PR TITLE
fix: move JWT auth token from localStorage to sessionStorage (#494)

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -39,7 +39,7 @@ export { supabaseUrl };
 // ─── Client ───────────────────────────────────────────────────────────────────
 export const supabase = createClient<Database>(supabaseUrl, supabasePublishableKey, {
   auth: {
-    storage: typeof window !== "undefined" ? localStorage : undefined,
+    storage: typeof window !== "undefined" ? sessionStorage : undefined,
     persistSession: true,
     autoRefreshToken: true,
   },


### PR DESCRIPTION
Closes #494

Move Supabase auth token storage from localStorage to sessionStorage to prevent JWT access tokens from persisting in plaintext after the browser is closed, reducing the attack surface for XSS-based token exfiltration.