### PR TITLE
fix: resolve memory match card flip animation

### DIFF
--- a/src/pages/Games/BrainGames.tsx
+++ b/src/pages/Games/BrainGames.tsx
@@ -1618,9 +1618,8 @@ const BrainGames = () => {
                             key={index} 
                             className="[perspective:1000px] w-full aspect-square relative"
                           >
-                            <motion.div
-                              whileHover={{ scale: 1.05 }}
-                              whileTap={{ scale: 0.95 }}
+                            <div
+                              
                               role="button"
                               tabIndex={0}
                               aria-label={`Memory card ${index + 1}`}
@@ -1644,7 +1643,7 @@ const BrainGames = () => {
                               <div className="absolute inset-0 w-full h-full [backface-visibility:hidden] [transform:rotateY(180deg)] bg-gradient-to-br from-primary to-primary-glow text-white rounded-2xl sm:rounded-3xl flex items-center justify-center text-3xl sm:text-5xl shadow-xl shadow-primary/20">
                                 <span>{["🫀", "🧠", "💊", "🏃"][card]}</span>
                               </div>
-                            </motion.div>
+                            </div>
                           </div>
                         );
                       })}


### PR DESCRIPTION
## **Pull Request Description**
This PR fixes the visual flip issue in the Memory Match game. The cards now flip correctly when clicked.

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

### **2. Related Issue**
- Fixes #513 

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
1. Opened the Brain Games page.
2. Started the Memory Match game.
3. Verified that cards visually flip when clicked.

### **4. Visual Verification **

https://github.com/user-attachments/assets/9b242721-ce36-4cbc-bdba-6432124c4606



### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
