### PR TITLE
fix: replace browser alert() with toast notifications for metric validation

### DIFF
--- a/src/pages/Metrics/index.tsx
+++ b/src/pages/Metrics/index.tsx
@@ -247,7 +247,7 @@ const Metrics = () => {
     if (metricType === "heart_rate") {
       const hr = Number(value);
       if (hr < 30 || hr > 250) {
-        alert("Heart Rate must be between 30 and 250 BPM");
+        showError("Invalid Value", "Heart Rate must be between 30 and 250 BPM");
         return;
       }
     }
@@ -255,7 +255,7 @@ const Metrics = () => {
     if (metricType === "temperature") {
       const temp = Number(value);
       if (temp < 86 || temp > 113) {
-        alert("Temperature must be between 86°F and 113°F");
+        showError("Invalid Value", "Temperature must be between 86\u00B0F and 113\u00B0F");
         return;
       }
     }
@@ -263,7 +263,7 @@ const Metrics = () => {
     if (metricType === "weight") {
       const wt = Number(value);
       if (wt <= 0 || wt > 500) {
-        alert("Weight must be between 1 and 500 lbs");
+        showError("Invalid Value", "Weight must be between 1 and 500 lbs");
         return;
       }
     }
@@ -271,7 +271,7 @@ const Metrics = () => {
     if (metricType === "blood_sugar") {
       const sugar = Number(value);
       if (sugar < 20 || sugar > 1000) {
-        alert("Blood Sugar must be between 20 and 1000 mg/dL");
+        showError("Invalid Value", "Blood Sugar must be between 20 and 1000 mg/dL");
         return;
       }
     }
@@ -279,7 +279,7 @@ const Metrics = () => {
     if (metricType === "oxygen_saturation") {
       const oxygen = Number(value);
       if (oxygen < 70 || oxygen > 100) {
-        alert("Oxygen Saturation must be between 70% and 100%");
+        showError("Invalid Value", "Oxygen Saturation must be between 70% and 100%");
         return;
       }
     }
@@ -289,7 +289,7 @@ const Metrics = () => {
       const dia = Number(diastolic);
 
       if (sys < 50 || sys > 300 || dia < 30 || dia > 200) {
-        alert("Blood Pressure values are out of valid range");
+        showError("Invalid Value", "Blood Pressure values are out of valid range");
         return;
       }
     }


### PR DESCRIPTION
## What this does

Replaced browser \lert()\ with toast notifications for metric validation errors.

## Why

Browser alerts are intrusive and block the UI. Toast notifications provide a better user experience.

## Changes

- Replaced \lert()\ calls with \showError()\ toasts in \src/pages/Metrics/index.tsx\

## Contributor

**Abhinav Jha** ([@Youngmaster0304](https://github.com/Youngmaster0304)) | abhinavjha0304@gmail.com
**GSSoC 2026 Participant**