### PR TITLE
Use bearer token for user authentication

### DIFF
--- a/supabase/functions/broadcast-emergency/index.ts
+++ b/supabase/functions/broadcast-emergency/index.ts
@@ -52,10 +52,15 @@ serve(async (req) => {
     );
 
     // Get the current user
+    // NOTE: auth.getUser() with no argument relies on a client-side session
+    // (e.g. set via signIn/setSession) which never exists on the server.
+    // We must explicitly pass the bearer token extracted from the request,
+    // the same way every other edge function in this project does.
+    const token = authHeader.replace("Bearer ", "");
     const {
       data: { user },
       error: userError,
-    } = await supabaseClient.auth.getUser();
+    } = await supabaseClient.auth.getUser(token);
 
     if (userError || !user) {
       return new Response(


### PR DESCRIPTION
## **Pull Request Description**
**File:** `supabase/functions/broadcast-emergency/index.ts`
 
`supabaseClient.auth.getUser()` was called with **no argument**. Passing the `Authorization` header into the client's `global.headers` only affects outgoing REST/Postgrest requests — it does **not** populate a client-side session, so `auth.getUser()` has nothing to read on the server and returns `Auth session missing`, even for a perfectly valid JWT. Every other function in this repo (`get-cached-data`, `invalidate-cache`, `delete-account`, `delete-user-account`, `symptom-analyzer`) already extracts the token and calls `auth.getUser(token)`.


---

### **1. Type of Change**
- [X ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #539 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [X] **Local Build**: The application builds successfully locally (`npm run build`).
- [X] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [X] **Manual Verification**: Briefly list the steps/features verified manually.


---

### **5. Contributor Quality Checklist**
- [X ] My code follows the code style and formatting guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings or console errors.
- [X] There is no commented-out code or debug logs left in the codebase.
