### PR TITLE
Feat/issue 597 offline fallback

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -6,7 +6,7 @@ import ChatMessage from "./ChatMessage";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { browserEnv } from "@/lib/env";
-import { showSuccess, showError, showInfo, showLoading } from "@/lib/toast-helpers";
+import { showSuccess, showError, showInfo, showLoading, showWarning } from "@/lib/toast-helpers";
 import { invalidateCache } from "@/lib/cached-queries";
 import { whenKeysReady } from "@/lib/encryption";
 import { encryptSymptom, db, type OfflineSymptom } from "@/lib/offline-db";
@@ -338,8 +338,20 @@ const ChatInterface = () => {
             .insert(supabaseRecord);
 
           if (insertError) {
-            console.error("Error saving symptom history:", insertError);
-            showError("Save failed", "Could not save to your health history");
+            console.warn("Supabase save failed, falling back to local saving:", insertError);
+            
+            // Save locally to Dexie immediately with pending_sync: 1
+            await db.symptomHistory.put({
+              ...encryptedRecord,
+              pending_sync: 1,
+              pending_update: 0,
+              pending_delete: 0,
+            });
+
+            showWarning(
+              "Saved Offline",
+              "Could not connect to server. Saved locally and will sync once connection is restored."
+            );
           } else {
             await invalidateCache("symptom_history");
 

--- a/src/pages/Health/AIHealthAssistant.tsx
+++ b/src/pages/Health/AIHealthAssistant.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
-import { showSuccess, showError, showInfo, showLoading } from "@/lib/toast-helpers";
+import { showSuccess, showError, showInfo, showLoading, showWarning } from "@/lib/toast-helpers";
 import { browserEnv } from "@/lib/env";
 import { invalidateCache } from "@/lib/cached-queries";
 import { whenKeysReady } from "@/lib/encryption";
@@ -332,8 +332,20 @@ const AIHealthAssistant = () => {
               .insert(supabaseRecord);
 
             if (insertError) {
-              console.error("Error saving symptom history:", insertError);
-              showError("Save failed", "Could not save to your health history");
+              console.warn("Supabase save failed, falling back to local saving:", insertError);
+              
+              // Save locally to Dexie immediately with pending_sync: 1
+              await db.symptomHistory.put({
+                ...encryptedRecord,
+                pending_sync: 1,
+                pending_update: 0,
+                pending_delete: 0,
+              });
+
+              showWarning(
+                "Saved Offline",
+                "Could not connect to server. Saved locally and will sync once connection is restored."
+              );
             } else {
               await invalidateCache("symptom_history");
 

--- a/src/pages/Metrics/index.tsx
+++ b/src/pages/Metrics/index.tsx
@@ -29,7 +29,7 @@ import {
   ArrowUpDown,
 } from "lucide-react";
 import type { Json } from "@/integrations/supabase/types";
-import { showSuccess, showError } from "@/lib/toast-helpers";
+import { showSuccess, showError, showWarning, showInfo } from "@/lib/toast-helpers";
 import { useMetricsHistory } from "@/hooks/useMetricsHistory";
 import { db, syncOfflineData, type OfflineMetric, encryptMetric } from "@/lib/offline-db";
 import { whenKeysReady } from "@/lib/encryption";
@@ -316,17 +316,30 @@ const Metrics = () => {
 
       if (navigator.onLine) {
         const { pending_sync, pending_delete, ...supabaseData } = encryptedRecord;
-        const { error } = await supabase.from("health_metrics").insert(supabaseData);
+        try {
+          const { error } = await supabase.from("health_metrics").insert(supabaseData);
+          if (error) throw error;
 
-        if (error) throw error;
+          await invalidateCache("health_metrics");
+          await db.healthMetrics.put(encryptedRecord);
 
-        await invalidateCache("health_metrics");
-        await db.healthMetrics.put(encryptedRecord);
+          showSuccess(
+            `${metricLabel} Recorded`,
+            "Your health metric has been saved successfully.",
+          );
+        } catch (supabaseError) {
+          console.warn("Supabase insert failed, falling back to local saving:", supabaseError);
+          const fallbackRecord = {
+            ...encryptedRecord,
+            pending_sync: 1,
+          };
+          await db.healthMetrics.put(fallbackRecord);
 
-        showSuccess(
-          `${metricLabel} Recorded`,
-          "Your health metric has been saved successfully.",
-        );
+          showWarning(
+            `${metricLabel} Saved Offline`,
+            "Could not connect to server. Saved locally and will sync once connection is restored."
+          );
+        }
       } else {
         await db.healthMetrics.put(encryptedRecord);
 


### PR DESCRIPTION
## **Pull Request Description**
A clear and concise description of the changes introduced by this pull request.

Implements a self-healing offline fallback mechanism to improve database resilience when the user is online but the remote Supabase server is unreachable, misconfigured, or experiencing downtime. 
## 🛠️ Proposed Changes
- **Health Metrics page (`src/pages/Metrics/index.tsx`)**: Wrapped Supabase `insert` calls in try-catch structures. Failed queries fall back to saving locally in Dexie (`db.healthMetrics`) with `pending_sync: 1`.
- **AI Health Assistant (`src/pages/Health/AIHealthAssistant.tsx`)**: Catches Supabase connection and insertion failures, caching symptom analyses in local storage/Dexie with a warning toast.
- **Chat Interface (`src/components/chat/ChatInterface.tsx`)**: Implements similar offline preservation checks when saving logs.

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [x] **New Feature** (non-breaking change which adds functionality)
- [x] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #597 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- `npm run build` compiled successfully.
- `npm test` completed with 63/63 passing unit tests.
- `npm run lint` completed with 0 errors.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
