### PR TITLE
fix : replaced Math.random() with crypto.randomUUID() for nodeId

### DIFF
--- a/src/lib/mesh-network.ts
+++ b/src/lib/mesh-network.ts
@@ -35,7 +35,7 @@ class MeshNetworkManager {
 
   constructor() {
     // Generate a unique node ID for this tab session
-    this.nodeId = "peer-" + Math.random().toString(36).substring(2, 9);
+    this.nodeId = crypto.randomUUID();
     this.isOfflineSimulated = localStorage.getItem("symptom_scribe_offline_sim") === "true";
 
     if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the insecure `Math.random()`-based nodeId generation in `src/lib/mesh-network.ts` with the Web Crypto API's `crypto.randomUUID()`.

**File changed:** `src/lib/mesh-network.ts`

**Before:**
```typescript
this.nodeId = "peer-" + Math.random().toString(36).substring(2, 9);
```

**After:**
```typescript
this.nodeId = crypto.randomUUID();
```

Closes #668

## Note: Please assign this PR to the `tmdeveloper007` account.
