### PR TITLE
feat: add Color Sequence Memory game to Brain Games section

### DIFF
--- a/src/pages/Games/BrainGames.tsx
+++ b/src/pages/Games/BrainGames.tsx
@@ -29,6 +29,7 @@ import {
   Palette,
   Calculator,
   Gauge,
+  LayoutGrid,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
@@ -137,6 +138,16 @@ const games = [
     iconColor: "text-amber-500",
     gradient: "from-amber-500 to-yellow-500",
     shadow: "shadow-amber-500/20",
+  },
+  {
+    id: "colorseq",
+    name: "Color Sequence Memory",
+    icon: LayoutGrid,
+    description: "Watch the tiles light up, then tap them back in the exact same order",
+    color: "from-fuchsia-500/20 to-purple-500/20",
+    iconColor: "text-fuchsia-500",
+    gradient: "from-fuchsia-500 to-purple-500",
+    shadow: "shadow-fuchsia-500/20",
   },
 ];
 
@@ -675,6 +686,149 @@ const ReactionGame = ({ onExit, onXp, onCelebrate }: MiniGameProps) => {
         >
           {zone.label}
         </button>
+      </div>
+    </GameShell>
+  );
+};
+
+// ── Color Sequence Memory ───────────────────────────────────────────────────
+const COLOR_TILES = [
+  { name: "Rose", base: "bg-rose-700", active: "bg-rose-300" },
+  { name: "Amber", base: "bg-amber-600", active: "bg-amber-200" },
+  { name: "Emerald", base: "bg-emerald-700", active: "bg-emerald-300" },
+  { name: "Sky", base: "bg-sky-700", active: "bg-sky-300" },
+  { name: "Violet", base: "bg-violet-700", active: "bg-violet-300" },
+  { name: "Fuchsia", base: "bg-fuchsia-700", active: "bg-fuchsia-300" },
+  { name: "Teal", base: "bg-teal-700", active: "bg-teal-300" },
+  { name: "Orange", base: "bg-orange-700", active: "bg-orange-300" },
+  { name: "Indigo", base: "bg-indigo-700", active: "bg-indigo-300" },
+];
+const COLOR_SEQ_START_LENGTH = 3;
+const COLOR_SEQ_FLASH_MS = 550;
+
+const ColorSequenceGame = ({ onExit, onXp, onCelebrate }: MiniGameProps) => {
+  const [sequence, setSequence] = useState<number[]>([]);
+  const [userTaps, setUserTaps] = useState<number[]>([]);
+  const [status, setStatus] = useState<"idle" | "showing" | "recall" | "over">("idle");
+  const [activeTile, setActiveTile] = useState<number | null>(null);
+  const [round, setRound] = useState(0);
+  const [best, setBest] = useState(0);
+  const [message, setMessage] = useState("Press Start, then watch the tiles closely.");
+  const timers = useRef<number[]>([]);
+
+  const clearTimers = () => {
+    timers.current.forEach((t) => window.clearTimeout(t));
+    timers.current = [];
+  };
+  useEffect(() => () => clearTimers(), []);
+
+  const flashSequence = (seq: number[]) => {
+    setStatus("showing");
+    setUserTaps([]);
+    setMessage("Watch the sequence…");
+    clearTimers();
+    seq.forEach((tile, i) => {
+      timers.current.push(
+        window.setTimeout(() => setActiveTile(tile), COLOR_SEQ_FLASH_MS * i + 300),
+      );
+      timers.current.push(
+        window.setTimeout(() => setActiveTile(null), COLOR_SEQ_FLASH_MS * i + COLOR_SEQ_FLASH_MS - 100),
+      );
+    });
+    timers.current.push(
+      window.setTimeout(() => {
+        setStatus("recall");
+        setMessage("Now tap the tiles in the same order.");
+      }, COLOR_SEQ_FLASH_MS * seq.length + 300),
+    );
+  };
+
+  const startGame = () => {
+    const first = Array.from({ length: COLOR_SEQ_START_LENGTH }, () =>
+      Math.floor(Math.random() * COLOR_TILES.length),
+    );
+    setRound(1);
+    setSequence(first);
+    flashSequence(first);
+  };
+
+  const handleTileTap = (tile: number) => {
+    if (status !== "recall") return;
+    setActiveTile(tile);
+    window.setTimeout(() => setActiveTile(null), 200);
+
+    const expected = sequence[userTaps.length];
+    if (tile !== expected) {
+      setStatus("over");
+      setMessage(`Not quite! You reached round ${round} (sequence of ${sequence.length}).`);
+      if (round >= 5) onCelebrate();
+      return;
+    }
+
+    const nextTaps = [...userTaps, tile];
+    setUserTaps(nextTaps);
+
+    if (nextTaps.length === sequence.length) {
+      onXp(6);
+      setBest((b) => Math.max(b, round));
+      setMessage(`Correct! Round ${round} cleared.`);
+      setStatus("showing");
+      timers.current.push(
+        window.setTimeout(() => {
+          const next = [...sequence, Math.floor(Math.random() * COLOR_TILES.length)];
+          setRound((r) => r + 1);
+          setSequence(next);
+          flashSequence(next);
+        }, 900),
+      );
+    }
+  };
+
+  return (
+    <GameShell
+      title="Color Sequence Memory"
+      subtitle="Watch the tiles light up, then recall the exact order"
+      onExit={onExit}
+    >
+      <div className="flex flex-col items-center gap-6">
+        <div className="flex items-center gap-6 text-sm font-semibold" aria-live="polite">
+          <span>
+            Round: <span className="text-primary">{round}</span>
+          </span>
+          <span>
+            Best: <span className="text-primary">{best}</span>
+          </span>
+        </div>
+        <p aria-live="polite" className="text-center text-muted-foreground min-h-[1.5rem]">
+          {message}
+        </p>
+        <div className="grid grid-cols-3 gap-3 sm:gap-4 w-full max-w-sm">
+          {COLOR_TILES.map((tile, i) => (
+            <button
+              key={tile.name}
+              type="button"
+              onClick={() => handleTileTap(i)}
+              disabled={status !== "recall"}
+              aria-label={`${tile.name} tile`}
+              onKeyDown={(e) => {
+                if ((e.key === "Enter" || e.key === " ") && status === "recall") {
+                  e.preventDefault();
+                  handleTileTap(i);
+                }
+              }}
+              className={`aspect-square rounded-2xl border-2 border-border/40 font-semibold text-white text-xs sm:text-sm flex items-center justify-center transition-all duration-150 disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary ${
+                activeTile === i ? `${tile.active} scale-105 ring-4 ring-white/60` : tile.base
+              }`}
+            >
+              <span className="drop-shadow sr-only sm:not-sr-only">{tile.name}</span>
+            </button>
+          ))}
+        </div>
+        {(status === "idle" || status === "over") && (
+          <Button onClick={startGame} className="rounded-2xl gap-2">
+            <RefreshCw className="w-4 h-4" /> {status === "over" ? "Play Again" : "Start"}
+          </Button>
+        )}
       </div>
     </GameShell>
   );
@@ -2570,6 +2724,12 @@ const BrainGames = () => {
               />
             ) : activeGame === "reaction" ? (
               <ReactionGame
+                onExit={() => setActiveGame(null)}
+                onXp={awardXp}
+                onCelebrate={triggerConfetti}
+              />
+            ) : activeGame === "colorseq" ? (
+              <ColorSequenceGame
                 onExit={() => setActiveGame(null)}
                 onXp={awardXp}
                 onCelebrate={triggerConfetti}


### PR DESCRIPTION
## Pull Request Description
Adds a new **Color Sequence Memory** game to the Brain Games section, expanding the collection of cognitive training games as outlined in the parent issue. The game targets visual perception and short-term memory: a 3x3 grid of color tiles flashes a sequence, and the user must recall and tap the tiles back in the exact same order. Sequence length grows each round, tracking current round and best score.

---

### 1. Type of Change
- [x] **New Feature** (non-breaking change which adds functionality)

---

### 2. Related Issue
Related to #568 (Expanding Brain Games Collection)

---

### 3. How Has This Been Tested?
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Manual Verification**: Verified the following steps/features manually:
  1. Played multiple rounds of Color Sequence Memory to confirm sequence generation, recall matching, round/best score tracking, and XP awarding on success.
  2. Verified incorrect tile taps correctly end the game and display the round reached.
  3. Verified keyboard navigation (Tab to focus tiles, Enter/Space to select) works without a mouse.
  4. Verified `aria-label` and `aria-live` announcements for screen reader users (tile names, status messages).
  5. Verified responsive layout on smaller screen widths (grid reflows correctly).
  6. Verified visual appearance and contrast in both light mode and dark mode.

---

### 4. Visual Verification (If applicable)
| Before | After |
| :--- | :--- |
| (No Color Sequence Memory game existed) | 
<img width="1506" height="730" alt="WhatsApp Image 2026-07-10 at 16 52 16" src="https://github.com/user-attachments/assets/1ac17d32-10d2-44eb-bd0b-56ec7d61cef7" />
<img width="1600" height="717" alt="WhatsApp Image 2026-07-10 at 16 52 34" src="https://github.com/user-attachments/assets/005c7e2d-2527-4860-91cc-32ba46cdbbba" />
|

---

### 5. Contributor Quality Checklist
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.