### PR TITLE
Enhance check-in logic with daily check validation

### DIFF
--- a/src/hooks/useGamification.ts
+++ b/src/hooks/useGamification.ts
@@ -139,7 +139,7 @@ export function useCheckInChallenge() {
       if (fetchErr) throw fetchErr;
 
       const now = new Date();
-      const todayDateStr = now.toISOString().split("T")[0]; // e.g. "2026-07-03"
+      const todayDateStr = now.toISOString().split("T")[0]; 
       const todayStartISO = `${todayDateStr}T00:00:00.000Z`;
 
       const lastCheckIn = current.last_check_in ? new Date(current.last_check_in) : null;
@@ -150,8 +150,16 @@ export function useCheckInChallenge() {
         return { streak: current.current_streak, alreadyCheckedInToday: true };
       }
 
-      const isConsecutive =
-        lastCheckIn !== null && now.getTime() - lastCheckIn.getTime() < 48 * 60 * 60 * 1000;
+      const lastCheckInDateStr = lastCheckIn ? lastCheckIn.toISOString().split("T")[0] : null;
+      const daysSinceLastCheckIn = lastCheckInDateStr
+        ? Math.round(
+            (Date.parse(`${todayDateStr}T00:00:00.000Z`) -
+              Date.parse(`${lastCheckInDateStr}T00:00:00.000Z`)) /
+              (24 * 60 * 60 * 1000)
+          )
+        : null;
+
+      const isConsecutive = daysSinceLastCheckIn === 1;
       const newStreak = isConsecutive ? current.current_streak + 1 : 1;
 
       const { data: updated, error } = await supabase
@@ -169,8 +177,6 @@ export function useCheckInChallenge() {
       if (error) throw error;
 
       if (!updated) {
-        // Someone (or another tab/request) already checked in today between
-        // our read and this write — don't double-count the streak.
         return { streak: current.current_streak, alreadyCheckedInToday: true };
       }
 

--- a/src/hooks/useGamification.ts
+++ b/src/hooks/useGamification.ts
@@ -131,7 +131,6 @@ export function useCheckInChallenge() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (userChallengeId: string) => {
-      // Get current record
       const { data: current, error: fetchErr } = await supabase
         .from("user_challenges")
         .select("*")
@@ -140,29 +139,52 @@ export function useCheckInChallenge() {
       if (fetchErr) throw fetchErr;
 
       const now = new Date();
-      const lastCheckIn = current.last_check_in
-        ? new Date(current.last_check_in)
-        : null;
-      const isConsecutive =
-        lastCheckIn &&
-        now.getTime() - lastCheckIn.getTime() < 48 * 60 * 60 * 1000;
+      const todayDateStr = now.toISOString().split("T")[0]; // e.g. "2026-07-03"
+      const todayStartISO = `${todayDateStr}T00:00:00.000Z`;
 
+      const lastCheckIn = current.last_check_in ? new Date(current.last_check_in) : null;
+      const alreadyCheckedInToday =
+        lastCheckIn !== null && lastCheckIn.toISOString() >= todayStartISO;
+
+      if (alreadyCheckedInToday) {
+        return { streak: current.current_streak, alreadyCheckedInToday: true };
+      }
+
+      const isConsecutive =
+        lastCheckIn !== null && now.getTime() - lastCheckIn.getTime() < 48 * 60 * 60 * 1000;
       const newStreak = isConsecutive ? current.current_streak + 1 : 1;
 
-      const { error } = await supabase
+      const { data: updated, error } = await supabase
         .from("user_challenges")
         .update({
           current_streak: newStreak,
           last_check_in: now.toISOString(),
         })
-        .eq("id", userChallengeId);
+        .eq("id", userChallengeId)
+        // Conditional write: only apply if no check-in has happened yet today.
+        .or(`last_check_in.is.null,last_check_in.lt.${todayStartISO}`)
+        .select()
+        .maybeSingle();
+
       if (error) throw error;
-      return newStreak;
+
+      if (!updated) {
+        // Someone (or another tab/request) already checked in today between
+        // our read and this write — don't double-count the streak.
+        return { streak: current.current_streak, alreadyCheckedInToday: true };
+      }
+
+      return { streak: newStreak, alreadyCheckedInToday: false };
     },
-    onSuccess: (streak) => {
+    onSuccess: ({ streak, alreadyCheckedInToday }) => {
       qc.invalidateQueries({ queryKey: ["user_challenges"] });
-      toast.success(`Day ${streak} checked in! 🔥 Keep it up!`);
+      if (alreadyCheckedInToday) {
+        toast.info("You've already checked in for today. Come back tomorrow!");
+      } else {
+        toast.success(`Day ${streak} checked in! 🔥 Keep it up!`);
+      }
     },
+    onError: () => toast.error("Could not check in. Try again."),
   });
 }
 


### PR DESCRIPTION
## **Pull Request Description**
**File:** `src/hooks/useGamification.ts`
 
`useCheckInChallenge` only rejected a check-in if the previous one was **less than 48 hours** ago, not "already checked in today." It also did a client-side fetch-then-update across two separate requests, so it wasn't atomic. A user could call the mutation repeatedly and inflate `current_streak` multiple times in a single day.
 
---

### **1. Type of Change**
- [X ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #537 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [ X] **Local Build**: The application builds successfully locally (`npm run build`).
- [ X] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [ X] **Manual Verification**: Briefly list the steps/features verified manually.


---

### **5. Contributor Quality Checklist**
- [X ] My code follows the code style and formatting guidelines of this project.
- [ X] I have performed a self-review of my own code.
- [ X] I have commented my code, particularly in hard-to-understand areas.
- [ X] My changes generate no new warnings or console errors.
- [ X] There is no commented-out code or debug logs left in the codebase.
