### PR TITLE
fix : replaced console.error with console.warn in Dashboard data fetch

### DIFF
--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -52,7 +52,7 @@ async function fetchSymptomHistory(
 
   if (directError) {
     if (error) {
-      console.error("Cached symptom_history fetch failed:", error);
+      console.warn("Cached symptom_history fetch failed:", error);
     }
     throw directError;
   }
@@ -198,7 +198,7 @@ const Dashboard = () => {
 
           setUserName(decryptedFullName);
         } catch (err) {
-          console.error("Full name decryption failed", err);
+          console.warn("Full name decryption failed", err);
         }
       }
 
@@ -262,7 +262,7 @@ const Dashboard = () => {
         }
       }
     } catch (error) {
-      console.error("Error fetching dashboard data:", error);
+      console.warn("Error fetching dashboard data:", error);
       showError("Connection Error", "Failed to load dashboard data");
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced `console.error` calls with `console.warn` in `src/pages/Dashboard/index.tsx` at three locations where non-critical data-fetch failures occur. These are gracefully handled with fallbacks, so `console.error` was too aggressive.

## Changes Made
- Line 55: `console.error` -> `console.warn` for cached symptom_history fetch failure
- Line 201: `console.error` -> `console.warn` for full name decryption failure
- Line 265: `console.error` -> `console.warn` for overall dashboard data fetch failure

## Impact it Made
- Reduces noise in browser developer tools and CI logs
- More accurate severity labeling of log messages
- Improves developer experience when debugging production issues

Closes #719

Note: Please assign this PR to the `tmdeveloper007` account.