### PR TITLE
fix: replace console.error with console.warn in ErrorBoundary

### DIFF
--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -35,10 +35,10 @@ class ErrorBoundary extends Component<Props, State> {
     // Replace with Sentry or your logging service in production
     if (process.env.NODE_ENV === "production") {
       // Sentry.captureException(error, { extra: errorInfo });
-      console.error("Production error logged:", error);
+      console.warn("Production error logged:", error);
     } else {
-      console.error("Application Error:", error);
-      console.error("Error Info:", errorInfo);
+      console.warn("Application Error:", error);
+      console.warn("Error Info:", errorInfo);
     }
   }
 


### PR DESCRIPTION
## **Pull Request Description**

Replaced all `console.error` calls with `console.warn` in the `ErrorBoundary` component to use an appropriate log severity for handled boundary errors.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
Fixes #768

---

### **3. How Has This Been Tested?**
- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**:
  1. Ran the application locally using `npm run dev`.
  2. Verified that the `ErrorBoundary` component now uses `console.warn` instead of `console.error`.

---

### **4. Visual Verification (If applicable)**

Not applicable. This change does not affect the UI.

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.