### PR TITLE
fix : wrapped fetchSessions in useCallback and added to useEffect deps in ChatInterface

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Send, Loader2, Plus, History, Trash2, Menu } from "lucide-react";
@@ -74,7 +74,7 @@ const ChatInterface = () => {
     scrollToBottom();
   }, [messages]);
 
-  const fetchSessions = async () => {
+  const fetchSessions = useCallback(async () => {
     try {
       setSessionsLoading(true);
       const {
@@ -94,11 +94,11 @@ const ChatInterface = () => {
     } finally {
       setSessionsLoading(false);
     }
-  };
+  }, [supabase]);
 
   useEffect(() => {
     fetchSessions();
-  }, []);
+  }, [fetchSessions]);
 
   const handleSelectSession = (sessionId: string) => {
     const session = sessions.find((s) => s.id === sessionId);


### PR DESCRIPTION
## Summary of What Has Been Done
In `src/components/chat/ChatInterface.tsx`, the `fetchSessions` async function was defined in the component body without `useCallback` and called from a `useEffect` with an empty dependency array `[]`. This causes a React exhaustive-deps lint warning.

## Changes Made
- Added `useCallback` to the React import.
- Wrapped `fetchSessions` in `useCallback` with `[supabase]` as dependencies.
- Added `fetchSessions` to the `useEffect` dependency array.

## Impact it Made
- Fixes React hook exhaustive-deps lint warnings.
- Ensures the effect uses the latest stable `fetchSessions` reference.
- Follows React best practices for async operations in effects.

Closes #734

Note: Please assign this PR to the `tmdeveloper007` account.