### PR TITLE
fix : replaced console.error with console.warn in SmartAlertsBanner

### DIFF
--- a/src/components/dashboard/SmartAlertsBanner.tsx
+++ b/src/components/dashboard/SmartAlertsBanner.tsx
@@ -31,7 +31,7 @@ export function SmartAlertsBanner({ userId, symptoms }: SmartAlertsBannerProps) 
       const activeAlerts = detectSmartAlerts(decryptedMetrics, symptoms);
       setAlerts(activeAlerts);
     } catch (err) {
-      console.error("Failed to calculate smart alerts:", err);
+      console.warn("Failed to calculate smart alerts:", err);
     }
   }, [userId, symptoms]);
 


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced `console.error` with `console.warn` in `src/components/dashboard/SmartAlertsBanner.tsx` for the smart alerts calculation failure handler.

## Changes Made
- Line 34: `console.error` -> `console.warn` in the catch block for alert calculation failures.

## Impact it Made
- Cleaner browser and CI logs by reducing false error-level noise.
- More accurate log severity for recoverable alert calculation failures.

Closes #722

Note: Please assign this PR to the `tmdeveloper007` account.