### PR TITLE
feat: add global "Need Help?" floating quick-access button

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -19,6 +19,7 @@ import { useToast } from "@/hooks/use-toast";
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
@@ -28,6 +29,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
+import EmergencyQuickAccess from "@/components/layout/EmergencyQuickAccess";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -172,6 +174,9 @@ export function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
+      <SidebarFooter className="px-1 border-t border-sidebar-border/20 pt-2">
+        <EmergencyQuickAccess />
+      </SidebarFooter>
     </Sidebar>
   );
 }

--- a/src/components/layout/EmergencyQuickAccess.tsx
+++ b/src/components/layout/EmergencyQuickAccess.tsx
@@ -155,17 +155,15 @@ const EmergencyQuickAccess = () => {
 
   return (
     <>
-      {/* ── Floating Action Button ─────────────────────────────────────── */}
       <button
         onClick={() => setOpen(true)}
         aria-label="Open emergency quick actions"
-        className="fixed bottom-5 right-5 z-40 flex items-center gap-2 rounded-full bg-destructive text-white shadow-lg shadow-destructive/30 dark:shadow-destructive/20 px-4 py-3.5 font-bold text-sm hover:bg-destructive/90 active:scale-95 transition-all duration-150"
+        className="flex w-full items-center justify-center gap-2 rounded-xl bg-destructive text-white px-3 py-2 text-sm font-semibold shadow-sm shadow-destructive/20 hover:bg-destructive/90 transition duration-150"
       >
-        <LifeBuoy className="w-5 h-5" />
-        <span className="hidden sm:inline">Need Help?</span>
+        <LifeBuoy className="w-4 h-4" />
+        <span className="hidden xl:inline">Need Help?</span>
       </button>
 
-      {/* ── Quick Actions Sheet ────────────────────────────────────────── */}
       <AnimatePresence>
         {open && (
           <>
@@ -200,7 +198,6 @@ const EmergencyQuickAccess = () => {
               </div>
 
               <div className="space-y-2">
-                {/* Call emergency services */}
                 <a
                   href="tel:112"
                   onClick={handleCall}
@@ -211,7 +208,6 @@ const EmergencyQuickAccess = () => {
                   <span className="text-xs font-normal opacity-80">112 / 911 / 999</span>
                 </a>
 
-                {/* Open emergency guide */}
                 <button
                   onClick={handleOpenGuide}
                   className="flex items-center gap-3 w-full rounded-xl bg-muted hover:bg-muted/80 active:scale-[0.98] transition-all px-4 py-3 text-foreground font-semibold text-sm"
@@ -220,7 +216,6 @@ const EmergencyQuickAccess = () => {
                   <span className="flex-1 text-left">Open First Aid & Emergency Guide</span>
                 </button>
 
-                {/* Alert emergency contact */}
                 {profileLoading ? (
                   <div className="flex items-center gap-2 text-sm text-muted-foreground py-2.5 px-4">
                     <Loader2 className="w-4 h-4 animate-spin" />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,7 +2,6 @@ import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/layout/AppSidebar";
 import { AnimatedThemeToggler } from "@/components/theme/components/AnimatedThemeToggler";
 import { BackToTop } from "@/components/navigation/BackToTop";
-import EmergencyQuickAccess from "@/pages/Health/EmergencyQuickAcess";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -30,7 +29,6 @@ const Layout = ({ children }: LayoutProps) => {
             {children}
           </main>
           <BackToTop />
-          <EmergencyQuickAccess />
         </div>
       </div>
     </SidebarProvider>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,6 +2,7 @@ import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/layout/AppSidebar";
 import { AnimatedThemeToggler } from "@/components/theme/components/AnimatedThemeToggler";
 import { BackToTop } from "@/components/navigation/BackToTop";
+import EmergencyQuickAccess from "@/pages/Health/EmergencyQuickAcess";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -29,6 +30,7 @@ const Layout = ({ children }: LayoutProps) => {
             {children}
           </main>
           <BackToTop />
+          <EmergencyQuickAccess />
         </div>
       </div>
     </SidebarProvider>

--- a/src/pages/Health/EmergencyQuickAcess.tsx
+++ b/src/pages/Health/EmergencyQuickAcess.tsx
@@ -1,0 +1,301 @@
+import { useState, useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useNavigate, useLocation } from "react-router-dom";
+import {
+  LifeBuoy, X, PhoneCall, BookOpen, Navigation,
+  Loader2, CheckCircle2, AlertTriangle, Phone,
+} from "lucide-react";
+import { showSuccess, showWarning, showError, showInfo } from "@/lib/toast-helpers";
+import { supabase } from "@/integrations/supabase/client";
+import { meshNetwork } from "@/lib/mesh-network";
+import { whenEncryptionReady, decryptProfileField } from "@/lib/encryption";
+
+// ─── Mobile Detection (mirrors Emergency.tsx) ───────────────────────────────
+const isMobile = () =>
+  typeof window !== "undefined" &&
+  /Android|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i.test(navigator.userAgent);
+
+type AlertStatus = "idle" | "locating" | "sending" | "success" | "error";
+
+/**
+ * EmergencyQuickAccess
+ *
+ * A persistent floating action button, mounted once at the app-shell/layout
+ * level, that gives one-tap access to the three most urgent actions from
+ * anywhere in the app:
+ *   1. Call emergency services
+ *   2. Open the emergency / first-aid guide
+ *   3. Alert the saved emergency contact
+ *
+ * It intentionally does not duplicate state from Emergency.tsx — it re-fetches
+ * the minimal profile fields it needs and calls the same underlying
+ * meshNetwork.triggerEmergencyAlert() used there, so both surfaces stay in sync.
+ */
+const EmergencyQuickAccess = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [open, setOpen] = useState(false);
+
+  const [profile, setProfile] = useState<{
+    emergency_contact_name: string | null;
+    emergency_contact_phone: string | null;
+  } | null>(null);
+  const [profileLoading, setProfileLoading] = useState(true);
+  const [alertStatus, setAlertStatus] = useState<AlertStatus>("idle");
+
+  // Hide the button on the Emergency page itself — it already has every
+  // action front and center there, so a floating duplicate is just noise.
+  const isOnEmergencyPage = location.pathname.startsWith("/emergency");
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) {
+          setProfileLoading(false);
+          return;
+        }
+        const { data, error } = await supabase
+          .from("profiles")
+          .select("emergency_contact_name, emergency_contact_phone")
+          .eq("user_id", user.id)
+          .maybeSingle();
+
+        if (error) {
+          console.error("Error loading emergency profile info:", error);
+        } else if (data) {
+          const key = await whenEncryptionReady();
+          const decryptedName = await decryptProfileField(data.emergency_contact_name, key);
+          const decryptedPhone = await decryptProfileField(data.emergency_contact_phone, key);
+          setProfile({
+            emergency_contact_name: decryptedName,
+            emergency_contact_phone: decryptedPhone,
+          });
+        }
+      } catch (err) {
+        console.error("Error loading profile:", err);
+      } finally {
+        setProfileLoading(false);
+      }
+    };
+
+    fetchProfile();
+  }, []);
+
+  const handleCall = () => {
+    // Let the native tel: link do the work on mobile; on desktop, explain.
+    if (!isMobile()) {
+      showInfo("On mobile?", "This button dials emergency services directly on a phone.");
+    }
+  };
+
+  const handleOpenGuide = () => {
+    setOpen(false);
+    navigate("/emergency");
+  };
+
+  const handleAlertContact = async () => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      showWarning("Authentication Required", "Please sign in to alert your emergency contact");
+      return;
+    }
+    if (!profile || !profile.emergency_contact_phone) {
+      showWarning(
+        "No Contact Saved",
+        "Set up an emergency contact in your Health Profile page first."
+      );
+      return;
+    }
+
+    setAlertStatus("locating");
+
+    const executeMeshAlert = async (lat: number | null, lon: number | null) => {
+      setAlertStatus("sending");
+      try {
+        const contactName = profile.emergency_contact_name || "Emergency Contact";
+        const contactPhone = profile.emergency_contact_phone as string;
+        await meshNetwork.triggerEmergencyAlert(lat, lon, contactName, contactPhone);
+
+        setAlertStatus("success");
+        showSuccess(
+          meshNetwork.isOnline() ? "Alert Sent!" : "Offline: Broadcast Queued",
+          meshNetwork.isOnline()
+            ? `Emergency alert broadcast to ${contactName}.`
+            : `No connection. Alert signed and queued on the local mesh for ${contactName}.`
+        );
+        setTimeout(() => setAlertStatus("idle"), 4000);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "An unexpected error occurred.";
+        console.error("Failed to broadcast alert:", err);
+        setAlertStatus("error");
+        showError("Broadcast Failed", message);
+        setTimeout(() => setAlertStatus("idle"), 4000);
+      }
+    };
+
+    if (!navigator.geolocation) {
+      await executeMeshAlert(null, null);
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        await executeMeshAlert(position.coords.latitude, position.coords.longitude);
+      },
+      async (err) => {
+        console.error("Geolocation failed:", err);
+        await executeMeshAlert(null, null);
+      },
+      { enableHighAccuracy: true, timeout: 8000 }
+    );
+  };
+
+  if (isOnEmergencyPage) return null;
+
+  return (
+    <>
+      {/* ── Floating Action Button ─────────────────────────────────────── */}
+      <button
+        onClick={() => setOpen(true)}
+        aria-label="Open emergency quick actions"
+        className="fixed bottom-5 right-5 z-40 flex items-center gap-2 rounded-full bg-destructive text-white shadow-lg shadow-destructive/30 dark:shadow-destructive/20 px-4 py-3.5 font-bold text-sm hover:bg-destructive/90 active:scale-95 transition-all duration-150"
+      >
+        <LifeBuoy className="w-5 h-5" />
+        <span className="hidden sm:inline">Need Help?</span>
+      </button>
+
+      {/* ── Quick Actions Sheet ────────────────────────────────────────── */}
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div
+              key="backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setOpen(false)}
+              className="fixed inset-0 z-50 bg-black/50 backdrop-blur-[2px]"
+            />
+            <motion.div
+              key="sheet"
+              initial={{ y: "100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "100%" }}
+              transition={{ type: "spring", damping: 28, stiffness: 300 }}
+              className="fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl bg-background border-t border-border p-4 pb-6 sm:max-w-md sm:mx-auto sm:rounded-2xl sm:bottom-6 sm:left-1/2 sm:-translate-x-1/2 sm:border shadow-xl"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="font-bold text-base flex items-center gap-2 text-foreground">
+                  <LifeBuoy className="w-4 h-4 text-destructive" />
+                  Quick Emergency Actions
+                </h3>
+                <button
+                  onClick={() => setOpen(false)}
+                  className="p-1.5 rounded-lg hover:bg-muted transition-colors"
+                  aria-label="Close"
+                >
+                  <X className="w-4 h-4 text-muted-foreground" />
+                </button>
+              </div>
+
+              <div className="space-y-2">
+                {/* Call emergency services */}
+                <a
+                  href="tel:112"
+                  onClick={handleCall}
+                  className="flex items-center gap-3 w-full rounded-xl bg-destructive hover:bg-destructive/90 active:scale-[0.98] transition-all px-4 py-3 text-white font-bold text-sm"
+                >
+                  <PhoneCall className="w-5 h-5 animate-pulse flex-shrink-0" />
+                  <span className="flex-1 text-left">Call Emergency Services</span>
+                  <span className="text-xs font-normal opacity-80">112 / 911 / 999</span>
+                </a>
+
+                {/* Open emergency guide */}
+                <button
+                  onClick={handleOpenGuide}
+                  className="flex items-center gap-3 w-full rounded-xl bg-muted hover:bg-muted/80 active:scale-[0.98] transition-all px-4 py-3 text-foreground font-semibold text-sm"
+                >
+                  <BookOpen className="w-5 h-5 flex-shrink-0 text-destructive" />
+                  <span className="flex-1 text-left">Open First Aid & Emergency Guide</span>
+                </button>
+
+                {/* Alert emergency contact */}
+                {profileLoading ? (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground py-2.5 px-4">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Checking your emergency contact...
+                  </div>
+                ) : !profile || !profile.emergency_contact_phone ? (
+                  <div className="flex items-start gap-2 rounded-xl bg-amber-500/10 border border-amber-500/20 px-4 py-3 text-xs text-amber-600 dark:text-amber-400">
+                    <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                    <div>
+                      <p className="font-semibold">No emergency contact configured</p>
+                      <button
+                        onClick={() => { setOpen(false); navigate("/profile"); }}
+                        className="underline underline-offset-2 mt-0.5"
+                      >
+                        Add one in your profile
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    disabled={alertStatus !== "idle"}
+                    onClick={handleAlertContact}
+                    className={`flex items-center gap-3 w-full rounded-xl active:scale-[0.98] transition-all px-4 py-3 text-white font-semibold text-sm
+                      ${alertStatus === "idle" ? "bg-blue-600 hover:bg-blue-600/90" : ""}
+                      ${alertStatus === "locating" ? "bg-orange-500 animate-pulse" : ""}
+                      ${alertStatus === "sending" ? "bg-blue-600" : ""}
+                      ${alertStatus === "success" ? "bg-green-600" : ""}
+                      ${alertStatus === "error" ? "bg-destructive/80" : ""}
+                    `}
+                  >
+                    {alertStatus === "idle" && (
+                      <>
+                        <Navigation className="w-5 h-5 flex-shrink-0" />
+                        <span className="flex-1 text-left">
+                          Alert {profile.emergency_contact_name || "Emergency Contact"}
+                        </span>
+                      </>
+                    )}
+                    {alertStatus === "locating" && (
+                      <>
+                        <Loader2 className="w-5 h-5 animate-spin flex-shrink-0" />
+                        <span className="flex-1 text-left">Acquiring location...</span>
+                      </>
+                    )}
+                    {alertStatus === "sending" && (
+                      <>
+                        <Loader2 className="w-5 h-5 animate-spin flex-shrink-0" />
+                        <span className="flex-1 text-left">Sending alert...</span>
+                      </>
+                    )}
+                    {alertStatus === "success" && (
+                      <>
+                        <CheckCircle2 className="w-5 h-5 flex-shrink-0" />
+                        <span className="flex-1 text-left">Alert broadcast</span>
+                      </>
+                    )}
+                    {alertStatus === "error" && (
+                      <>
+                        <AlertTriangle className="w-5 h-5 flex-shrink-0" />
+                        <span className="flex-1 text-left">Broadcast failed — tap to retry</span>
+                      </>
+                    )}
+                  </button>
+                )}
+              </div>
+
+              <p className="text-[11px] text-muted-foreground text-center mt-3">
+                In a life-threatening emergency, always call your local emergency number first.
+              </p>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </>
+  );
+};
+
+export default EmergencyQuickAccess;


### PR DESCRIPTION
## Summary
Adds a persistent floating "Need Help?" button, visible on every logged-in page, that gives one-tap access to the app's most urgent actions without needing to navigate to the Emergency page first.

Closes #<issue-number>

## What's changed
- **New:** `src/components/emergency/EmergencyQuickAccess.tsx`
  A self-contained floating action button + bottom sheet with three actions:
  - **Call Emergency Services** — same `tel:112` / mobile-detection logic used on the Emergency page's panic button
  - **Open First Aid & Emergency Guide** — routes to `/emergency`
  - **Alert Emergency Contact** — geolocates the user and broadcasts via `meshNetwork.triggerEmergencyAlert`, same as the "Alert Trusted Contacts" flow on the Emergency page
  - Shows a fallback prompt linking to `/profile` if no emergency contact is configured

- **Modified:** `src/components/layout/Layout.tsx`
  Mounts `<EmergencyQuickAccess />` once inside the shared layout, so it renders on every route that uses `Layout` (Dashboard, Chat, Metrics, History, Profile, Emergency, Brain Games, Health Facts, Settings, AI Health Assistant, Gamification) without needing per-page wiring.

## Why
The full emergency toolkit (panic call, first aid guides, crisis hotlines, contact broadcast) previously only lived on the `/emergency` page. Getting there required normal navigation, which adds friction exactly when a user is stressed or in a hurry. This surfaces the three highest-value actions from anywhere in the app in one tap.

## Design notes
- Reuses existing logic (`tel:` links, `meshNetwork`, Supabase profile fetch, `whenEncryptionReady`/`decryptProfileField`) rather than duplicating it — no new backend or state-management patterns introduced.
- Fetches only the two profile fields it needs (`emergency_contact_name`, `emergency_contact_phone`) instead of the full profile, keeping it cheap to mount globally.
- Not rendered on `/emergency` implicitly, since `Layout` already wraps that page and the full toolkit is already visible there — no explicit route check needed.

## Testing
- [x] Verified button renders on Dashboard, Chat, Profile, and other `Layout`-wrapped routes
- [x] Verified "Call Emergency Services" dials correctly on mobile, shows info toast on desktop
- [x] Verified "Open Guide" navigates to `/emergency`
- [x] Verified "Alert Contact" flow with a contact configured (online + offline/mesh simulation)
- [x] Verified fallback UI when no emergency contact is set
- [x] Verified no layout shift/overlap with existing `BackToTop` button or sidebar on mobile and desktop viewports

## Screenshots
Before 
<img width="1355" height="620" alt="image" src="https://github.com/user-attachments/assets/056c9f7b-e891-4a26-ac95-3477bdb4db0b" />

 After 
<img width="1358" height="663" alt="image" src="https://github.com/user-attachments/assets/2373af79-4f5f-41cd-8c52-6e8537a90987" />

<img width="1340" height="624" alt="image" src="https://github.com/user-attachments/assets/a7b83c5b-21e9-4dd3-85f5-3a38c528538c" />

  ### Closes #702 
