### PR TITLE
fix : replaced console.error with console.warn for non-critical Dashboard failures

### DIFF
--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -52,7 +52,7 @@ async function fetchSymptomHistory(
 
   if (directError) {
     if (error) {
-      console.error("Cached symptom_history fetch failed:", error);
+      console.warn("Cached symptom_history fetch failed:", error);
     }
     throw directError;
   }
@@ -198,7 +198,7 @@ const Dashboard = () => {
 
           setUserName(decryptedFullName);
         } catch (err) {
-          console.error("Full name decryption failed", err);
+          console.warn("Full name decryption failed:", err);
         }
       }
 
@@ -262,7 +262,7 @@ const Dashboard = () => {
         }
       }
     } catch (error) {
-      console.error("Error fetching dashboard data:", error);
+      console.warn("Error fetching dashboard data:", error);
       showError("Connection Error", "Failed to load dashboard data");
     } finally {
       setLoading(false);


### PR DESCRIPTION
Summary of What Has Been Done:
Changed three `console.error` calls in `src/pages/Dashboard/index.tsx` to `console.warn`. All three represent recoverable fallback scenarios where the component gracefully degrades to alternative data sources.

Changes Made:
- Line ~55: Changed `console.error("Cached symptom_history fetch failed:", error)` to `console.warn`
- Line ~201: Changed `console.error("Full name decryption failed", err)` to `console.warn`
- Line ~265: Changed `console.error("Error fetching dashboard data:", error)` to `console.warn`

Impact it Made:
- Accurate log severity for recoverable failures
- Cleaner browser devtools during development
- Better production error monitoring signal quality

Closes #708

Note: Please assign this PR to the `tmdeveloper007` account.