### PR TITLE
fix : replaced console.error with console.warn in useMetricsHistory.ts fetchHistory

### DIFF
--- a/src/hooks/useMetricsHistory.ts
+++ b/src/hooks/useMetricsHistory.ts
@@ -87,7 +87,7 @@ export function useMetricsHistory(userId: string | null) {
 
       setRecords(sortedRecords);
     } catch (err) {
-      console.error("Error loading local metrics:", err);
+      console.warn("Error loading local metrics:", err);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Closes #749

## Summary of What Has Been Done

Replaced console.error with console.warn for the local metrics load failure in src/hooks/useMetricsHistory.ts. This is a non-critical fallback operation - when local storage fails, the app continues to function. The console.error was overstating the severity.

## Changes Made

- src/hooks/useMetricsHistory.ts: Line 90 - console.error replaced with console.warn in fetchHistory catch block

## Impact it Made

- Reduces noise in error monitoring for non-critical fallback failures
- Reflects actual severity (graceful degradation, not application failure)
- Consistent with the existing pattern in the same file (line 62 already uses console.warn for a similar fallback)

## Note: Please assign this PR to the `tmdeveloper007` account.