### PR TITLE
fix : remove explicit cursor-pointer from active Log Mood button

### DIFF
--- a/src/components/gamification/MoodCalendarView.tsx
+++ b/src/components/gamification/MoodCalendarView.tsx
@@ -120,7 +120,7 @@ export default function MoodCalendarView({ moodLogs, onLogMood }: Props) {
               disabled={!selectedMood || isLogging}
               className={`w-full py-3 rounded-lg text-sm font-semibold transition-all ${
                 selectedMood && !isLogging
-                  ? "bg-primary hover:bg-primary/80 active:bg-primary/70 text-primary-foreground cursor-pointer shadow-md hover:shadow-lg transition-all"
+                  ? "bg-primary hover:bg-primary/80 active:bg-primary/70 text-primary-foreground shadow-md hover:shadow-lg transition-all"
                   : "bg-muted text-muted-foreground cursor-not-allowed opacity-50"
               }`}
             >


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the explicit `cursor-pointer` class from the active/enabled state of the Log Mood button in `src/components/gamification/MoodCalendarView.tsx`.

## Changes Made

- Removed `cursor-pointer` from the enabled button class string
- The disabled path already correctly uses `cursor-not-allowed`
- Buttons are cursor-pointer by default, so the explicit class was redundant

## Impact it Made

- Cleaner button class strings with no redundant cursor declarations
- More maintainable code

Closes #658

## Note: Please assign this PR to the `tmdeveloper007` account.