### PR TITLE
feat : added respiratory rate metric to Health Metrics page

### DIFF
--- a/src/pages/Metrics/index.tsx
+++ b/src/pages/Metrics/index.tsx
@@ -105,6 +105,12 @@ const metricTypes = [
     icon: Footprints,
     unit: "steps",
   },
+  {
+    value: "respiratory_rate",
+    label: "Respiratory Rate",
+    icon: Wind,
+    unit: "brpm",
+  },
 ];
 
 const MetricsTableSkeleton = () => (


### PR DESCRIPTION
## Summary of What Has Been Done

Added a new "Respiratory Rate" metric type to the Health Metrics page (`src/pages/Metrics/index.tsx`). The new metric appears in the dropdown alongside existing metrics (blood pressure, heart rate, temperature, etc.) and is stored with the unit "brpm" (breaths per minute).

## Changes Made

- Extended the `metricTypes` array in `src/pages/Metrics/index.tsx` with a new entry:
  - `value: "respiratory_rate"`
  - `label: "Respiratory Rate"`
  - `icon: Wind` (already imported)
  - `unit: "brpm"`

## Impact it Made

- Users can now log their respiratory rate as part of their vital signs tracking
- Helps monitor breathing patterns for early detection of respiratory issues (tachypnea >20 brpm, bradypnea <12 brpm)
- Complements existing vital signs metrics (heart rate, blood pressure, oxygen saturation)

Closes #681

## Note

Please assign this PR to the `tmdeveloper007` account.
