### PR TITLE
fix : used crypto.getRandomValues() for fact selection in HealthFacts

### DIFF
--- a/src/pages/Health/HealthFacts.tsx
+++ b/src/pages/Health/HealthFacts.tsx
@@ -248,7 +248,9 @@ const HealthFacts = () => {
     }
 
     const remaining = FACTS.filter((f) => !shownIds.current.has(f.id));
-    const pick = remaining[Math.floor(Math.random() * remaining.length)];
+    const arr = new Uint32Array(1);
+    crypto.getRandomValues(arr);
+    const pick = remaining[arr[0] % remaining.length];
     shownIds.current.add(pick.id);
 
     setCurrentFact(pick);


### PR DESCRIPTION
Summary of What Has Been Done:
Replaced the `Math.random()` usage in `HealthFacts.tsx` when selecting a random fact from the remaining pool with `crypto.getRandomValues()`.

Changes Made:
- `src/pages/Health/HealthFacts.tsx`: Replaced `Math.floor(Math.random() * remaining.length)` with `crypto.getRandomValues()` based selection using `Uint32Array` modulo

Impact it Made:
- Cryptographically secure random fact selection
- Consistent codebase approach — aligns with the ongoing effort to replace Math.random() across the project

Closes #706

Note: Please assign this PR to the `tmdeveloper007` account.