### PR TITLE
fix : use crypto.getRandomValues() for health score simulation in AIHealthAssistant.tsx

### DIFF
--- a/src/pages/Health/AIHealthAssistant.tsx
+++ b/src/pages/Health/AIHealthAssistant.tsx
@@ -290,12 +290,14 @@ const AIHealthAssistant = () => {
             showInfo("Severity Assessment", `AI rates this as ${severityLevel} severity`);
           }
 
+          const rngScore = (range: number, offset: number) =>
+            offset + Math.floor(crypto.getRandomValues(new Uint32Array(1))[0] / (0xFFFFFFFF + 1) * range);
           const riskScore =
             severityLevel === "high"
-              ? Math.floor(Math.random() * 20) + 70
+              ? rngScore(20, 70)
               : severityLevel === "moderate"
-                ? Math.floor(Math.random() * 30) + 40
-                : Math.floor(Math.random() * 30) + 10;
+                ? rngScore(30, 40)
+                : rngScore(30, 10);
 
           if (shouldPersistConsultation(assistantContent)) {
             const recordId = crypto.randomUUID();


### PR DESCRIPTION
## Summary of What Needs to be Done

Replace `Math.random()` used for generating simulated health risk scores in `AIHealthAssistant.tsx` with `crypto.getRandomValues()`.

## Changes that Need to be Made

In `src/pages/Health/AIHealthAssistant.tsx`, the risk score computation uses `Math.random()` three times:

```js
const riskScore =
  severityLevel === "high"
    ? Math.floor(Math.random() * 20) + 70
    : severityLevel === "moderate"
      ? Math.floor(Math.random() * 30) + 40
      : Math.floor(Math.random() * 30) + 10;
```

Replace with a single `crypto.getRandomValues()` based approach:

```js
const rand = crypto.getRandomValues(new Uint32Array(1))[0] / 0xFFFFFFFF;
const riskScore =
  severityLevel === "high"
    ? Math.floor(rand * 20) + 70
    : severityLevel === "moderate"
      ? Math.floor(rand * 30) + 40
      : Math.floor(rand * 30) + 10;
```

## Impact that it would Provide

- Uses cryptographically secure randomness for score simulation
- Follows modern security best practices for any random value generation in browser contexts
- No functional change in output range or distribution

## Note

Please assign this issue to the `tmdeveloper007` account.