### PR TITLE
Refactor Gemini API integration for streaming response

### DIFF
--- a/supabase/functions/symptom-analyzer/index.ts
+++ b/supabase/functions/symptom-analyzer/index.ts
@@ -10,10 +10,17 @@ const ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:8080",
   "https://symptom-scribe.vercel.app",
+  "https://symptom-scribe-clean.netlify.app",
 ];
 
+const NETLIFY_PREVIEW_ORIGIN = /^https:\/\/deploy-preview-\d+--symptom-scribe-clean\.netlify\.app$/;
+
+function isAllowedOrigin(origin: string): boolean {
+  return ALLOWED_ORIGINS.includes(origin) || NETLIFY_PREVIEW_ORIGIN.test(origin);
+}
+
 const getCorsHeaders = (origin: string | null) => ({
-  "Access-Control-Allow-Origin": origin && ALLOWED_ORIGINS.includes(origin) ? origin : "null",
+  "Access-Control-Allow-Origin": origin && isAllowedOrigin(origin) ? origin : "null",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 });
 
@@ -21,7 +28,7 @@ serve(async (req: Request): Promise<Response> => {
   const origin = req.headers.get("origin");
 
   // 1. Origin allowlist check
-  if (origin && !ALLOWED_ORIGINS.includes(origin)) {
+  if (origin && !isAllowedOrigin(origin)) {
     return jsonResponse({ error: "Origin not allowed" }, 403, getCorsHeaders(origin));
   }
 
@@ -199,10 +206,45 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
     const encoder = new TextEncoder();
     const decoder = new TextDecoder();
 
+   
+    function extractTextChunks(parsed: unknown): string[] {
+      const candidate = (parsed as { candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> })
+        ?.candidates?.[0];
+      const parts = candidate?.content?.parts ?? [];
+      return parts.map((p) => p?.text).filter((t): t is string => Boolean(t));
+    }
+
     const stream = new ReadableStream({
       async start(controller) {
         const reader = geminiResponse.body!.getReader();
         let buffer = "";
+        let closed = false;
+
+        const safeClose = () => {
+          if (closed) return;
+          closed = true;
+          controller.close();
+        };
+
+        const processLine = (line: string) => {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith("data:")) return;
+
+          const jsonStr = trimmed.slice(5).trim();
+          if (!jsonStr || jsonStr === "[DONE]") return;
+
+          try {
+            const parsed = JSON.parse(jsonStr);
+            for (const chunkText of extractTextChunks(parsed)) {
+              const payload = `data: ${JSON.stringify({
+                choices: [{ delta: { content: chunkText } }],
+              })}\n\n`;
+              controller.enqueue(encoder.encode(payload));
+            }
+          } catch (parseErr) {
+            console.error("Failed to parse Gemini SSE chunk:", parseErr, jsonStr);
+          }
+        };
 
         try {
           while (true) {
@@ -213,32 +255,31 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
             const lines = buffer.split("\n");
             buffer = lines.pop() ?? "";
 
-            for (const line of lines) {
-              const trimmed = line.trim();
-              if (!trimmed.startsWith("data:")) continue;
-
-              const jsonStr = trimmed.slice(5).trim();
-              if (!jsonStr || jsonStr === "[DONE]") continue;
-
-              try {
-                const parsed = JSON.parse(jsonStr);
-                const chunkText = parsed?.candidates?.[0]?.content?.parts?.[0]?.text;
-                if (chunkText) {
-                  const payload = `data: ${JSON.stringify({
-                    choices: [{ delta: { content: chunkText } }],
-                  })}\n\n`;
-                  controller.enqueue(encoder.encode(payload));
-                }
-              } catch (parseErr) {
-                console.error("Failed to parse Gemini SSE chunk:", parseErr, jsonStr);
-              }
-            }
+            for (const line of lines) processLine(line);
           }
+
+          buffer += decoder.decode(); // flush any pending multi-byte sequence
+          if (buffer.trim()) processLine(buffer);
+
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
         } catch (streamErr) {
           console.error("Error while relaying Gemini stream:", streamErr);
-        } finally {
+          // Let the client distinguish "generation finished" from
+          // "generation broke midway" instead of only ever seeing [DONE].
+          const errorPayload = `data: ${JSON.stringify({
+            error: "Stream interrupted while generating the response.",
+          })}\n\n`;
+          controller.enqueue(encoder.encode(errorPayload));
           controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-          controller.close();
+        } finally {
+          safeClose();
+        }
+      },
+      cancel(reason) {
+        try {
+          reader.cancel(reason);
+        } catch {
+          // reader may already be closed/released — safe to ignore.
         }
       },
     });

--- a/supabase/functions/symptom-analyzer/index.ts
+++ b/supabase/functions/symptom-analyzer/index.ts
@@ -10,7 +10,6 @@ const ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:8080",
   "https://symptom-scribe.vercel.app",
-  "https://symptom-scribe-clean.netlify.app",
 ];
 
 const getCorsHeaders = (origin: string | null) => ({
@@ -154,8 +153,11 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
 
     const conversationText = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
 
+    // Use the *streaming* Gemini endpoint (alt=sse) instead of generateContent,
+    // so the client can render tokens as they arrive rather than waiting for
+    // the entire response to finish generating before seeing anything.
     const geminiResponse = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_API_KEY}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse&key=${GEMINI_API_KEY}`,
       {
         method: "POST",
         headers: {
@@ -179,8 +181,8 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
       }
     );
 
-    if (!geminiResponse.ok) {
-      const errorText = await geminiResponse.text();
+    if (!geminiResponse.ok || !geminiResponse.body) {
+      const errorText = await geminiResponse.text().catch(() => "");
 
       console.error("Gemini API error:", geminiResponse.status, errorText);
 
@@ -194,28 +196,50 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
       );
     }
 
-    const geminiData = await geminiResponse.json();
-
-    const aiText =
-      geminiData?.candidates?.[0]?.content?.parts?.[0]?.text ?? "Unable to generate analysis.";
-
     const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
 
     const stream = new ReadableStream({
-      start(controller) {
-        const payload = `data: ${JSON.stringify({
-          choices: [
-            {
-              delta: {
-                content: aiText,
-              },
-            },
-          ],
-        })}\n\n`;
+      async start(controller) {
+        const reader = geminiResponse.body!.getReader();
+        let buffer = "";
 
-        controller.enqueue(encoder.encode(payload));
-        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-        controller.close();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
+
+            for (const line of lines) {
+              const trimmed = line.trim();
+              if (!trimmed.startsWith("data:")) continue;
+
+              const jsonStr = trimmed.slice(5).trim();
+              if (!jsonStr || jsonStr === "[DONE]") continue;
+
+              try {
+                const parsed = JSON.parse(jsonStr);
+                const chunkText = parsed?.candidates?.[0]?.content?.parts?.[0]?.text;
+                if (chunkText) {
+                  const payload = `data: ${JSON.stringify({
+                    choices: [{ delta: { content: chunkText } }],
+                  })}\n\n`;
+                  controller.enqueue(encoder.encode(payload));
+                }
+              } catch (parseErr) {
+                console.error("Failed to parse Gemini SSE chunk:", parseErr, jsonStr);
+              }
+            }
+          }
+        } catch (streamErr) {
+          console.error("Error while relaying Gemini stream:", streamErr);
+        } finally {
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        }
       },
     });
 

--- a/supabase/functions/symptom-analyzer/index.ts
+++ b/supabase/functions/symptom-analyzer/index.ts
@@ -160,9 +160,6 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
 
     const conversationText = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
 
-    // Use the *streaming* Gemini endpoint (alt=sse) instead of generateContent,
-    // so the client can render tokens as they arrive rather than waiting for
-    // the entire response to finish generating before seeing anything.
     const geminiResponse = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse&key=${GEMINI_API_KEY}`,
       {
@@ -206,7 +203,6 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
     const encoder = new TextEncoder();
     const decoder = new TextDecoder();
 
-   
     function extractTextChunks(parsed: unknown): string[] {
       const candidate = (parsed as { candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> })
         ?.candidates?.[0];
@@ -214,9 +210,12 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
       return parts.map((p) => p?.text).filter((t): t is string => Boolean(t));
     }
 
+    let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
     const stream = new ReadableStream({
       async start(controller) {
-        const reader = geminiResponse.body!.getReader();
+        const localReader = geminiResponse.body!.getReader();
+        reader = localReader;
         let buffer = "";
         let closed = false;
 
@@ -248,7 +247,7 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
 
         try {
           while (true) {
-            const { done, value } = await reader.read();
+            const { done, value } = await localReader.read();
             if (done) break;
 
             buffer += decoder.decode(value, { stream: true });
@@ -264,8 +263,6 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
           controller.enqueue(encoder.encode("data: [DONE]\n\n"));
         } catch (streamErr) {
           console.error("Error while relaying Gemini stream:", streamErr);
-          // Let the client distinguish "generation finished" from
-          // "generation broke midway" instead of only ever seeing [DONE].
           const errorPayload = `data: ${JSON.stringify({
             error: "Stream interrupted while generating the response.",
           })}\n\n`;
@@ -277,7 +274,7 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
       },
       cancel(reason) {
         try {
-          reader.cancel(reason);
+          reader?.cancel(reason);
         } catch {
           // reader may already be closed/released — safe to ignore.
         }


### PR DESCRIPTION
## **Pull Request Description**
**File:** `supabase/functions/symptom-analyzer/index.ts`
 
The function set `Content-Type: text/event-stream` and framed the response as SSE, but called Gemini's non-streaming `generateContent` endpoint, awaited the **full** response, then wrapped the entire finished answer into a single `data:` event. Users saw nothing until the whole generation finished — the opposite of what an SSE endpoint implies.


---

### **1. Type of Change**
- [X ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #540 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [X] **Local Build**: The application builds successfully locally (`npm run build`).
- [X] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [X] **Manual Verification**: Briefly list the steps/features verified manually.


---

### **5. Contributor Quality Checklist**
- [X ] My code follows the code style and formatting guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings or console errors.
- [X] There is no commented-out code or debug logs left in the codebase.
