### PR TITLE
Implement warning for fallback rate limiter

### DIFF
--- a/supabase/functions/_shared/rateLimit.ts
+++ b/supabase/functions/_shared/rateLimit.ts
@@ -9,8 +9,19 @@ const requestStore = new Map<string, RequestRecord>();
 
 const WINDOW_SIZE_MS = 60 * 1000;
 const MAX_REQUESTS = 10;
+let warnedAboutFallback = false;
 
 function memoryRateLimit(ip: string): { success: boolean } {
+  if (!warnedAboutFallback) {
+    warnedAboutFallback = true;
+    console.warn(
+      "[rateLimit] Redis is not configured or unreachable — falling back to a " +
+        "per-instance in-memory rate limiter. This does NOT enforce a global " +
+        "limit across multiple Edge Function instances. Configure " +
+        "UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN for reliable " +
+        "rate limiting in production."
+    );
+  }
   const now = Date.now();
   const existing = requestStore.get(ip);
   


### PR DESCRIPTION
## **Pull Request Description**
When Redis is unavailable, `rateLimit()` falls back to an in-memory `Map`. Edge Functions can run as multiple concurrent/regional isolates, each with its own `Map`, so the "10 req/min per IP" limit isn't actually global in that mode — and this degradation happened silently.
Added a warning for fallback to in-memory rate limiting when Redis is not configured.

---

### **1. Type of Change**
- [X] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #554 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [X] **Local Build**: The application builds successfully locally (`npm run build`).
- [X] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).

---

### **5. Contributor Quality Checklist**
- [X] My code follows the code style and formatting guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings or console errors.
- [X] There is no commented-out code or debug logs left in the codebase.
