### PR TITLE
accessibility: trap keyboard focus inside Dialog and AlertDialog over…

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -3,6 +3,7 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
 import { cn } from "@/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -28,19 +29,34 @@ AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <AlertDialogPortal>
-    <AlertDialogOverlay />
-    <AlertDialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className,
-      )}
-      {...props}
-    />
-  </AlertDialogPortal>
-));
+>(({ className, ...props }, ref) => {
+  const trapRef = useFocusTrap();
+  const mergedRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      trapRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    },
+    [ref, trapRef],
+  );
+
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        ref={mergedRef}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+});
 AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,6 +3,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
 
 const Dialog = DialogPrimitive.Root;
 
@@ -30,25 +31,40 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-accent data-[state=open]:text-muted-foreground hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
+>(({ className, children, ...props }, ref) => {
+  const trapRef = useFocusTrap();
+  const mergedRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      trapRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    },
+    [ref, trapRef],
+  );
+
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={mergedRef}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-accent data-[state=open]:text-muted-foreground hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+});
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/src/hooks/use-focus-trap.ts
+++ b/src/hooks/use-focus-trap.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from "react";
+
+export function useFocusTrap(active = true) {
+  const containerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+
+      const container = containerRef.current;
+      if (!container) return;
+
+      // Find all focusable elements inside the container
+      const focusableSelector =
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+      const allFocusable = Array.from(
+        container.querySelectorAll(focusableSelector)
+      ) as HTMLElement[];
+
+      // Filter out elements that are disabled or hidden
+      const focusableElements = allFocusable.filter((el) => {
+        const style = window.getComputedStyle(el);
+        const isVisible =
+          el.offsetWidth > 0 &&
+          el.offsetHeight > 0 &&
+          style.visibility !== "hidden" &&
+          style.display !== "none";
+        const isNotDisabled = !el.hasAttribute("disabled") && !("disabled" in el && (el as unknown as { disabled: boolean }).disabled === true);
+        return isVisible && isNotDisabled;
+      });
+
+      if (focusableElements.length === 0) {
+        e.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement as HTMLElement;
+
+      if (e.shiftKey) {
+        // Shift + Tab (Backward)
+        if (activeElement === firstElement || !focusableElements.includes(activeElement)) {
+          lastElement.focus();
+          e.preventDefault();
+        }
+      } else {
+        // Tab (Forward)
+        if (activeElement === lastElement || !focusableElements.includes(activeElement)) {
+          firstElement.focus();
+          e.preventDefault();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+
+    // Initial focus: Focus the first focusable element inside the modal on open
+    const focusTimer = setTimeout(() => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      const focusableSelector =
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+      const allFocusable = Array.from(
+        container.querySelectorAll(focusableSelector)
+      ) as HTMLElement[];
+
+      const focusableElements = allFocusable.filter((el) => {
+        const style = window.getComputedStyle(el);
+        const isVisible =
+          el.offsetWidth > 0 &&
+          el.offsetHeight > 0 &&
+          style.visibility !== "hidden" &&
+          style.display !== "none";
+        const isNotDisabled = !el.hasAttribute("disabled") && !("disabled" in el && (el as unknown as { disabled: boolean }).disabled === true);
+        return isVisible && isNotDisabled;
+      });
+
+      if (focusableElements.length > 0) {
+        if (!container.contains(document.activeElement)) {
+          focusableElements[0].focus();
+        }
+      }
+    }, 50);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+      clearTimeout(focusTimer);
+    };
+  }, [active]);
+
+  return containerRef;
+}


### PR DESCRIPTION
…lays

## **Pull Request Description**

Addresses #400. Implements keyboard focus trapping in `Dialog` and `AlertDialog` modals to satisfy accessibility (A11y) standards and WCAG overlay guidelines:
- **Custom Focus Trap Hook:** Created a lightweight, reusable `useFocusTrap` hook that dynamically queries visible, active controls and loops keyboard navigation focus bounds.
- **Component Integration:** Integrated the hook inside `DialogContent` and `AlertDialogContent` using callback refs for safe ref forwarding.
- **Improved UX:** Restricts keyboard user tab loops to active modal actions (such as "Cancel" and "Confirm") rather than escaping to background elements behind the backdrop overlay.
---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [x] **New Feature** (non-breaking change which adds functionality)
- [x] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [x] **Other** (please specify): =Accessibility, UX

---

### **2. Related Issue**
- Fixes #400 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- **Production Build:** Ran `npm run build` to confirm compilation is clean.
- **Tests:** Ran `npm test` successfully (All 63 tests passed).
- **Linter:** Ran `npm run lint` (0 errors).
- **Manual Verification:** Open any dialog (e.g. Sign Out confirmation), verify focus defaults to modal elements and loops correctly upon Tab/Shift+Tab boundaries.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
