### PR TITLE
fix: add ARIA attributes for screen reader accessibility in chat 

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -435,6 +435,7 @@ const ChatInterface = () => {
                         : "text-muted-foreground hover:text-destructive"
                     }`}
                     title="Delete Session"
+                    aria-label={`Delete session: ${session.title || "Untitled Session"}`}
                   >
                     <Trash2 className="w-3.5 h-3.5" />
                   </button>
@@ -474,7 +475,7 @@ const ChatInterface = () => {
             onClick={handleNewChat}
             className="w-full flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-primary to-primary-glow font-semibold"
           >
-            <Plus className="w-4 h-4" />
+            <Plus className="w-4 h-4" aria-hidden="true" />
             New Chat
           </Button>
         </div>
@@ -493,7 +494,7 @@ const ChatInterface = () => {
           <div className="flex items-center gap-2">
             <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
               <SheetTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-9 w-9">
+                <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="Open chat history menu">
                   <Menu className="w-5 h-5" />
                 </Button>
               </SheetTrigger>
@@ -509,7 +510,7 @@ const ChatInterface = () => {
                     onClick={handleNewChat}
                     className="w-full flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-primary to-primary-glow font-semibold"
                   >
-                    <Plus className="w-4 h-4" />
+                    <Plus className="w-4 h-4" aria-hidden="true" />
                     New Chat
                   </Button>
                 </div>
@@ -530,13 +531,18 @@ const ChatInterface = () => {
             onClick={handleNewChat}
             className="text-xs flex items-center gap-1"
           >
-            <Plus className="w-3.5 h-3.5" />
+            <Plus className="w-3.5 h-3.5" aria-hidden="true" />
             New
           </Button>
         </header>
 
         {/* Message Panel */}
-        <div className="flex-1 min-h-0 overflow-y-auto space-y-4 p-4">
+        <div
+          className="flex-1 min-h-0 overflow-y-auto space-y-4 p-4"
+          role="log"
+          aria-live="polite"
+          aria-label="Chat conversation with AI health assistant"
+        >
           {messages.map((message, index) => (
             <ChatMessage key={index} role={message.role} content={message.content} />
           ))}
@@ -554,6 +560,7 @@ const ChatInterface = () => {
                 onChange={(e) => setInput(e.target.value.slice(0, MAX_CHARS))}
                 onKeyDown={handleKeyPress}
                 placeholder="Describe your symptoms... (e.g., 'I have a sore throat and headache')"
+                aria-label="Describe your symptoms to the AI health assistant"
                 className="min-h-[60px] max-h-[120px] resize-none rounded-xl"
                 disabled={isLoading}
               />
@@ -586,6 +593,7 @@ const ChatInterface = () => {
               disabled={!input.trim() || isLoading}
               size="icon"
               className="h-[60px] w-[60px] flex-shrink-0 rounded-xl"
+              aria-label={isLoading ? "Sending message" : "Send message"}
             >
               {isLoading ? (
                 <Loader2 className="w-5 h-5 animate-spin" />

--- a/src/components/chat/ChatLoading.tsx
+++ b/src/components/chat/ChatLoading.tsx
@@ -2,7 +2,7 @@ import { Loader2 } from "lucide-react";
 
 const ChatLoading = () => {
   return (
-    <div className="flex gap-3">
+    <div className="flex gap-3" role="status" aria-label="AI is typing a response">
       <div className="flex-shrink-0 w-8 h-8 rounded-full bg-gradient-to-br from-primary to-primary-glow flex items-center justify-center animate-pulse">
         <Loader2 className="w-5 h-5 text-primary-foreground animate-spin" />
       </div>
@@ -22,6 +22,7 @@ const ChatLoading = () => {
             style={{ animationDelay: "300ms" }}
           />
         </div>
+        <span className="sr-only">AI is typing…</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## **Pull Request Description**
Adds ARIA accessibility support to the AI Health Assistant chat interface so screen reader users (NVDA, VoiceOver, JAWS) can use the core chat feature. Adds a live region for incoming AI messages, `role="status"` on the typing indicator, and `aria-label`s on the message input, send button, and other icon-only controls.

---
### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---
### **2. Related Issue**
Fixes #577

---
### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Verified the chat UI renders and functions identically to before (no visual changes)  sent messages, received AI responses, opened/closed chat history sidebar.
  2. Tested with Windows Narrator: confirmed the textarea announces "Describe your symptoms to the AI health assistant," the send button announces "Send message," new AI messages in the chat log are announced as they arrive, and the typing indicator announces "AI is typing a response."

---
### **4. Visual Verification (If applicable)**
No visual/layout changes all changes are ARIA attributes (`role`, `aria-label`, `aria-live`, `aria-hidden`), which are invisible to sighted users. Screenshots not applicable.

---
### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.