### PR TITLE
Refactor health metrics sync logic

### DIFF
--- a/src/hooks/useMetricsHistory.ts
+++ b/src/hooks/useMetricsHistory.ts
@@ -19,7 +19,7 @@ export function useMetricsHistory(userId: string | null) {
 
       if (navigator.onLine) {
         try {
-          const { data, error } = await getCachedData<OfflineMetric[]>("health_metrics");
+          const { data, cachedAt, error } = await getCachedData<OfflineMetric[]>("health_metrics");
 
           if (!error && data) {
             const localEntries = data.map((record) => ({
@@ -38,24 +38,24 @@ export function useMetricsHistory(userId: string | null) {
             );
 
             await db.healthMetrics.bulkPut(encryptedEntries);
+            if (cachedAt) {
+              const snapshotTime = new Date(cachedAt).getTime();
+              const remoteIds = new Set(data.map((record) => record.id));
 
-            const remoteIds = new Set(data.map((record) => record.id));
-            const CACHE_STALENESS_MS = 5 * 60 * 1000; // matches get-cached-data TTL
-            const staleCutoff = Date.now() - CACHE_STALENESS_MS;
+              const existingSynced = await db.healthMetrics
+                .where("user_id")
+                .equals(userId)
+                .filter((record) => record.pending_sync === 0 && record.pending_delete === 0)
+                .toArray();
 
-            const existingSynced = await db.healthMetrics
-              .where("user_id")
-              .equals(userId)
-              .filter((record) => record.pending_sync === 0 && record.pending_delete === 0)
-              .toArray();
+              const idsToRemove = existingSynced
+                .filter((record) => !remoteIds.has(record.id))
+                .filter((record) => new Date(record.recorded_at).getTime() < snapshotTime)
+                .map((record) => record.id);
 
-            const idsToRemove = existingSynced
-              .filter((record) => !remoteIds.has(record.id))
-              .filter((record) => new Date(record.recorded_at).getTime() < staleCutoff)
-              .map((record) => record.id);
-
-            if (idsToRemove.length > 0) {
-              await db.healthMetrics.bulkDelete(idsToRemove);
+              if (idsToRemove.length > 0) {
+                await db.healthMetrics.bulkDelete(idsToRemove);
+              }
             }
           }
         } catch (err) {

--- a/src/hooks/useMetricsHistory.ts
+++ b/src/hooks/useMetricsHistory.ts
@@ -22,12 +22,6 @@ export function useMetricsHistory(userId: string | null) {
           const { data, error } = await getCachedData<OfflineMetric[]>("health_metrics");
 
           if (!error && data) {
-            await db.healthMetrics
-              .where("user_id")
-              .equals(userId)
-              .filter((record) => record.pending_sync === 0 && record.pending_delete === 0)
-              .delete();
-
             const localEntries = data.map((record) => ({
               id: record.id,
               user_id: record.user_id,
@@ -44,6 +38,25 @@ export function useMetricsHistory(userId: string | null) {
             );
 
             await db.healthMetrics.bulkPut(encryptedEntries);
+
+            const remoteIds = new Set(data.map((record) => record.id));
+            const CACHE_STALENESS_MS = 5 * 60 * 1000; // matches get-cached-data TTL
+            const staleCutoff = Date.now() - CACHE_STALENESS_MS;
+
+            const existingSynced = await db.healthMetrics
+              .where("user_id")
+              .equals(userId)
+              .filter((record) => record.pending_sync === 0 && record.pending_delete === 0)
+              .toArray();
+
+            const idsToRemove = existingSynced
+              .filter((record) => !remoteIds.has(record.id))
+              .filter((record) => new Date(record.recorded_at).getTime() < staleCutoff)
+              .map((record) => record.id);
+
+            if (idsToRemove.length > 0) {
+              await db.healthMetrics.bulkDelete(idsToRemove);
+            }
           }
         } catch (err) {
           console.warn("Failed to fetch from Supabase, falling back to local DB:", err);

--- a/src/lib/cached-queries.ts
+++ b/src/lib/cached-queries.ts
@@ -19,7 +19,7 @@ async function extractFunctionError(error: unknown): Promise<string> {
 
 export async function getCachedData<T = unknown>(
   table: CachedTable
-): Promise<{ data: T | null; error: string | null }> {
+): Promise<{ data: T | null; cachedAt: string | null; error: string | null }> {
   try {
     const { data, error } = await supabase.functions.invoke("get-cached-data", {
       body: { table },
@@ -28,20 +28,25 @@ export async function getCachedData<T = unknown>(
     if (error) {
       const message = await extractFunctionError(error);
       console.error(`get-cached-data error for table ${table}:`, message);
-      return { data: null, error: message };
+      return { data: null, cachedAt: null, error: message };
     }
 
-    return { data: data as T, error: null };
+    // get-cached-data now returns { data, cachedAt } so callers can tell
+    // exactly how old a given snapshot is, instead of guessing from a
+    // duplicated TTL constant or the shape of the data itself.
+    const payload = data as { data: T; cachedAt: string } | null;
+    return {
+      data: payload?.data ?? null,
+      cachedAt: payload?.cachedAt ?? null,
+      error: null,
+    };
   } catch (err) {
     const message = await extractFunctionError(err);
     console.error(`Error invoking get-cached-data for table ${table}:`, message);
-    return { data: null, error: message };
+    return { data: null, cachedAt: null, error: message };
   }
 }
 
-/**
- * Invalidates the Redis cache for the current user and the specified table.
- */
 export async function invalidateCache(
   table: CachedTable
 ): Promise<{ success: boolean; error: string | null }> {

--- a/supabase/functions/get-cached-data/index.ts
+++ b/supabase/functions/get-cached-data/index.ts
@@ -113,6 +113,7 @@ serve(async (req) => {
 
     if (cachedData) {
       console.log(`Cache hit for ${cacheKey}`);
+      // cachedData already has the { data, cachedAt } shape written below.
       return new Response(cachedData, {
         status: 200,
         headers: {
@@ -148,9 +149,17 @@ serve(async (req) => {
       dbData = data;
     }
 
-    const jsonString = JSON.stringify(dbData);
+    const cachedAt = new Date().toISOString();
+    const responseBody = { data: dbData, cachedAt };
+    const jsonString = JSON.stringify(responseBody);
 
-    // Save to Redis Cache (TTL = 300 seconds)
+    // Save to Redis Cache (TTL = 300 seconds).
+    // We store `cachedAt` alongside the data itself so that any client
+    // reading this snapshot later (possibly minutes from now, up until the
+    // TTL expires) can tell exactly how old the snapshot is, rather than
+    // having to guess based on a duplicated TTL constant or the record's
+    // own timestamp (which says nothing about when this cache entry was
+    // generated).
     if (redis && dbData !== null) {
       try {
         await redis.set(cacheKey, jsonString, { ex: 300 });


### PR DESCRIPTION
## **Pull Request Description**
 
**File:** `src/hooks/useMetricsHistory.ts`
 
On every online fetch, the hook deleted **all** locally-synced `health_metrics` rows for the user and replaced them with whatever `get-cached-data` returned — a Redis cache entry that can be up to 5 minutes stale (see the function's `ex: 300` TTL). If a metric was added on another device/tab within that window, the stale response wouldn't contain it, and this delete-then-replace wiped the locally-synced, correct copy.


---

### **1. Type of Change**
- [X ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #541 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [X] **Local Build**: The application builds successfully locally (`npm run build`).
- [X] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [X] **Manual Verification**: Briefly list the steps/features verified manually.


---

### **5. Contributor Quality Checklist**
- [X ] My code follows the code style and formatting guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings or console errors.
- [X] There is no commented-out code or debug logs left in the codebase.
