### PR TITLE
fix : replaced console.error with console.warn in History/index.tsx fetchHistory

### DIFF
--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -224,7 +224,7 @@ const History = () => {
           setHistory(decryptedRecords as unknown as SymptomEntry[]);
         }
       } catch (err) {
-        console.error("Error loading local symptoms:", err);
+        console.warn("Error loading local symptoms:", err);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
Closes #750

## Summary of What Has Been Done

Replaced console.error with console.warn for the local symptom history load failure in src/pages/History/index.tsx. This is a non-critical local DB fallback failure - the app continues to function when this operation fails.

## Changes Made

- src/pages/History/index.tsx: Line 227 - console.error replaced with console.warn in fetchHistory catch block

## Impact it Made

- Reduces noise in error monitoring for non-critical local DB fallback failures
- Consistent with similar patterns applied in useMetricsHistory.ts and alerts-engine.ts
- Reflects actual severity: graceful degradation, not application failure

## Note: Please assign this PR to the `tmdeveloper007` account.