### PR TITLE
Add comprehensive security policy documenting credential protection

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Reporting Security Vulnerabilities
+
+If you discover a security vulnerability in symptom-scribe, please email security details to the project maintainers rather than using the public issue tracker. This allows us to address the vulnerability before it becomes public knowledge.
+
+## Environment Variables and Credentials
+
+IMPORTANT: Never commit `.env` or any files containing API keys, secrets, or credentials to version control.
+
+How we protect secrets:
+- `.env` is listed in `.gitignore` to prevent accidental commits
+- `.env.example` contains placeholder values showing which variables are needed
+- Developers copy `.env.example` to `.env.local` and fill in their own credentials
+
+What to do if credentials are accidentally committed:
+1. Immediately invalidate the exposed credentials (rotate keys in provider dashboard)
+2. Remove the file from git tracking: `git rm --cached .env`
+3. Add to `.gitignore` if not already present
+4. Commit the changes: `git commit -m 'Remove accidentally committed credentials'`
+5. Notify security team of the incident
+
+For comprehensive history purging of accidentally committed secrets, see git-filter-repo documentation at https://github.com/newren/git-filter-repo
+
+## Browser Application Security (VITE_*)
+
+The VITE_SUPABASE_PUBLISHABLE_KEY is intentionally exposed in the browser build. This is the public anon key and is designed for browser access.
+
+Security is enforced through:
+- Supabase Row Level Security (RLS) policies
+- Proper authentication and authorization checks
+- Rate limiting on API endpoints
+- Input validation and sanitization
+
+## Edge Function Secrets
+
+Never place service role keys or API tokens in `.env.local` or `.env`. These must be configured via:
+- Supabase Dashboard (Project Settings > Edge Functions > Secrets)
+- Command line: `supabase secrets set KEY_NAME=value`
+
+This prevents accidental exposure in browser bundles.
+
+## Credential Rotation
+
+Supabase credentials should be rotated periodically:
+1. Navigate to Supabase Dashboard > Project Settings > API
+2. Click "Regenerate" on any key
+3. Update your environment variables
+4. Redeploy application
+
+## Security Checklist for Contributors
+
+Before committing:
+- Never add `.env`, `.env.local`, or other secret files
+- Always use `.env.example` as the template
+- Don't hardcode API endpoints with credentials
+- Use environment variables for all secrets
+- Run `git status` to verify no secret files are staged
+
+## Incident History
+
+Initial commit (93fbbcf) contained exposed Supabase credentials in the .env file. These credentials have been invalidated. The .env file was removed from tracking in commit b6bfb80. Developers should be aware that cloning from commit 93fbbcf exposes the old (now invalidated) credentials from git history.


### PR DESCRIPTION
Closes #779

## Summary

Address the exposed .env credentials incident by documenting comprehensive security policies and credential management best practices for the project.

## Changes

- Add SECURITY.md with complete security policy
- Document environment variable protection strategy
- Provide credential rotation procedures
- Include security incident history and remediation
- Add security checklist for future contributors

## What This Fixes

Issue #779 documented that .env was committed to the initial commit with actual Supabase credentials. While the file has already been removed from tracking (commit b6bfb80) and credentials have been rotated, this PR formalizes the security practices to prevent future incidents.

## Remediation Already Completed

- Initial .env credentials (from commit 93fbbcf) have been invalidated
- .env file removed from git tracking (commit b6bfb80)
- .env added to .gitignore
- .env.example created with placeholder values

## This PR Adds

- SECURITY.md documenting:
  - How credentials are protected going forward
  - Why VITE_ variables are intentionally public (for browser use)
  - How to properly configure secrets
  - Credential rotation procedures
  - Security checklist for developers
  - What to do if secrets are accidentally exposed
  - Reference to git-filter-repo for comprehensive history cleanup

## Security Practices Documented

- Environment variables and .gitignore strategy
- Browser security (RLS policies, authentication, rate limiting)
- Edge Function secret management via Supabase dashboard
- Incident history and remediation timeline
- Clear contributor guidelines to prevent future exposures

## Notes for Maintainer

The exposed Supabase credentials from the initial commit are already invalidated. Future developers cloning from earlier commits should understand:
- Those credentials are no longer valid
- Current production uses rotated credentials
- The security.md file explains the incident and how we prevent recurrence
- All new deployments should rotate credentials as outlined in SECURITY.md