### PR TITLE
fix : replaced console.error with console.warn in SmartAlertsBanner

### DIFF
--- a/src/components/dashboard/SmartAlertsBanner.tsx
+++ b/src/components/dashboard/SmartAlertsBanner.tsx
@@ -31,7 +31,7 @@ export function SmartAlertsBanner({ userId, symptoms }: SmartAlertsBannerProps) 
       const activeAlerts = detectSmartAlerts(decryptedMetrics, symptoms);
       setAlerts(activeAlerts);
     } catch (err) {
-      console.error("Failed to calculate smart alerts:", err);
+      console.warn("Failed to calculate smart alerts:", err);
     }
   }, [userId, symptoms]);
 


### PR DESCRIPTION
Summary of What Has Been Done:
Changed the `console.error` call in `SmartAlertsBanner.tsx` to `console.warn`. The failed alert calculation is a non-critical fallback scenario — the component gracefully handles the error by rendering an empty/zero-alert state.

Changes Made:
- `src/components/dashboard/SmartAlertsBanner.tsx`: Changed `console.error("Failed to calculate smart alerts:", err)` to `console.warn(...)`

Impact it Made:
- Correct logging semantics for non-critical async failures
- Prevents devtools console from showing error-level entries for expected fallback scenarios
- Better production log quality

Closes #705

Note: Please assign this PR to the `tmdeveloper007` account.