### PR TITLE
fix : added crypto.randomUUID() for nodeId generation in mesh-network.ts

### DIFF
--- a/src/lib/mesh-network.ts
+++ b/src/lib/mesh-network.ts
@@ -35,7 +35,7 @@ class MeshNetworkManager {
 
   constructor() {
     // Generate a unique node ID for this tab session
-    this.nodeId = "peer-" + Math.random().toString(36).substring(2, 9);
+    this.nodeId = crypto.randomUUID();
     this.isOfflineSimulated = localStorage.getItem("symptom_scribe_offline_sim") === "true";
 
     if (typeof window !== "undefined") {


### PR DESCRIPTION
Closes #747

## Summary of What Has Been Done

Replaced the low-entropy Math.random() based nodeId generation with crypto.randomUUID() in src/lib/mesh-network.ts.

## Changes Made

- src/lib/mesh-network.ts: Line 38 - replaced Math.random() with crypto.randomUUID() for nodeId generation

## Impact it Made

- Generates cryptographically secure, truly unique node identifiers
- Eliminates collision risk for peer IDs in the mesh network
- Aligns with the security standard already used in the same file

## Note: Please assign this PR to the `tmdeveloper007` account.