### PR TITLE
fix : respected activeFilter in hasData memo for HealthTrendsChart

### DIFF
--- a/src/components/dashboard/HealthTrendsChart.tsx
+++ b/src/components/dashboard/HealthTrendsChart.tsx
@@ -75,10 +75,22 @@ export default function HealthTrendsChart({ userId }: HealthTrendsChartProps) {
 
   // Determine if there is any data to show in the chart
   const hasData = useMemo(() => {
-    return chartData.some(
-      (d) => d["Heart Rate"] !== null || d["Sleep Duration"] !== null || d["Daily Steps"] !== null
-    );
-  }, [chartData]);
+    if (activeFilter === "all") {
+      return chartData.some(
+        (d) => d["Heart Rate"] !== null || d["Sleep Duration"] !== null || d["Daily Steps"] !== null
+      );
+    }
+    if (activeFilter === "heart_rate") {
+      return chartData.some((d) => d["Heart Rate"] !== null);
+    }
+    if (activeFilter === "sleep") {
+      return chartData.some((d) => d["Sleep Duration"] !== null);
+    }
+    if (activeFilter === "steps") {
+      return chartData.some((d) => d["Daily Steps"] !== null);
+    }
+    return false;
+  }, [chartData, activeFilter]);
 
   // Compute accessible screen reader summary text
   const summaryText = useMemo(() => {


### PR DESCRIPTION
## Summary of What Has Been Done
In `src/components/dashboard/HealthTrendsChart.tsx`, the `hasData` useMemo did not account for the `activeFilter` state. When a user filtered to a single metric (e.g., heart_rate), `hasData` would return true if ANY metric had data, even if the filtered metric had none. This caused an empty chart to be shown.

## Changes Made
- Updated `hasData` useMemo to check data based on the current `activeFilter` value.
- Added `activeFilter` to the `hasData` useMemo dependency array.
- Shows empty-state message when the filtered metric has no data.

## Impact it Made
- Correct empty-state display when a filtered metric has no records.
- Improved user experience for the health trends chart.
- More accurate chart visibility logic.

Closes #732

Note: Please assign this PR to the `tmdeveloper007` account.