### PR TITLE
Fix PHI encryption for blood type field

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,7 @@ const App = () => {
                 const key = await whenEncryptionReady();
                 const encryptedFullName = await encryptProfileField(pendingProfile.full_name, key);
                 const encryptedDob = await encryptProfileField(pendingProfile.date_of_birth, key);
+                const encryptedBloodType = await encryptProfileField(pendingProfile.blood_type, key);
                 const encryptedEmergencyName = await encryptProfileField(pendingProfile.emergency_contact_name, key);
                 const encryptedEmergencyPhone = await encryptProfileField(pendingProfile.emergency_contact_phone, key);
                 const encryptedAllergies = await encryptProfileArray(pendingProfile.allergies, key);
@@ -89,7 +90,7 @@ const App = () => {
                     full_name: encryptedFullName,
                     date_of_birth: encryptedDob,
                     gender: pendingProfile.gender || null,
-                    blood_type: pendingProfile.blood_type || null,
+                    blood_type: encryptedBloodType,
                     allergies: encryptedAllergies,
                     chronic_conditions: encryptedChronicConditions,
                     emergency_contact_name: encryptedEmergencyName,

--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -59,6 +59,7 @@ const Profile = () => {
         const key = await whenEncryptionReady();
         const decryptedFullName = await decryptProfileField(data.full_name, key);
         const decryptedDob = await decryptProfileField(data.date_of_birth, key);
+        const decryptedBloodType = await decryptProfileField(data.blood_type, key);
         const decryptedEmergencyName = await decryptProfileField(data.emergency_contact_name, key);
         const decryptedEmergencyPhone = await decryptProfileField(data.emergency_contact_phone, key);
         const decryptedAllergies = await decryptProfileArray(data.allergies, key);
@@ -68,7 +69,7 @@ const Profile = () => {
           full_name: decryptedFullName,
           date_of_birth: decryptedDob,
           gender: data.gender || "",
-          blood_type: data.blood_type || "",
+          blood_type: decryptedBloodType,
           allergies: decryptedAllergies,
           chronic_conditions: decryptedChronicConditions,
           emergency_contact_name: decryptedEmergencyName,
@@ -163,6 +164,7 @@ if (!profile.blood_type) {
 
       const encryptedFullName = await encryptProfileField(profile.full_name, key);
       const encryptedDob = await encryptProfileField(profile.date_of_birth, key);
+      const encryptedBloodType = await encryptProfileField(profile.blood_type, key);
       const encryptedEmergencyName = await encryptProfileField(profile.emergency_contact_name, key);
       const encryptedEmergencyPhone = await encryptProfileField(profile.emergency_contact_phone, key);
       const encryptedAllergies = await encryptProfileArray(allergiesArray, key);
@@ -173,7 +175,7 @@ if (!profile.blood_type) {
         full_name: encryptedFullName,
         date_of_birth: encryptedDob,
         gender: profile.gender || null,
-        blood_type: profile.blood_type || null,
+        blood_type: encryptedBloodType,
         allergies: encryptedAllergies,
         chronic_conditions: encryptedChronicConditions,
         emergency_contact_name: encryptedEmergencyName,


### PR DESCRIPTION
Implement field-level encryption for blood type to ensure all sensitive health information is properly encrypted before storage.

Fixes #792

Applied AES-256-GCM encryption to blood_type field during profile creation and updates, matching the encryption already in place for other PHI fields. Blood type is now encrypted with the same user-derived key derived from authentication tokens.

Changes:
- Encrypt blood_type during profile creation in App.tsx  
- Decrypt blood_type when fetching and displaying profile
- Apply consistent encryption to profile updates in Profile page

Blood type is Protected Health Information (PHI) under HIPAA/GDPR. This change prevents plaintext storage of blood type alongside other encrypted PHI fields, reducing breach impact if database rows are exposed.

Co-authored contributions welcome for database migration strategy to retroactively encrypt existing plaintext blood type values.