### PR TITLE
fix : use animate-pulse instead of animate-bounce on life-threatening choking guide

### DIFF
--- a/src/pages/Health/Emergency.tsx
+++ b/src/pages/Health/Emergency.tsx
@@ -78,7 +78,7 @@ const firstAidGuides = [
     badgeColor: "bg-orange-500/20 text-orange-500 border-orange-500/30",
     urgency: "LIFE THREATENING",
     isLifeThreatening: true,
-    animationClass: "animate-bounce",
+    animationClass: "animate-pulse",
     steps: [
       "Ask 'Are you choking?' — if they cannot speak, cough, or breathe, act immediately",
       "Stand behind the person, slightly to one side. Support their chest with one hand",


### PR DESCRIPTION
## Summary of What Has Been Done

Changed the `animationClass` property for the choking first aid guide from `"animate-bounce"` to `"animate-pulse"` in `src/pages/Health/Emergency.tsx`.

## Changes Made

- `src/pages/Health/Emergency.tsx` (line 81): Changed `animationClass: "animate-bounce"` to `animationClass: "animate-pulse"` for the choking guide

## Impact it Made

- Consistent urgency animation (pulse) across all life-threatening first aid guides
- Removes inappropriate playful bounce animation from emergency content

Closes #655

## Note: Please assign this PR to the `tmdeveloper007` account.