### PR TITLE
fix : replaced emoji characters with Lucide icons in MoodCalendarView

### DIFF
--- a/src/components/gamification/MoodCalendarView.tsx
+++ b/src/components/gamification/MoodCalendarView.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { CheckCircle2, AlertTriangle, Smile } from "lucide-react";
 
 interface MoodLog {
   logged_at: string;
@@ -77,7 +78,7 @@ export default function MoodCalendarView({ moodLogs, onLogMood }: Props) {
 
         {alreadyLoggedToday ? (
           <div className="flex items-center gap-3 p-4 rounded-lg bg-primary/10 border border-primary/20">
-            <span className="text-2xl">✅</span>
+            <CheckCircle2 className="w-5 h-5 text-primary" />
             <div>
               <p className="text-sm font-medium text-primary">Mood logged for today!</p>
               <p className="text-xs text-muted-foreground">Come back tomorrow to log again.</p>
@@ -104,13 +105,13 @@ export default function MoodCalendarView({ moodLogs, onLogMood }: Props) {
 
             {logStatus === "error" && (
               <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-sm text-destructive">
-                <span>⚠️</span>
+                <AlertTriangle className="w-4 h-4 shrink-0" />
                 <span>Could not save mood. Please try again.</span>
               </div>
             )}
             {logStatus === "success" && (
               <div className="flex items-center gap-2 p-3 rounded-lg bg-primary/10 border border-primary/20 text-sm text-primary">
-                <span>✅</span>
+                <CheckCircle2 className="w-4 h-4 shrink-0" />
                 <span>Mood logged successfully!</span>
               </div>
             )}
@@ -182,7 +183,8 @@ export default function MoodCalendarView({ moodLogs, onLogMood }: Props) {
           </div>
         ) : (
           <div className="text-center py-4 text-sm text-muted-foreground">
-            No moods logged yet — start by logging today's mood above! 😊
+            No moods logged yet — start by logging today&apos;s mood above!{" "}
+            <Smile className="inline-block w-4 h-4 align-middle text-yellow-500" />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced plain text emoji characters in `src/components/gamification/MoodCalendarView.tsx` with Lucide React icons for consistent UI.

## Changes Made

- Replaced `✅` (already-logged-today success state) with `<CheckCircle2 className="w-5 h-5 text-primary" />`
- Replaced `✅` (logging success state) with `<CheckCircle2 className="w-4 h-4 shrink-0" />`
- Replaced `⚠️` (error state) with `<AlertTriangle className="w-4 h-4 shrink-0" />`
- Replaced `😊` (empty state encouragement) with `<Smile className="inline-block w-4 h-4 align-middle text-yellow-500" />`

## Impact it Made

Consistent iconography throughout the gamification module. Lucide icons are SVG-based, accessible, and match the design system used in all other components in the codebase.

## Note: please assign this PR to the tmdeveloper007 account.

Closes #759