### PR TITLE
fix : wrap scrollToBottom in useCallback with correct deps in ChatInterface.tsx

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Send, Loader2, Plus, History, Trash2, Menu } from "lucide-react";
@@ -64,15 +64,15 @@ const ChatInterface = () => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
 
-  const scrollToBottom = () => {
+  const scrollToBottom = useCallback(() => {
     if (typeof messagesEndRef.current?.scrollIntoView === "function") {
       messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
     }
-  };
+  }, []);
 
   useEffect(() => {
     scrollToBottom();
-  }, [messages]);
+  }, [messages, scrollToBottom]);
 
   const fetchSessions = async () => {
     try {


### PR DESCRIPTION
## Summary of What Needs to be Done

Wrap the `scrollToBottom` function in `ChatInterface.tsx` inside `useCallback` with correct dependency array, and add it to the `useEffect` dependency array.

## Changes that Need to be Made

In `src/components/chat/ChatInterface.tsx`:

1. Add `useCallback` to the React imports from `"react"`.
2. Wrap `scrollToBottom` in `useCallback`:

```js
const scrollToBottom = useCallback(() => {
  if (typeof messagesEndRef.current?.scrollIntoView === "function") {
    messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
  }
}, []);
```

3. Update the `useEffect` dependency array to include `scrollToBottom`:

```js
useEffect(() => {
  scrollToBottom();
}, [messages, scrollToBottom]);
```

## Impact that it would Provide

- Eliminates potential stale closure issues with the scroll-to-bottom behavior
- Follows React best practices for callback stability and proper dependency management
- Ensures the effect runs correctly whenever `messages` changes and `scrollToBottom` is stable

## Note

Please assign this issue to the `tmdeveloper007` account.