### PR TITLE
feat: add network status listener with auto-sync on reconnection

### DIFF
--- a/src/components/common/OfflineBanner.tsx
+++ b/src/components/common/OfflineBanner.tsx
@@ -1,0 +1,26 @@
+import { WifiOff, Loader2 } from "lucide-react";
+
+interface OfflineBannerProps {
+  isOnline: boolean;
+  isSyncing: boolean;
+}
+
+export function OfflineBanner({ isOnline, isSyncing }: OfflineBannerProps) {
+  if (isOnline && !isSyncing) return null;
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-lg shadow-lg border text-sm font-medium flex items-center gap-2 max-w-md">
+      {isSyncing ? (
+        <>
+          <Loader2 className="w-4 h-4 animate-spin text-primary" />
+          <span>Syncing your data...</span>
+        </>
+      ) : (
+        <>
+          <WifiOff className="w-4 h-4 text-orange-500" />
+          <span>You're offline. Changes will sync when reconnected.</span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,12 +2,17 @@ import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/layout/AppSidebar";
 import { AnimatedThemeToggler } from "@/components/theme/components/AnimatedThemeToggler";
 import { BackToTop } from "@/components/navigation/BackToTop";
+import { OfflineBanner } from "@/components/common/OfflineBanner";
+import { useNetworkStatus } from "@/hooks/use-network-status";
+import { syncOfflineData } from "@/lib/offline-db";
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 
 const Layout = ({ children }: LayoutProps) => {
+  const { isOnline, isSyncing } = useNetworkStatus(syncOfflineData);
+
   return (
     <SidebarProvider>
       <div className="min-h-screen overflow-hidden flex w-full max-w-full bg-background">
@@ -19,7 +24,7 @@ const Layout = ({ children }: LayoutProps) => {
             <div className="flex items-center gap-2">
               <AnimatedThemeToggler />
 
-              {/* ✅ Visible ONLY on mobile. Hidden on laptop/desktop. */}
+              {/* Visible ONLY on mobile. Hidden on laptop/desktop. */}
               <div className="md:hidden">
                 <SidebarTrigger />
               </div>
@@ -31,6 +36,7 @@ const Layout = ({ children }: LayoutProps) => {
           <BackToTop />
         </div>
       </div>
+      <OfflineBanner isOnline={isOnline} isSyncing={isSyncing} />
     </SidebarProvider>
   );
 };

--- a/src/hooks/use-network-status.ts
+++ b/src/hooks/use-network-status.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface NetworkStatus {
+  isOnline: boolean;
+  isSyncing: boolean;
+  pendingCount: number;
+  triggerSync: () => Promise<void>;
+}
+
+export function useNetworkStatus(syncFn?: () => Promise<void>): NetworkStatus {
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [pendingCount, setPendingCount] = useState(0);
+
+  const triggerSync = useCallback(async () => {
+    if (!syncFn || isSyncing || !navigator.onLine) return;
+    setIsSyncing(true);
+    try {
+      await syncFn();
+      setPendingCount(0);
+    } catch (err) {
+      console.error("Auto-sync failed:", err);
+    } finally {
+      setIsSyncing(false);
+    }
+  }, [syncFn, isSyncing]);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      setIsOnline(true);
+      triggerSync();
+    };
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, [triggerSync]);
+
+  return { isOnline, isSyncing, pendingCount, triggerSync };
+}


### PR DESCRIPTION
## What this does

Added network status listener with automatic data sync on reconnection.

## Why

Users had no indication when they were offline, and data wouldn't sync when connectivity returned.

## Changes

- Created \useNetworkStatus\ hook (\src/hooks/use-network-status.ts\)
- Created \OfflineBanner\ component (\src/components/common/OfflineBanner.tsx\)
- Integrated into Layout component (\src/components/layout/Layout.tsx\)

## Contributor

**Abhinav Jha** ([@Youngmaster0304](https://github.com/Youngmaster0304)) | abhinavjha0304@gmail.com
**GSSoC 2026 Participant**