### PR TITLE
feat : added accessibility improvements to Metrics input form

### DIFF
--- a/src/pages/Metrics/index.tsx
+++ b/src/pages/Metrics/index.tsx
@@ -459,7 +459,7 @@ const Metrics = () => {
         </p>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4" role="group" aria-label="Select a metric type to record">
         {metricTypes.map((metric) => {
           const Icon = metric.icon;
           const isSelected = metricType === metric.value;
@@ -482,7 +482,7 @@ const Metrics = () => {
               }}
             >
               <CardContent className="pt-6 text-center">
-                <Icon className="w-8 h-8 mx-auto mb-2 text-primary" />
+                <Icon className="w-8 h-8 mx-auto mb-2 text-primary" aria-hidden="true" />
                 <p className="text-sm font-medium">{metric.label}</p>
               </CardContent>
             </Card>
@@ -500,7 +500,7 @@ const Metrics = () => {
             <DialogDescription>Enter your latest reading below.</DialogDescription>
           </DialogHeader>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-4" role="form" aria-label={`Record ${selectedMetric?.label ?? 'measurement'} form`}>
             {metricType === "blood_pressure" ? (
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
@@ -512,7 +512,10 @@ const Metrics = () => {
                     value={systolic}
                     onChange={(e) => setSystolic(e.target.value)}
                     required
+                    aria-required="true"
+                    aria-describedby="systolic-hint"
                   />
+                  <p id="systolic-hint" className="text-xs text-muted-foreground">Enter a value between 60 and 250 mmHg</p>
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="diastolic">Diastolic</Label>
@@ -523,7 +526,10 @@ const Metrics = () => {
                     value={diastolic}
                     onChange={(e) => setDiastolic(e.target.value)}
                     required
+                    aria-required="true"
+                    aria-describedby="diastolic-hint"
                   />
+                  <p id="diastolic-hint" className="text-xs text-muted-foreground">Enter a value between 30 and 150 mmHg</p>
                 </div>
               </div>
             ) : (
@@ -533,11 +539,14 @@ const Metrics = () => {
                   id="value"
                   type="number"
                   step="0.1"
-                  placeholder="Enter value"
+                  placeholder={`Enter value in ${selectedMetric?.unit ?? 'units'}`}
                   value={value}
                   onChange={(e) => setValue(e.target.value)}
                   required
+                  aria-required="true"
+                  aria-describedby="value-hint"
                 />
+                <p id="value-hint" className="text-xs text-muted-foreground">Enter a valid measurement value</p>
               </div>
             )}
 
@@ -552,7 +561,7 @@ const Metrics = () => {
               />
             </div>
 
-            <Button type="submit" disabled={loading} className="w-full">
+            <Button type="submit" disabled={loading} className="w-full" aria-label={loading ? "Saving metric" : "Record metric"}>
               {loading ? "Saving..." : "Record Metric"}
             </Button>
           </form>
@@ -568,7 +577,7 @@ const Metrics = () => {
             </CardDescription>
           </div>
           {historyView === "chart" && (
-            <Button onClick={downloadChart}>
+            <Button onClick={downloadChart} aria-label="Download chart as PNG image">
               Download Chart
             </Button>
           )}
@@ -590,6 +599,7 @@ const Metrics = () => {
                 <Select
                   value={historyMetricFilter}
                   onValueChange={setHistoryMetricFilter}
+                  aria-label="Filter metrics by type"
                 >
                   <SelectTrigger className="w-[180px]">
                     <SelectValue placeholder="Filter metric" />
@@ -607,6 +617,7 @@ const Metrics = () => {
                 <Select
                   value={timeframeFilter}
                   onValueChange={setTimeframeFilter}
+                  aria-label="Filter by time range"
                 >
                   <SelectTrigger className="w-[180px]">
                     <SelectValue placeholder="Select timeframe" />
@@ -623,38 +634,46 @@ const Metrics = () => {
                     variant={sortOrder === "newest" ? "default" : "outline"}
                     onClick={() => setSortOrder("newest")}
                     className="gap-2"
+                    aria-pressed={sortOrder === "newest"}
                   >
-                    <ArrowUpDown className="h-4 w-4" />
+                    <ArrowUpDown className="h-4 w-4" aria-hidden="true" />
                     Newest First
                   </Button>
                   <Button
                     variant={sortOrder === "oldest" ? "default" : "outline"}
                     onClick={() => setSortOrder("oldest")}
                     className="gap-2"
+                    aria-pressed={sortOrder === "oldest"}
                   >
-                    <ArrowUpDown className="h-4 w-4" />
+                    <ArrowUpDown className="h-4 w-4" aria-hidden="true" />
                     Oldest First
                   </Button>
                 </div>
               </div>
 
-              <div className="flex gap-2 mb-4">
+              <div className="flex gap-2 mb-4" role="tablist" aria-label="Metrics history view">
                 <Button
                   variant={historyView === "table" ? "default" : "outline"}
                   onClick={() => setHistoryView("table")}
+                  role="tab"
+                  aria-selected={historyView === "table"}
+                  aria-controls="metrics-history-panel"
                 >
                   Table
                 </Button>
                 <Button
                   variant={historyView === "chart" ? "default" : "outline"}
                   onClick={() => setHistoryView("chart")}
+                  role="tab"
+                  aria-selected={historyView === "chart"}
+                  aria-controls="metrics-history-panel"
                 >
                   Chart
                 </Button>
               </div>
 
               {historyView === "table" && (
-                <div className="rounded-xl border overflow-x-auto">
+                <div className="rounded-xl border overflow-x-auto" id="metrics-history-panel" role="tabpanel">
                   <Table className="min-w-[600px]">
                     <TableHeader>
                       <TableRow>
@@ -683,7 +702,7 @@ const Metrics = () => {
                           <TableCell>
                             <AlertDialog>
                               <AlertDialogTrigger asChild>
-                                <Button variant="destructive" size="icon">
+                                <Button variant="destructive" size="icon" aria-label="Delete metric record">
                                   <Trash2 className="h-4 w-4" />
                                 </Button>
                               </AlertDialogTrigger>


### PR DESCRIPTION
## Summary of What Has Been Done

Improved accessibility of the Health Metrics page (`src/pages/Metrics/index.tsx`) to meet WCAG 2.1 guidelines and support screen reader and keyboard-only users.

## Changes Made

1. Added `role="group"` and `aria-label` to the metric type card grid for screen reader users
2. Added `aria-hidden="true"` to decorative metric icons to reduce noise for screen readers
3. Added `role="form"` and descriptive `aria-label` to the metric entry dialog form
4. Added `aria-required="true"` to all required input fields (systolic, diastolic, value)
5. Added `aria-describedby` with hint text to input fields (systolic-hint, diastolic-hint, value-hint)
6. Added `aria-label` to submit button ("Record metric" / "Saving metric")
7. Added `aria-label` to metric type filter select and time range filter select
8. Added `aria-pressed` state to sort order toggle buttons (Newest First / Oldest First)
9. Added `aria-hidden="true"` to decorative ArrowUpDown icons in sort buttons
10. Added `role="tablist"` and `aria-label` to the history view toggle (Table/Chart)
11. Added `role="tab"` with `aria-selected` and `aria-controls` to view toggle buttons
12. Added `id="metrics-history-panel"` and `role="tabpanel"` to the history data container
13. Added `aria-label` to Download Chart button ("Download chart as PNG image")
14. Added `aria-label` to Delete button ("Delete metric record")

## Impact it Made

- Screen reader users can navigate and use the Metrics form without visual cues
- Better keyboard-only navigation for users with motor impairments
- Clear feedback through aria-describedby hint text for input fields
- Proper landmark roles and tab panel structure for assistive technology users
- Compliance with WCAG 2.1 accessibility guidelines

Closes #690

## Note

Please assign this PR to the `tmdeveloper007` account.
