### PR TITLE
fix : replaced console.error with console.warn in alerts-engine.ts dismissAlert

### DIFF
--- a/src/lib/alerts-engine.ts
+++ b/src/lib/alerts-engine.ts
@@ -29,7 +29,7 @@ export function dismissAlert(alertId: string) {
       localStorage.setItem(DISMISSED_ALERTS_KEY, JSON.stringify(dismissed));
     }
   } catch (err) {
-    console.error("Failed to dismiss alert:", err);
+    console.warn("Failed to dismiss alert:", err);
   }
 }
 


### PR DESCRIPTION
Closes #748

## Summary of What Has Been Done

Replaced console.error with console.warn for the dismissAlert localStorage failure in src/lib/alerts-engine.ts. Alert dismissal is a non-critical UI operation - when it fails, the app continues to function normally. The console.error was overstating the severity.

## Changes Made

- src/lib/alerts-engine.ts: Line 32 - console.error replaced with console.warn in dismissAlert catch block

## Impact it Made

- Reduces noise in error monitoring for non-critical localStorage failures
- Reflects actual severity (alert dismissal failure does not affect app functionality)
- Consistent with the pattern applied elsewhere in the codebase

## Note: Please assign this PR to the `tmdeveloper007` account.