### PR TITLE
fix : used deterministic width in SidebarMenuSkeleton instead of Math.random()

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -531,11 +531,7 @@ const SidebarMenuSkeleton = React.forwardRef<
     showIcon?: boolean;
   }
 >(({ className, showIcon = false, ...props }, ref) => {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
-
+  // Deterministic skeleton text width.
   return (
     <div
       ref={ref}
@@ -545,13 +541,8 @@ const SidebarMenuSkeleton = React.forwardRef<
     >
       {showIcon && <Skeleton className="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />}
       <Skeleton
-        className="h-4 max-w-[--skeleton-width] flex-1"
+        className="h-4 w-24 flex-1 rounded"
         data-sidebar="menu-skeleton-text"
-        style={
-          {
-            "--skeleton-width": width,
-          } as React.CSSProperties
-        }
       />
     </div>
   );


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced the `Math.random()`-based random width generation in `SidebarMenuSkeleton` with a fixed deterministic width. The `React.useMemo` wrapper and the random width logic were removed.

## Changes Made
- In `src/components/ui/sidebar.tsx`, replaced the `useMemo`-wrapped random width with a fixed `w-24` (96px) class on the skeleton text element.
- Removed the `--skeleton-width` CSS variable and the `React.useMemo` call.
- The skeleton now renders with a consistent, predictable width.

## Impact it Made
- Consistent skeleton UI rendering across page loads.
- Simpler, more maintainable code.
- Better testability of sidebar components.

Closes #723

Note: Please assign this PR to the `tmdeveloper007` account.