### PR TITLE
Create assigned-label.yml

### DIFF
--- a/.github/workflows/assigned-label.yml
+++ b/.github/workflows/assigned-label.yml
@@ -1,0 +1,58 @@
+name: Issue Assigned Labeler
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+
+  add-assigned-label:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      issues: write
+      
+    steps:
+      - name: Add 'assigned' label
+      
+        uses: actions/github-script@v7
+        
+        with:
+          script: |
+            const labelName = 'assigned';
+            
+            // 1. Check if label exists, create if missing
+            
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+              });
+
+              
+            } catch (error) {
+              if (error.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  
+                  name: labelName,
+                  color: '0e8a16',
+                  description: 'Indicates an issue has been assigned',
+                });
+                
+              }
+            }
+
+            // 2. Apply label to the assigned issue
+            
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [labelName],
+            });
+
+            


### PR DESCRIPTION
##  Description of Changes
Fixes #849 @mohdmaazgani 

- Added a dedicated standalone workflow (`.github/workflows/assign-label.yml`) using `actions/github-script@v7`.
- Automatically triggers whenever an issue receives an assignment (`types: [assigned]`).
- Dynamically checks if the `assigned` label exists in the repository—if not, creates it via GitHub's API.
- Applies the `assigned` label to the issue immediately upon assignment using ci/cd devops

##  How Has This Been Tested?
- [x] Verified GitHub Script syntax using local YAML linter.
- [x] Confirmed `types: [assigned]` handles both automated bot assignments and manual maintainer assignments.

##  Proof & Visuals
### Screenshots / Evidence:
<img width="1583" height="882" alt="Screenshot 2026-08-02 001212" src="https://github.com/user-attachments/assets/d1262c27-64b1-49a7-9d1c-0374b22d5115" />


##  Checklist
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

- **Program:** GSSoC '26
- **Requested Level:** intermediate

