### PR TITLE
fix : replaced Math.random() in SidebarMenuSkeleton with deterministic width

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -531,9 +531,9 @@ const SidebarMenuSkeleton = React.forwardRef<
     showIcon?: boolean;
   }
 >(({ className, showIcon = false, ...props }, ref) => {
-  // Random width between 50 to 90%.
+  // Deterministic skeleton width of 75%.
   const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
+    return '75%';
   }, []);
 
   return (


### PR DESCRIPTION
Summary of What Has Been Done:
Replaced the `Math.random()` call in the `SidebarMenuSkeleton` component with a fixed deterministic width of `75%`. The `useMemo` is retained but now computes a fixed value.

Changes Made:
- `src/components/ui/sidebar.tsx`: Changed the `width` calculation from `${Math.floor(Math.random() * 40) + 50}%` to the fixed string `'75%'`

Impact it Made:
- Removes unnecessary non-deterministic behavior from skeleton rendering
- Eliminates Math.random() usage in a UI rendering component
- Skeleton loading indicators do not benefit from random widths

Closes #704

Note: Please assign this PR to the `tmdeveloper007` account.