### PR TITLE
fix : replaced Math.random() with deterministic index in HealthFacts fact selection

### DIFF
--- a/src/pages/Health/HealthFacts.tsx
+++ b/src/pages/Health/HealthFacts.tsx
@@ -248,7 +248,8 @@ const HealthFacts = () => {
     }
 
     const remaining = FACTS.filter((f) => !shownIds.current.has(f.id));
-    const pick = remaining[Math.floor(Math.random() * remaining.length)];
+    const idx = shownIds.current.size % remaining.length;
+    const pick = remaining[idx];
     shownIds.current.add(pick.id);
 
     setCurrentFact(pick);


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced `Math.random()` with a deterministic index-based selection in `src/pages/Health/HealthFacts.tsx` for picking the next health fact to display.

## Changes Made
- Replaced `remaining[Math.floor(Math.random() * remaining.length)]` with `remaining[shownIds.current.size % remaining.length]`.
- This provides consistent fact selection based on the number of already-shown facts, ensuring predictable cycling through the facts array.

## Impact it Made
- Deterministic fact selection for better testability.
- Consistent user experience with predictable fact rotation.
- Removes unnecessary randomness from the UI logic.

Closes #721

Note: Please assign this PR to the `tmdeveloper007` account.