### PR TITLE
fix : use crypto.randomUUID() for nodeId in mesh-network.ts

### DIFF
--- a/src/lib/mesh-network.ts
+++ b/src/lib/mesh-network.ts
@@ -35,7 +35,7 @@ class MeshNetworkManager {
 
   constructor() {
     // Generate a unique node ID for this tab session
-    this.nodeId = "peer-" + Math.random().toString(36).substring(2, 9);
+    this.nodeId = "peer-" + crypto.randomUUID();
     this.isOfflineSimulated = localStorage.getItem("symptom_scribe_offline_sim") === "true";
 
     if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary of What Needs to be Done

Replace the insecure `Math.random()` usage in `mesh-network.ts` for generating the nodeId with the `crypto.randomUUID()` API.

## Changes that Need to be Made

In `src/lib/mesh-network.ts`, the constructor currently generates a node ID like this:

```js
this.nodeId = "peer-" + Math.random().toString(36).substring(2, 9);
```

Replace it with:

```js
this.nodeId = "peer-" + crypto.randomUUID();
```

`crypto.randomUUID()` is a Web Crypto API standard method that generates cryptographically secure UUIDs. It is available in all modern browsers and Node.js 16+.

## Impact that it would Provide

- Generates genuinely unique node identifiers using a cryptographically secure source
- Eliminates the theoretical collision risk from `Math.random()` which is not suitable for identifiers
- Follows modern browser API best practices

## Note

Please assign this issue to the `tmdeveloper007` account.