### PR TITLE
feat: add optional TOTP two-factor authentication 

### DIFF
--- a/src/components/settings/TwoFactorAuth.tsx
+++ b/src/components/settings/TwoFactorAuth.tsx
@@ -1,0 +1,187 @@
+import { useState, useEffect } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp";
+import { Loader2, ShieldCheck, ShieldOff, Smartphone } from "lucide-react";
+import { showSuccess, showError } from "@/lib/toast-helpers";
+
+type Factor = {
+  id: string;
+  factor_type: string;
+  status: string;
+};
+
+const TwoFactorAuth = () => {
+  const [loading, setLoading] = useState(true);
+  const [factors, setFactors] = useState<Factor[]>([]);
+  const [enrolling, setEnrolling] = useState(false);
+  const [qrCode, setQrCode] = useState("");
+  const [secret, setSecret] = useState("");
+  const [factorId, setFactorId] = useState("");
+  const [verifyCode, setVerifyCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const verifiedFactor = factors.find((f) => f.status === "verified");
+
+  const loadFactors = async () => {
+    setLoading(true);
+    const { data, error } = await supabase.auth.mfa.listFactors();
+    if (error) {
+      showError("Error", "Could not load 2FA status");
+    } else {
+      setFactors(data?.totp ?? []);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    loadFactors();
+  }, []);
+
+  const startEnrollment = async () => {
+    setSubmitting(true);
+    const { data, error } = await supabase.auth.mfa.enroll({ factorType: "totp" });
+    if (error) {
+      showError("Enrollment Failed", error.message);
+    } else if (data) {
+      setFactorId(data.id);
+      setQrCode(data.totp.qr_code);
+      setSecret(data.totp.secret);
+      setEnrolling(true);
+    }
+    setSubmitting(false);
+  };
+
+  const confirmEnrollment = async () => {
+    if (verifyCode.length !== 6) {
+      showError("Invalid Code", "Enter the 6-digit code from your authenticator app");
+      return;
+    }
+    setSubmitting(true);
+    const { data: challengeData, error: challengeError } = await supabase.auth.mfa.challenge({
+      factorId,
+    });
+    if (challengeError) {
+      showError("Verification Failed", challengeError.message);
+      setSubmitting(false);
+      return;
+    }
+    const { error: verifyError } = await supabase.auth.mfa.verify({
+      factorId,
+      challengeId: challengeData.id,
+      code: verifyCode,
+    });
+    if (verifyError) {
+      showError("Incorrect Code", "The code you entered is incorrect or expired");
+    } else {
+      showSuccess("2FA Enabled", "Two-factor authentication is now active on your account");
+      setEnrolling(false);
+      setVerifyCode("");
+      await loadFactors();
+    }
+    setSubmitting(false);
+  };
+
+  const disable2FA = async () => {
+    if (!verifiedFactor) return;
+    setSubmitting(true);
+    const { error } = await supabase.auth.mfa.unenroll({ factorId: verifiedFactor.id });
+    if (error) {
+      showError("Error", "Could not disable 2FA");
+    } else {
+      showSuccess("2FA Disabled", "Two-factor authentication has been turned off");
+      await loadFactors();
+    }
+    setSubmitting(false);
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="py-10 flex justify-center">
+          <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Two-Factor Authentication</CardTitle>
+        <CardDescription>
+          Add an extra layer of security by requiring a code from an authenticator app when you sign in.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {verifiedFactor ? (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2 text-green-600 dark:text-green-400">
+              <ShieldCheck className="w-5 h-5" />
+              <span className="font-medium">2FA is enabled on your account</span>
+            </div>
+            <Button variant="destructive" onClick={disable2FA} disabled={submitting}>
+              {submitting ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <ShieldOff className="mr-2 h-4 w-4" />
+              )}
+              Disable 2FA
+            </Button>
+          </div>
+        ) : enrolling ? (
+          <div className="space-y-4">
+            <div className="flex flex-col items-center gap-3 text-center">
+              <Smartphone className="w-8 h-8 text-teal-600" />
+              <p className="text-sm text-muted-foreground">
+                Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.)
+              </p>
+              {qrCode && (
+                <img src={qrCode} alt="2FA QR Code" className="w-48 h-48 border rounded-lg" />
+              )}
+              <p className="text-xs text-muted-foreground">
+                Or enter this code manually: <code className="font-mono">{secret}</code>
+              </p>
+            </div>
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-center">Enter the 6-digit code to confirm</p>
+              <div className="flex justify-center">
+                <InputOTP maxLength={6} value={verifyCode} onChange={setVerifyCode}>
+                  <InputOTPGroup>
+                    <InputOTPSlot index={0} />
+                    <InputOTPSlot index={1} />
+                    <InputOTPSlot index={2} />
+                    <InputOTPSlot index={3} />
+                    <InputOTPSlot index={4} />
+                    <InputOTPSlot index={5} />
+                  </InputOTPGroup>
+                </InputOTP>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" className="flex-1" onClick={() => setEnrolling(false)}>
+                Cancel
+              </Button>
+              <Button className="flex-1" onClick={confirmEnrollment} disabled={submitting}>
+                {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Verify & Enable
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button onClick={startEnrollment} disabled={submitting}>
+            {submitting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <ShieldCheck className="mr-2 h-4 w-4" />
+            )}
+            Enable 2FA
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TwoFactorAuth;

--- a/src/pages/Auth.test.tsx
+++ b/src/pages/Auth.test.tsx
@@ -63,6 +63,16 @@ vi.mock("@/integrations/supabase/client", () => ({
         authStateChangeHolder.current = callback;
         return { data: { subscription: { unsubscribe: vi.fn() } } };
       }),
+      mfa: {
+        getAuthenticatorAssuranceLevel: vi.fn().mockResolvedValue({
+          data: { currentLevel: "aal1", nextLevel: "aal1" },
+          error: null,
+        }),
+        listFactors: vi.fn().mockResolvedValue({
+          data: { totp: [] },
+          error: null,
+        }),
+      },
     },
   },
 }));
@@ -302,13 +312,15 @@ describe("Auth", () => {
   });
 
   // 11. Redirects to /dashboard when a session already exists on mount
-  it("redirects to /dashboard when onAuthStateChange reports an existing session", () => {
+  it("redirects to /dashboard when onAuthStateChange reports an existing session", async () => {
     render(<Auth />);
 
     expect(authStateChangeHolder.current).toBeDefined();
     authStateChangeHolder.current?.("SIGNED_IN", { user: { id: "user-1" } });
 
-    expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
+    });
   });
 
   // 12. Redirects to /reset-password when the URL signals a recovery flow

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -31,6 +31,7 @@ import { showSuccess, showError } from "@/lib/toast-helpers";
 import { setupKeysFromPassword } from "@/lib/encryption";
 
 import MultiStepSignUp from "@/components/registration/forms/MultiStepSignUp";
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp";
 
 const emailSchema = z.string().email("Invalid email address");
 const signinPasswordSchema = z.string().min(1, "Password is required");
@@ -43,6 +44,11 @@ const Auth = () => {
   const [redirecting, setRedirecting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [authTab, setAuthTab] = useState("signin");
+
+  const [mfaRequired, setMfaRequired] = useState(false);
+  const [mfaFactorId, setMfaFactorId] = useState("");
+  const [mfaCode, setMfaCode] = useState("");
+  const [mfaSubmitting, setMfaSubmitting] = useState(false);
 
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -57,7 +63,7 @@ const Auth = () => {
   useEffect(() => {
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange(async (_event, session) => {
       if (session &&
         window.location.href.includes("type=recovery")
       ) {
@@ -66,7 +72,12 @@ const Auth = () => {
       }
 
       if (session) {
-      navigate("/dashboard");
+        const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        if (aalData && aalData.nextLevel === "aal2" && aalData.currentLevel !== aalData.nextLevel) {
+          // 2FA verification still pending — don't navigate yet
+          return;
+        }
+        navigate("/dashboard");
       }
    });
 
@@ -111,6 +122,19 @@ const Auth = () => {
       showError("Sign In Failed", error.message);
       setLoading(false);
     } else {
+      const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+
+      if (aalData && aalData.nextLevel === "aal2" && aalData.currentLevel !== aalData.nextLevel) {
+        const { data: factorsData } = await supabase.auth.mfa.listFactors();
+        const totpFactor = factorsData?.totp?.[0];
+        if (totpFactor) {
+          setMfaFactorId(totpFactor.id);
+          setMfaRequired(true);
+        }
+        setLoading(false);
+        return;
+      }
+
       if (signInData?.user) {
         try {
           await setupKeysFromPassword(signInPassword, signInEmail, signInData.user.id);
@@ -121,6 +145,48 @@ const Auth = () => {
       setLoading(false);
       setRedirecting(true);
     }
+  };
+
+  const handleMfaVerify = async () => {
+    if (mfaCode.length !== 6) {
+      showError("Invalid Code", "Enter the 6-digit code from your authenticator app");
+      return;
+    }
+    setMfaSubmitting(true);
+
+    const { data: challengeData, error: challengeError } = await supabase.auth.mfa.challenge({
+      factorId: mfaFactorId,
+    });
+
+    if (challengeError) {
+      showError("Verification Failed", challengeError.message);
+      setMfaSubmitting(false);
+      return;
+    }
+
+    const { error: verifyError } = await supabase.auth.mfa.verify({
+      factorId: mfaFactorId,
+      challengeId: challengeData.id,
+      code: mfaCode,
+    });
+
+    if (verifyError) {
+      showError("Incorrect Code", "The code you entered is incorrect or expired");
+      setMfaSubmitting(false);
+      return;
+    }
+
+    try {
+      const { data: userRes } = await supabase.auth.getUser();
+      if (userRes?.user) {
+        await setupKeysFromPassword(signInPassword, signInEmail, userRes.user.id);
+      }
+    } catch (deriveErr) {
+      console.error("Error setting up encryption keys:", deriveErr);
+    }
+
+    setMfaSubmitting(false);
+    setRedirecting(true);
   };
 
 const handleForgotPassword= async () => {
@@ -231,6 +297,61 @@ const handleForgotPassword= async () => {
               </TabsList>
 
               <TabsContent value="signin">
+                {mfaRequired ? (
+                  <div className="space-y-5">
+                    <div className="flex flex-col items-center gap-2 text-center">
+                      <ShieldCheck className="h-8 w-8 text-cyan-300" />
+                      <p className="text-sm text-slate-200">
+                        Enter the 6-digit code from your authenticator app
+                      </p>
+                    </div>
+                    <div className="flex justify-center">
+                      <InputOTP maxLength={6} value={mfaCode} onChange={setMfaCode}>
+                        <InputOTPGroup>
+                          <InputOTPSlot index={0} />
+                          <InputOTPSlot index={1} />
+                          <InputOTPSlot index={2} />
+                          <InputOTPSlot index={3} />
+                          <InputOTPSlot index={4} />
+                          <InputOTPSlot index={5} />
+                        </InputOTPGroup>
+                      </InputOTP>
+                    </div>
+                    <div className="flex gap-3">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="flex-1 rounded-2xl border-white/10 bg-transparent text-slate-200 hover:bg-white/10"
+                        onClick={() => {
+                          setMfaRequired(false);
+                          setMfaCode("");
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        type="button"
+                        onClick={handleMfaVerify}
+                        disabled={mfaSubmitting || redirecting}
+                        className={`flex-1 ${actionButtonClass}`}
+                      >
+                        {redirecting ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Redirecting...
+                          </>
+                        ) : mfaSubmitting ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Verifying...
+                          </>
+                        ) : (
+                          "Verify"
+                        )}
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
                 <form onSubmit={handleSignIn} className="space-y-5">
                   <div className="space-y-2">
                     <Label htmlFor="signin-email" className="text-sm font-medium text-slate-100">
@@ -309,6 +430,7 @@ const handleForgotPassword= async () => {
                     )}
                   </Button>
                 </form>
+                )}
               </TabsContent>
 
               <TabsContent value="signup">

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -72,7 +72,7 @@ const Auth = () => {
       }
 
       if (session) {
-        const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        const { data: aalData } = (await supabase.auth.mfa?.getAuthenticatorAssuranceLevel()) ?? { data: null };
         if (aalData && aalData.nextLevel === "aal2" && aalData.currentLevel !== aalData.nextLevel) {
           // 2FA verification still pending — don't navigate yet
           return;
@@ -122,7 +122,7 @@ const Auth = () => {
       showError("Sign In Failed", error.message);
       setLoading(false);
     } else {
-      const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+      const { data: aalData } = (await supabase.auth.mfa?.getAuthenticatorAssuranceLevel()) ?? { data: null };
 
       if (aalData && aalData.nextLevel === "aal2" && aalData.currentLevel !== aalData.nextLevel) {
         const { data: factorsData } = await supabase.auth.mfa.listFactors();

--- a/src/pages/User/Settings.tsx
+++ b/src/pages/User/Settings.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
-import { Lock, Trash2, Loader2, AlertTriangle } from "lucide-react";
+import { Lock, Trash2, Loader2, AlertTriangle, ShieldCheck } from "lucide-react";
 import { PasswordStrengthMeter } from "@/components/registration/shared/PasswordStrengthMeter";
 import { DEFAULT_PASSWORD_POLICY, evaluatePasswordStrength } from "@/lib/password-strength";
 import { showSuccess, showError } from "@/lib/toast-helpers";
@@ -19,6 +19,7 @@ import {
   setupKeysFromPassword,
   triggerKeyRotation,
 } from "@/lib/encryption";
+import TwoFactorAuth from "@/components/settings/TwoFactorAuth";
 
 const Settings = () => {
   const navigate = useNavigate();
@@ -213,11 +214,16 @@ const Settings = () => {
       </div>
 
       <Tabs defaultValue="password" className="w-full">
-        <TabsList className="grid w-full grid-cols-2">
+        <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="password" className="flex items-center gap-2">
             <Lock className="w-4 h-4" />
             <span className="hidden sm:inline">Change Password</span>
             <span className="sm:hidden">Password</span>
+          </TabsTrigger>
+          <TabsTrigger value="2fa" className="flex items-center gap-2">
+            <ShieldCheck className="w-4 h-4" />
+            <span className="hidden sm:inline">Two-Factor Auth</span>
+            <span className="sm:hidden">2FA</span>
           </TabsTrigger>
           <TabsTrigger value="delete" className="flex items-center gap-2">
             <Trash2 className="w-4 h-4" />
@@ -299,6 +305,11 @@ const Settings = () => {
               </form>
             </CardContent>
           </Card>
+        </TabsContent>
+
+        {/* Two-Factor Auth Tab */}
+        <TabsContent value="2fa">
+          <TwoFactorAuth />
         </TabsContent>
 
         {/* Delete Account Tab */}


### PR DESCRIPTION
## **Pull Request Description**
Adds optional TOTP-based two-factor authentication using Supabase Auth's built-in MFA support. Users can enable/disable 2FA from Settings, and are prompted for a verification code at login when enabled.

---
### **1. Type of Change**
- [x] **New Feature** (non-breaking change which adds functionality)

---
### **2. Related Issue**
Fixes #579

---
### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Enabled 2FA from Settings scanned QR code with an authenticator app, entered the 6-digit code, and confirmed successful enrollment ("2FA Enabled").
  2. Signed out and signed back in with email/password confirmed the app correctly prompted for a 6-digit code before granting access, and that entering the current code from the authenticator successfully logged in.

---
### **4. Visual Verification (If applicable)**
No major visual redesign  adds a new "Two-Factor Auth" tab to the existing Settings page (matching the style of the other tabs), and a code-entry screen on the sign-in form when 2FA is required.
<img width="1877" height="896" alt="Screenshot 2026-07-19 103017" src="https://github.com/user-attachments/assets/9bccaf23-9187-4202-bd81-9e7dde99d57d" />
<img width="1917" height="917" alt="Screenshot 2026-07-19 103558" src="https://github.com/user-attachments/assets/beefd9d7-adf3-4cfb-bee6-00ab4403f147" />


---
### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
