### PR TITLE
fix: move auth session from localStorage to sessionStorage

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -52,7 +52,7 @@ const effectiveKey = supabasePublishableKey || (isTestEnv ? "placeholder-key" : 
 
 export const supabase = createClient<Database>(effectiveUrl, effectiveKey, {
   auth: {
-    storage: typeof window !== "undefined" ? localStorage : undefined,
+    storage: typeof window !== "undefined" ? sessionStorage : undefined,
     persistSession: true,
     autoRefreshToken: true,
   },


### PR DESCRIPTION
## What this does

Changed auth session storage from localStorage to sessionStorage for better security.

## Why

localStorage persists across browser sessions, increasing risk of token exposure. sessionStorage clears when the tab closes.

## Changes

- Changed \localStorage\ to \sessionStorage\ in the Supabase client configuration

## Contributor

**Abhinav Jha** ([@Youngmaster0304](https://github.com/Youngmaster0304)) | abhinavjha0304@gmail.com
**GSSoC 2026 Participant**