### PR TITLE
fix : added domain prop to YAxis in Metrics chart for predictable scale

### DIFF
--- a/src/pages/Metrics/index.tsx
+++ b/src/pages/Metrics/index.tsx
@@ -747,7 +747,7 @@ const Metrics = () => {
                           tick={{ fontSize: 10 }}
                           minTickGap={25}
                         />
-                        <YAxis tick={{ fontSize: 10 }} />
+                        <YAxis tick={{ fontSize: 10 }} domain={[0, "auto"]} />
                         <Tooltip labelFormatter={(value) => formatDate(value)} />
                         {isBloodPressure ? (
                           <>


### PR DESCRIPTION
## Summary of What Has Been Done
In `src/pages/Metrics/index.tsx`, the `YAxis` component in the metrics LineChart had no `domain` prop, relying solely on Recharts default auto-scaling. For blood pressure values, this can produce unintuitive or clinically unclear Y-axis ranges.

## Changes Made
- Added `domain={[0, "auto"]}` to the `YAxis` component on line 750.
- This ensures the Y-axis always starts at 0 and auto-scales to the maximum data value.

## Impact it Made
- More predictable Y-axis scaling for health metrics charts.
- Ensures blood pressure values are clearly visible regardless of data range.
- Improves chart readability and clinical utility.

Closes #735

Note: Please assign this PR to the `tmdeveloper007` account.