### PR TITLE
Refactor emergency contact handling in index.ts

### DIFF
--- a/supabase/functions/broadcast-emergency/index.ts
+++ b/supabase/functions/broadcast-emergency/index.ts
@@ -172,9 +172,11 @@ serve(async (req) => {
       );
     }
 
-    const rawContactPhone = bodyContactPhone || (profile ? profile.emergency_contact_phone : null);
-    const rawContactName = bodyContactName || (profile ? profile.emergency_contact_name : null);
-    const rawSenderName = bodySenderName || (profile ? profile.full_name : null) || "A user";
+    // FIX: use the values already destructured from the request body instead of
+    // the undefined bodyContactPhone / bodyContactName / bodySenderName / profile identifiers
+    const rawContactPhone = contact_phone ?? null;
+    const rawContactName = contact_name ?? null;
+    const rawSenderName = sender_name || "A user";
 
     if (!rawContactPhone) {
       return new Response(


### PR DESCRIPTION
## **Pull Request Description**
Fixes a critical bug where `broadcast-emergency` threw a `ReferenceError` on every single invocation, completely disabling the Emergency SOS SMS feature. The function referenced undefined identifiers (`bodyContactPhone`, `bodyContactName`, `bodySenderName`, `profile`) instead of the `contact_phone`, `contact_name`, and `sender_name` values already destructured from the request body.

Fixes #805 

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature**
- [ ] **Refactoring / Performance**
- [ ] **Documentation Update**
- [ ] **Other**: _________

---

### **3. How Has This Been Tested?**
- [x] **Local Build**: builds successfully (`npm run build`, `supabase functions serve` locally).
- [x] **Manual Verification**:
  1. Sent a fully valid, correctly signed emergency alert payload to `broadcast-emergency`.
  2. Confirmed the request no longer throws `ReferenceError: profile is not defined` and instead reaches the Twilio send step.
  3. Confirmed the response is `200` with `success: true` and a Twilio `sid` when Twilio credentials are configured.

**File changed:** `supabase/functions/broadcast-emergency/index.ts`

---

### **4. Visual Verification (If applicable)**
N/A — backend-only change, no UI affected.

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.