### PR TITLE
feat: add empty states with CTAs for Dashboard, Metrics, and Chat His…

### DIFF
--- a/.github/workflows/assigned-label.yml
+++ b/.github/workflows/assigned-label.yml
@@ -1,0 +1,58 @@
+name: Issue Assigned Labeler
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+
+  add-assigned-label:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      issues: write
+      
+    steps:
+      - name: Add 'assigned' label
+      
+        uses: actions/github-script@v7
+        
+        with:
+          script: |
+            const labelName = 'assigned';
+            
+            // 1. Check if label exists, create if missing
+            
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+              });
+
+              
+            } catch (error) {
+              if (error.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  
+                  name: labelName,
+                  color: '0e8a16',
+                  description: 'Indicates an issue has been assigned',
+                });
+                
+              }
+            }
+
+            // 2. Apply label to the assigned issue
+            
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [labelName],
+            });
+
+            

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,82 @@
+name: "Stale Issue & PR Sweeper"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+    
+  workflow_dispatch:
+
+jobs:
+  stale:
+    name: Mark and Close Stale Issues & PRs
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Run Stale Action
+      
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Inactivity thresholds (14 days warning + 7 days close = 21 days total)
+          days-before-stale: 14
+          
+          days-before-close: 7
+
+          # Labels applied when stale
+          stale-issue-label: "stale"
+          
+          stale-pr-label: "stale"
+
+          # Remove stale label automatically if activity resumes
+          remove-stale-when-updated: true
+
+          # Warning comment posted on stale issues
+          
+          stale-issue-message: >
+            👋 This issue has had no activity for **14 days** and has been
+            marked as `stale`. If this is still relevant, please leave a
+            comment or push an update within the next **7 days**, otherwise
+            it will be closed automatically to keep the tracker clean.
+
+          # Warning comment posted on stale PRs
+          
+          stale-pr-message: >
+            👋 This pull request has had no activity for **14 days** and
+            has been marked as `stale`. If this is still being worked on,
+            please push a commit or leave a comment within the next **7 days**,
+            otherwise it will be closed automatically.
+
+          # Comment posted when a stale issue is closed
+          
+          close-issue-message: >
+            🔒 This issue has been automatically closed after 21 days of
+            inactivity. If still relevant, please open a new issue with
+            updated context. Thank you for contributing to symptom-scribe-clean !
+
+          # Comment posted when a stale PR is closed
+          
+          close-pr-message: >
+            🔒 This pull request has been automatically closed after 21 days
+            of inactivity. Please reopen or raise a fresh PR rebased on the
+            latest main branch if you would like to continue. Thank you!
+
+          # Exemptions (Never touch these)
+          
+          exempt-issue-labels: "pinned,security,critical,in-progress,blocked,help wanted,gssoc:approved"
+          exempt-pr-labels: "pinned,security,critical,in-progress,blocked,do-not-merge,gssoc:approved"
+
+
+          # Cap API calls per run to respect GitHub rate limits
+          operations-per-run: 100
+
+          # Process oldest items first
+          ascending: true
+
+
+
+          

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,267 @@
+# Architecture
+
+## 1. Overview
+
+Symptom Scribe is a health tracking and wellness SPA. Users log symptoms, track health metrics, chat with an AI health assistant, and earn gamification rewards. All personal health data is **client-side encrypted** before being stored in Supabase.
+
+---
+
+## 2. Technology Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | React 18 + TypeScript |
+| Build | Vite + SWC |
+| Styling | Tailwind CSS + Radix UI |
+| Routing | React Router v6 |
+| Server state | TanStack Query v5 |
+| Forms | React Hook Form + Zod |
+| Backend Platform | Supabase (Authentication, PostgreSQL, Edge Functions) |
+| Offline storage | Dexie (IndexedDB) |
+| Encryption | Web Crypto API (AES-GCM) |
+| i18n | i18next + react-i18next |
+| Testing | Vitest + Testing Library |
+| PWA | vite-plugin-pwa |
+
+---
+
+## 3. High-Level Architecture
+
+```
+Browser
+├── React SPA (Vite)
+│   ├── Pages / Components
+│   ├── TanStack Query (server state cache)
+│   ├── Dexie (offline IndexedDB)
+│   └── Web Crypto (client-side encryption)
+│
+
+└── Supabase
+    ├── Auth (email/password, magic link)
+    ├── Postgres + RLS
+    ├── Edge Functions (Deno)
+    │   ├── symptom-analyzer      ← AI analysis via external LLM
+    │   ├── broadcast-emergency
+    │   ├── get-cached-data
+    │   ├── invalidate-cache
+    │   ├── delete-account
+    │   └── delete-user-account
+    └── Redis (rate limiting via _shared/redis.ts)
+```
+
+The app has **no dedicated backend server**. All business logic runs either in the browser or in Supabase Edge Functions.
+
+---
+
+## 4. Architectural Principles
+
+The project emphasizes:
+
+- Separation of presentation and data access.
+- Reusable application logic through custom hooks and shared utilities.
+- Client-side encryption of sensitive information.
+- Offline-first support using IndexedDB.
+- Backend services provided through Supabase authentication, database, and Edge Functions.
+
+---
+
+## 5. Project Structure
+
+```text
+src/
+├── components/          # Reusable UI components organized by feature
+├── hooks/               # Custom React hooks for state management and data access
+├── integrations/
+│   └── supabase/        # Supabase client configuration and generated database types
+├── lib/                 # Shared utilities (encryption, offline sync, caching, helpers, i18n)
+├── pages/               # Route-level pages
+└── test/                # Shared testing utilities
+```
+
+### Key Responsibilities
+
+- **components/** contains reusable UI components grouped by feature.
+- **hooks/** encapsulates reusable logic for data fetching, state management, and interactions with Supabase.
+- **integrations/supabase/** centralizes Supabase client configuration and generated database types.
+- **lib/** contains shared utilities such as encryption, offline synchronization, caching, and helper functions.
+- **pages/** defines the application's route-level components.
+- **test/** provides shared utilities used across the test suite.
+
+> **Note:** The project currently does not use a dedicated global state management library. Data access is primarily coordinated through custom hooks and shared utility modules.
+
+---
+
+## 6. Frontend Architecture
+
+**State management**
+
+- No global state library. State is either:
+  - **Server state** — TanStack Query (fetching, caching, invalidation)
+  - **Local component state** — `useState` / `useReducer`
+- There is no React Context for auth state — `ProtectedRoute` manages session independently via `supabase.auth.getSession()` + `onAuthStateChange`
+
+**Routing**
+
+- React Router v6 with lazy-loaded pages via `React.lazy` + `Suspense`
+- Protected routes are wrapped with `<ProtectedRoute>` which redirects to `/auth` if no session exists
+- Public routes: `/`, `/auth`, `/reset-password`, `/blog`, `/health-library`, `/contact`, legal pages
+
+**Code splitting**
+
+Every page is lazy-loaded. The `LoadingScreen` spinner in `App.tsx` is the Suspense fallback.
+
+---
+
+## 7. Authentication Flow
+
+```
+User visits protected route
+        │
+        ▼
+ProtectedRoute
+├── supabase.auth.getSession()   ← checks existing session
+├── onAuthStateChange()          ← subscribes to session changes
+│
+
+├── loading → spinner
+├── error   → error UI with retry
+├── no session → <Navigate to="/auth" />
+└── session → render children
+
+On SIGNED_IN (App.tsx global listener)
+├── offline synchronization process            ← flush Dexie pending queue to Supabase
+└── if localStorage has pending profile:
+    ├── encrypt PII fields with user's CryptoKey
+    ├── supabase.from("profiles").upsert(...)
+    └── clear localStorage entry
+```
+
+**Encryption keys** are derived per-user from their Supabase JWT access token via `encryption initialization` in `App.tsx`. Keys are held in memory only — never persisted.
+
+---
+
+## 8. Supabase Integration
+
+**Database tables**
+
+| Table | Purpose |
+|---|---|
+| `profiles` | User PII (encrypted), blood type, emergency contact |
+| `symptom_history` | Logged symptoms + AI analysis results |
+| `health_metrics` | Typed metric entries (weight, BP, sleep, etc.) |
+| `chat_sessions` | AI chat history (messages stored as JSON) |
+
+All tables have **Row Level Security (RLS)** enforced. Every migration in `supabase/migrations/` should be reviewed before applying.
+
+**Edge Functions**
+
+| Function | Responsibility |
+|---|---|
+| `symptom-analyzer` | Validates input, checks for emergency symptoms, calls LLM, rate-limits per user |
+| `broadcast-emergency` | Sends emergency alerts |
+| `get-cached-data` | Returns cached table data (Redis-backed) |
+| `invalidate-cache` | Purges Redis cache for a given table |
+| `delete-account` / `delete-user-account` | Cascade-deletes all user data |
+
+**Caching Layer**
+
+The application includes a caching abstraction for frequently accessed data to reduce unnecessary database requests and improve performance.
+
+**Searchable Encrypted Data**
+
+Searchable encrypted fields are accompanied by derived search metadata, allowing limited search functionality without exposing plaintext values.
+
+---
+
+## 9. Data Flow
+
+**Online write**
+
+```
+Component → hook/lib → supabase.from(...) → Postgres (RLS enforced)
+                                          → caching layer
+```
+
+**Offline write**
+
+```
+Component → hook/lib → Dexie (offline queue)
+                     → on next SIGNED_IN / navigator.onLine
+                     → offline synchronization process
+                     → Supabase
+```
+
+**AI symptom analysis**
+
+```
+ChatInterface → symptom consultation utility → symptom-analyzer edge fn
+                                        ├── rate limit check (Redis)
+                                        ├── emergency symptom detection
+                                        ├── LLM call
+                                        └── response → stored in symptom_history
+```
+
+**Encrypted PII flow**
+
+```
+User input → encrypt sensitive value → encrypted string → Supabase
+                                                    → generate search metadata → _search_tokens column
+```
+
+---
+
+## 10. Feature Development Guide
+
+### Adding a New Page
+
+1. Create a page under `src/pages/`.
+2. Register the route in `App.tsx`.
+3. Wrap protected pages with `ProtectedRoute` when authentication is required.
+
+### Adding Persistent Data
+
+1. Create the required Supabase migration.
+2. Configure appropriate Row Level Security (RLS) policies.
+3. Regenerate the Supabase TypeScript types.
+4. Add data access through existing hooks or shared utility modules.
+5. Consider offline synchronization where applicable.
+
+### Working with Sensitive Data
+
+- Encrypt sensitive user information before storage.
+- Avoid exposing sensitive information in logs.
+- Follow the project's existing encryption workflow.
+
+### Extending Existing Features
+
+- Reuse existing hooks and shared utilities whenever possible.
+- Keep UI components focused on presentation.
+- Keep reusable logic outside UI components.
+
+---
+
+## 11. Best Practices
+
+### Security
+
+- Enable Row Level Security (RLS) for all new database tables.
+- Encrypt sensitive user information before storage.
+- Validate external input before processing it in Edge Functions.
+- Avoid exposing privileged Supabase APIs to the client.
+
+### Data Access
+
+- Reuse existing hooks and shared utility modules for database operations.
+- Keep Supabase interactions outside UI components whenever practical.
+- Use TanStack Query to keep cached server state synchronized after mutations.
+
+### Offline Support
+
+- Consider offline behavior when introducing new user-generated data.
+- Integrate new synchronization logic with the existing offline workflow.
+
+### Maintainability
+
+- Keep components focused on presentation.
+- Prefer reusable hooks and shared utilities over duplicated logic.
+- Update this document whenever architectural changes are introduced.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Reporting Security Vulnerabilities
+
+If you discover a security vulnerability in symptom-scribe, please email security details to the project maintainers rather than using the public issue tracker. This allows us to address the vulnerability before it becomes public knowledge.
+
+## Environment Variables and Credentials
+
+IMPORTANT: Never commit `.env` or any files containing API keys, secrets, or credentials to version control.
+
+How we protect secrets:
+- `.env` is listed in `.gitignore` to prevent accidental commits
+- `.env.example` contains placeholder values showing which variables are needed
+- Developers copy `.env.example` to `.env.local` and fill in their own credentials
+
+What to do if credentials are accidentally committed:
+1. Immediately invalidate the exposed credentials (rotate keys in provider dashboard)
+2. Remove the file from git tracking: `git rm --cached .env`
+3. Add to `.gitignore` if not already present
+4. Commit the changes: `git commit -m 'Remove accidentally committed credentials'`
+5. Notify security team of the incident
+
+For comprehensive history purging of accidentally committed secrets, see git-filter-repo documentation at https://github.com/newren/git-filter-repo
+
+## Browser Application Security (VITE_*)
+
+The VITE_SUPABASE_PUBLISHABLE_KEY is intentionally exposed in the browser build. This is the public anon key and is designed for browser access.
+
+Security is enforced through:
+- Supabase Row Level Security (RLS) policies
+- Proper authentication and authorization checks
+- Rate limiting on API endpoints
+- Input validation and sanitization
+
+## Edge Function Secrets
+
+Never place service role keys or API tokens in `.env.local` or `.env`. These must be configured via:
+- Supabase Dashboard (Project Settings > Edge Functions > Secrets)
+- Command line: `supabase secrets set KEY_NAME=value`
+
+This prevents accidental exposure in browser bundles.
+
+## Credential Rotation
+
+Supabase credentials should be rotated periodically:
+1. Navigate to Supabase Dashboard > Project Settings > API
+2. Click "Regenerate" on any key
+3. Update your environment variables
+4. Redeploy application
+
+## Security Checklist for Contributors
+
+Before committing:
+- Never add `.env`, `.env.local`, or other secret files
+- Always use `.env.example` as the template
+- Don't hardcode API endpoints with credentials
+- Use environment variables for all secrets
+- Run `git status` to verify no secret files are staged
+
+## Incident History
+
+Initial commit (93fbbcf) contained exposed Supabase credentials in the .env file. These credentials have been invalidated. The .env file was removed from tracking in commit b6bfb80. Developers should be aware that cloning from commit 93fbbcf exposes the old (now invalidated) credentials from git history.

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -1,0 +1,267 @@
+# Architecture
+
+## 1. Overview
+
+Symptom Scribe is a health tracking and wellness SPA. Users log symptoms, track health metrics, chat with an AI health assistant, and earn gamification rewards. All personal health data is **client-side encrypted** before being stored in Supabase.
+
+---
+
+## 2. Technology Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | React 18 + TypeScript |
+| Build | Vite + SWC |
+| Styling | Tailwind CSS + Radix UI |
+| Routing | React Router v6 |
+| Server state | TanStack Query v5 |
+| Forms | React Hook Form + Zod |
+| Backend Platform | Supabase (Authentication, PostgreSQL, Edge Functions) |
+| Offline storage | Dexie (IndexedDB) |
+| Encryption | Web Crypto API (AES-GCM) |
+| i18n | i18next + react-i18next |
+| Testing | Vitest + Testing Library |
+| PWA | vite-plugin-pwa |
+
+---
+
+## 3. High-Level Architecture
+
+```
+Browser
+├── React SPA (Vite)
+│   ├── Pages / Components
+│   ├── TanStack Query (server state cache)
+│   ├── Dexie (offline IndexedDB)
+│   └── Web Crypto (client-side encryption)
+│
+
+└── Supabase
+    ├── Auth (email/password, magic link)
+    ├── Postgres + RLS
+    ├── Edge Functions (Deno)
+    │   ├── symptom-analyzer      ← AI analysis via external LLM
+    │   ├── broadcast-emergency
+    │   ├── get-cached-data
+    │   ├── invalidate-cache
+    │   ├── delete-account
+    │   └── delete-user-account
+    └── Redis (rate limiting via _shared/redis.ts)
+```
+
+The app has **no dedicated backend server**. All business logic runs either in the browser or in Supabase Edge Functions.
+
+---
+
+## 4. Architectural Principles
+
+The project emphasizes:
+
+- Separation of presentation and data access.
+- Reusable application logic through custom hooks and shared utilities.
+- Client-side encryption of sensitive information.
+- Offline-first support using IndexedDB.
+- Backend services provided through Supabase authentication, database, and Edge Functions.
+
+---
+
+## 5. Project Structure
+
+```text
+src/
+├── components/          # Reusable UI components organized by feature
+├── hooks/               # Custom React hooks for state management and data access
+├── integrations/
+│   └── supabase/        # Supabase client configuration and generated database types
+├── lib/                 # Shared utilities (encryption, offline sync, caching, helpers, i18n)
+├── pages/               # Route-level pages
+└── test/                # Shared testing utilities
+```
+
+### Key Responsibilities
+
+- **components/** contains reusable UI components grouped by feature.
+- **hooks/** encapsulates reusable logic for data fetching, state management, and interactions with Supabase.
+- **integrations/supabase/** centralizes Supabase client configuration and generated database types.
+- **lib/** contains shared utilities such as encryption, offline synchronization, caching, and helper functions.
+- **pages/** defines the application's route-level components.
+- **test/** provides shared utilities used across the test suite.
+
+> **Note:** The project currently does not use a dedicated global state management library. Data access is primarily coordinated through custom hooks and shared utility modules.
+
+---
+
+## 6. Frontend Architecture
+
+**State management**
+
+- No global state library. State is either:
+  - **Server state** — TanStack Query (fetching, caching, invalidation)
+  - **Local component state** — `useState` / `useReducer`
+- There is no React Context for auth state — `ProtectedRoute` manages session independently via `supabase.auth.getSession()` + `onAuthStateChange`
+
+**Routing**
+
+- React Router v6 with lazy-loaded pages via `React.lazy` + `Suspense`
+- Protected routes are wrapped with `<ProtectedRoute>` which redirects to `/auth` if no session exists
+- Public routes: `/`, `/auth`, `/reset-password`, `/blog`, `/health-library`, `/contact`, legal pages
+
+**Code splitting**
+
+Every page is lazy-loaded. The `LoadingScreen` spinner in `App.tsx` is the Suspense fallback.
+
+---
+
+## 7. Authentication Flow
+
+```
+User visits protected route
+        │
+        ▼
+ProtectedRoute
+├── supabase.auth.getSession()   ← checks existing session
+├── onAuthStateChange()          ← subscribes to session changes
+│
+
+├── loading → spinner
+├── error   → error UI with retry
+├── no session → <Navigate to="/auth" />
+└── session → render children
+
+On SIGNED_IN (App.tsx global listener)
+├── offline synchronization process            ← flush Dexie pending queue to Supabase
+└── if localStorage has pending profile:
+    ├── encrypt PII fields with user's CryptoKey
+    ├── supabase.from("profiles").upsert(...)
+    └── clear localStorage entry
+```
+
+**Encryption keys** are derived per-user from their Supabase JWT access token via `encryption initialization` in `App.tsx`. Keys are held in memory only — never persisted.
+
+---
+
+## 8. Supabase Integration
+
+**Database tables**
+
+| Table | Purpose |
+|---|---|
+| `profiles` | User PII (encrypted), blood type, emergency contact |
+| `symptom_history` | Logged symptoms + AI analysis results |
+| `health_metrics` | Typed metric entries (weight, BP, sleep, etc.) |
+| `chat_sessions` | AI chat history (messages stored as JSON) |
+
+All tables have **Row Level Security (RLS)** enforced. Every migration in `supabase/migrations/` should be reviewed before applying.
+
+**Edge Functions**
+
+| Function | Responsibility |
+|---|---|
+| `symptom-analyzer` | Validates input, checks for emergency symptoms, calls LLM, rate-limits per user |
+| `broadcast-emergency` | Sends emergency alerts |
+| `get-cached-data` | Returns cached table data (Redis-backed) |
+| `invalidate-cache` | Purges Redis cache for a given table |
+| `delete-account` / `delete-user-account` | Cascade-deletes all user data |
+
+**Caching Layer**
+
+The application includes a caching abstraction for frequently accessed data to reduce unnecessary database requests and improve performance.
+
+**Searchable Encrypted Data**
+
+Searchable encrypted fields are accompanied by derived search metadata, allowing limited search functionality without exposing plaintext values.
+
+---
+
+## 9. Data Flow
+
+**Online write**
+
+```
+Component → hook/lib → supabase.from(...) → Postgres (RLS enforced)
+                                          → caching layer
+```
+
+**Offline write**
+
+```
+Component → hook/lib → Dexie (offline queue)
+                     → on next SIGNED_IN / navigator.onLine
+                     → offline synchronization process
+                     → Supabase
+```
+
+**AI symptom analysis**
+
+```
+ChatInterface → symptom consultation utility → symptom-analyzer edge fn
+                                        ├── rate limit check (Redis)
+                                        ├── emergency symptom detection
+                                        ├── LLM call
+                                        └── response → stored in symptom_history
+```
+
+**Encrypted PII flow**
+
+```
+User input → encrypt sensitive value → encrypted string → Supabase
+                                                    → generate search metadata → _search_tokens column
+```
+
+---
+
+## 10. Feature Development Guide
+
+### Adding a New Page
+
+1. Create a page under `src/pages/`.
+2. Register the route in `App.tsx`.
+3. Wrap protected pages with `ProtectedRoute` when authentication is required.
+
+### Adding Persistent Data
+
+1. Create the required Supabase migration.
+2. Configure appropriate Row Level Security (RLS) policies.
+3. Regenerate the Supabase TypeScript types.
+4. Add data access through existing hooks or shared utility modules.
+5. Consider offline synchronization where applicable.
+
+### Working with Sensitive Data
+
+- Encrypt sensitive user information before storage.
+- Avoid exposing sensitive information in logs.
+- Follow the project's existing encryption workflow.
+
+### Extending Existing Features
+
+- Reuse existing hooks and shared utilities whenever possible.
+- Keep UI components focused on presentation.
+- Keep reusable logic outside UI components.
+
+---
+
+## 11. Best Practices
+
+### Security
+
+- Enable Row Level Security (RLS) for all new database tables.
+- Encrypt sensitive user information before storage.
+- Validate external input before processing it in Edge Functions.
+- Avoid exposing privileged Supabase APIs to the client.
+
+### Data Access
+
+- Reuse existing hooks and shared utility modules for database operations.
+- Keep Supabase interactions outside UI components whenever practical.
+- Use TanStack Query to keep cached server state synchronized after mutations.
+
+### Offline Support
+
+- Consider offline behavior when introducing new user-generated data.
+- Integrate new synchronization logic with the existing offline workflow.
+
+### Maintainability
+
+- Keep components focused on presentation.
+- Prefer reusable hooks and shared utilities over duplicated logic.
+- Update this document whenever architectural changes are introduced.

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -12,12 +12,15 @@ import {
   Thermometer,
   Brain,
   HeartPulse,
+  MessageSquarePlus,
 } from "lucide-react";
 import ChatMessage from "./ChatMessage";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { browserEnv } from "@/lib/env";
 import { showSuccess, showError, showInfo, showLoading, showWarning } from "@/lib/toast-helpers";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/common/EmptyState";
 import { invalidateCache } from "@/lib/cached-queries";
 import { whenKeysReady } from "@/lib/encryption";
 import { encryptSymptom, db, type OfflineSymptom } from "@/lib/offline-db";
@@ -402,22 +405,38 @@ const ChatInterface = () => {
   const isWelcomeState = messages.length === 1 && messages[0] === INITIAL_GREETING;
 
   const renderHistoryList = () => {
-    if (sessionsLoading) {
-      return (
-        <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
-          <Loader2 className="w-4 h-4 animate-spin mr-2" />
-          Loading history...
-        </div>
-      );
-    }
+  if (sessionsLoading) {
+    return (
+      <div className="space-y-2 p-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 rounded-lg border border-border/60 px-3 py-2.5"
+          >
+            <Skeleton className="h-4 w-4 rounded-full shrink-0" />
+            <Skeleton className="h-4 flex-1 rounded" />
+          </div>
+        ))}
+      </div>
+    );
+  }
 
-    if (sessions.length === 0) {
-      return (
-        <div className="text-center py-8 text-sm text-muted-foreground px-4">
-          No previous sessions found. Start a conversation to save one!
-        </div>
-      );
-    }
+  if (sessions.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <MessageSquarePlus
+            className="w-8 h-8 text-teal-600 dark:text-teal-400"
+            strokeWidth={1.5}
+          />
+        }
+        title="Start a new conversation"
+        description="Your saved chat sessions will appear here once you begin talking with the AI assistant."
+        ctaText="New Chat"
+        onCtaClick={handleNewChat}
+      />
+    );
+  }
 
     return (
       <div className="space-y-1 p-2 overflow-y-auto flex-1 select-none chat-scrollbar">

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -439,7 +439,7 @@ const ChatInterface = () => {
   }
 
     return (
-      <div className="space-y-1 p-2 overflow-y-auto flex-1 select-none chat-scrollbar">
+       <div className="space-y-1 p-2 overflow-y-auto flex-1 select-none chat-scrollbar animate-fade-in">
         {sessions.map((session) => {
           const isActive = session.id === activeSessionId;
           return (

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface EmptyStateProps {
+  icon: ReactNode;
+  title: string;
+  description?: string;
+  ctaText?: string;
+  onCtaClick?: () => void;
+  className?: string;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  ctaText,
+  onCtaClick,
+  className = "",
+}: EmptyStateProps) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center text-center py-12 px-4 gap-4 animate-in fade-in duration-300 ${className}`}
+    >
+      <div className="flex items-center justify-center w-16 h-16 rounded-full bg-teal-50 dark:bg-teal-950">
+        {icon}
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+        {description && (
+          <p className="text-sm text-muted-foreground max-w-xs">{description}</p>
+        )}
+      </div>
+      {ctaText && onCtaClick && (
+        <Button
+          onClick={onCtaClick}
+          className="bg-teal-600 hover:bg-teal-700 text-white mt-2"
+        >
+          {ctaText}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/gamification/MoodCalendarView.tsx
+++ b/src/components/gamification/MoodCalendarView.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { CheckCircle2, AlertTriangle, Smile } from "lucide-react";
 
 interface MoodLog {
   logged_at: string;
@@ -77,7 +78,7 @@ export default function MoodCalendarView({ moodLogs, onLogMood }: Props) {
 
         {alreadyLoggedToday ? (
           <div className="flex items-center gap-3 p-4 rounded-lg bg-primary/10 border border-primary/20">
-            <span className="text-2xl">✅</span>
+            <CheckCircle2 className="w-5 h-5 text-primary" />
             <div>
               <p className="text-sm font-medium text-primary">Mood logged for today!</p>
               <p className="text-xs text-muted-foreground">Come back tomorrow to log again.</p>
@@ -104,13 +105,13 @@ export default function MoodCalendarView({ moodLogs, onLogMood }: Props) {
 
             {logStatus === "error" && (
               <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-sm text-destructive">
-                <span>⚠️</span>
+                <AlertTriangle className="w-4 h-4 shrink-0" />
                 <span>Could not save mood. Please try again.</span>
               </div>
             )}
             {logStatus === "success" && (
               <div className="flex items-center gap-2 p-3 rounded-lg bg-primary/10 border border-primary/20 text-sm text-primary">
-                <span>✅</span>
+                <CheckCircle2 className="w-4 h-4 shrink-0" />
                 <span>Mood logged successfully!</span>
               </div>
             )}
@@ -182,7 +183,8 @@ export default function MoodCalendarView({ moodLogs, onLogMood }: Props) {
           </div>
         ) : (
           <div className="text-center py-4 text-sm text-muted-foreground">
-            No moods logged yet — start by logging today's mood above! 😊
+            No moods logged yet — start by logging today&apos;s mood above!{" "}
+            <Smile className="inline-block w-4 h-4 align-middle text-yellow-500" />
           </div>
         )}
       </div>

--- a/src/components/history/SymptomCalendarView.tsx
+++ b/src/components/history/SymptomCalendarView.tsx
@@ -1,0 +1,635 @@
+import { useState, useMemo } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Calendar as CalendarIcon,
+  CheckCircle,
+  X,
+  Trash2,
+  Filter,
+  Search,
+  RotateCcw,
+} from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
+export interface SymptomEntry {
+  id: string;
+  user_id?: string;
+  symptoms: string;
+  severity_level: string;
+  possible_causes: string[];
+  recommendations: string[];
+  risk_score: number;
+  resolved: boolean;
+  created_at: string;
+  ai_analysis?: string;
+}
+
+interface SymptomCalendarViewProps {
+  history: SymptomEntry[];
+  onToggleResolved: (id: string, currentStatus: boolean) => Promise<void>;
+  onDeleteEntry: (id: string) => Promise<void>;
+}
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+const DAYS_OF_WEEK = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+// Helper to format Date to YYYY-MM-DD local string
+const toLocalDateString = (d: Date) => {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const SymptomCalendarView = ({
+  history,
+  onToggleResolved,
+  onDeleteEntry,
+}: SymptomCalendarViewProps) => {
+  const today = new Date();
+  const [currentDate, setCurrentDate] = useState<Date>(
+    new Date(today.getFullYear(), today.getMonth(), 1)
+  );
+  const [selectedDateStr, setSelectedDateStr] = useState<string>(toLocalDateString(today));
+  const [severityFilter, setSeverityFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [searchQuery, setSearchQuery] = useState<string>("");
+
+  const currentYear = currentDate.getFullYear();
+  const currentMonth = currentDate.getMonth();
+
+  // Filter history entries based on severity, status, search query
+  const filteredEntries = useMemo(() => {
+    return history.filter((entry) => {
+      // Severity filter
+      if (severityFilter !== "all" && entry.severity_level.toLowerCase() !== severityFilter) {
+        return false;
+      }
+      // Status filter
+      if (statusFilter === "active" && entry.resolved) return false;
+      if (statusFilter === "resolved" && !entry.resolved) return false;
+      // Search query
+      if (searchQuery.trim() !== "") {
+        const query = searchQuery.toLowerCase();
+        const matchesSymptoms = entry.symptoms.toLowerCase().includes(query);
+        const matchesCauses = entry.possible_causes?.some((c) => c.toLowerCase().includes(query));
+        if (!matchesSymptoms && !matchesCauses) return false;
+      }
+      return true;
+    });
+  }, [history, severityFilter, statusFilter, searchQuery]);
+
+  // Group filtered entries by date string YYYY-MM-DD
+  const entriesByDate = useMemo(() => {
+    const map: Record<string, SymptomEntry[]> = {};
+    filteredEntries.forEach((entry) => {
+      const dateObj = new Date(entry.created_at);
+      if (!isNaN(dateObj.getTime())) {
+        const dateKey = toLocalDateString(dateObj);
+        if (!map[dateKey]) {
+          map[dateKey] = [];
+        }
+        map[dateKey].push(entry);
+      }
+    });
+    return map;
+  }, [filteredEntries]);
+
+  // Navigation handlers
+  const handlePrevMonth = () => {
+    setCurrentDate(new Date(currentYear, currentMonth - 1, 1));
+  };
+
+  const handleNextMonth = () => {
+    setCurrentDate(new Date(currentYear, currentMonth + 1, 1));
+  };
+
+  const handleToday = () => {
+    const now = new Date();
+    setCurrentDate(new Date(now.getFullYear(), now.getMonth(), 1));
+    setSelectedDateStr(toLocalDateString(now));
+  };
+
+  const handleMonthChange = (monthIdx: number) => {
+    setCurrentDate(new Date(currentYear, monthIdx, 1));
+  };
+
+  const handleYearChange = (year: number) => {
+    setCurrentDate(new Date(year, currentMonth, 1));
+  };
+
+  // Calendar Grid calculations
+  const calendarDays = useMemo(() => {
+    const firstDayOfMonth = new Date(currentYear, currentMonth, 1);
+    const startingDayOfWeek = firstDayOfMonth.getDay();
+    const totalDaysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
+
+    // Previous month padding days
+    const prevMonthDaysCount = startingDayOfWeek;
+    const prevMonthLastDate = new Date(currentYear, currentMonth, 0).getDate();
+    const days: Array<{ date: Date; isCurrentMonth: boolean; dateStr: string }> = [];
+
+    for (let i = prevMonthDaysCount - 1; i >= 0; i--) {
+      const d = new Date(currentYear, currentMonth - 1, prevMonthLastDate - i);
+      days.push({
+        date: d,
+        isCurrentMonth: false,
+        dateStr: toLocalDateString(d),
+      });
+    }
+
+    // Current month days
+    for (let day = 1; day <= totalDaysInMonth; day++) {
+      const d = new Date(currentYear, currentMonth, day);
+      days.push({
+        date: d,
+        isCurrentMonth: true,
+        dateStr: toLocalDateString(d),
+      });
+    }
+
+    // Next month padding days to complete grid (multiples of 7)
+    const remainingDays = (7 - (days.length % 7)) % 7;
+    for (let i = 1; i <= remainingDays; i++) {
+      const d = new Date(currentYear, currentMonth + 1, i);
+      days.push({
+        date: d,
+        isCurrentMonth: false,
+        dateStr: toLocalDateString(d),
+      });
+    }
+
+    return days;
+  }, [currentYear, currentMonth]);
+
+  // Determine severity styling
+  const getSeverityBadgeVariant = (severity: string): "destructive" | "default" | "secondary" => {
+    switch (severity?.toLowerCase()) {
+      case "high":
+        return "destructive";
+      case "moderate":
+        return "default";
+      default:
+        return "secondary";
+    }
+  };
+
+  const getHighestSeverity = (entries: SymptomEntry[]): string => {
+    if (entries.some((e) => e.severity_level?.toLowerCase() === "high")) return "high";
+    if (entries.some((e) => e.severity_level?.toLowerCase() === "moderate")) return "moderate";
+    return "low";
+  };
+
+  const getSeverityColorClasses = (severity: string) => {
+    switch (severity) {
+      case "high":
+        return "bg-red-500 text-white dark:bg-red-600";
+      case "moderate":
+        return "bg-amber-500 text-white dark:bg-amber-600";
+      default:
+        return "bg-teal-500 text-white dark:bg-teal-600";
+    }
+  };
+
+  const getSeverityBorderColor = (severity: string) => {
+    switch (severity) {
+      case "high":
+        return "border-red-500/60 bg-red-500/10";
+      case "moderate":
+        return "border-amber-500/60 bg-amber-500/10";
+      default:
+        return "border-teal-500/60 bg-teal-500/10";
+    }
+  };
+
+  // Selected date entries
+  const selectedDateEntries = entriesByDate[selectedDateStr] || [];
+  const todayStr = toLocalDateString(today);
+
+  // Generate Year options around current year
+  const yearOptions = Array.from({ length: 11 }, (_, i) => currentYear - 5 + i);
+
+  return (
+    <div className="space-y-6">
+      {/* Calendar Controls & Filters Header */}
+      <Card className="border shadow-sm">
+        <CardContent className="p-4 space-y-4">
+          <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+            {/* Month & Year Navigation */}
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={handlePrevMonth}
+                title="Previous Month"
+                aria-label="Previous Month"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+
+              <h2 className="text-xl font-semibold text-foreground min-w-[160px] text-center">
+                {MONTH_NAMES[currentMonth]} {currentYear}
+              </h2>
+
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={handleNextMonth}
+                aria-label="Next Month"
+                title="Next Month"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+
+              <Button variant="secondary" size="sm" onClick={handleToday} className="ml-2">
+                Today
+              </Button>
+            </div>
+
+            {/* Jump to Date / Select Month & Year */}
+            <div className="flex flex-wrap items-center gap-2 w-full md:w-auto">
+              <span className="text-xs font-medium text-muted-foreground">Jump to:</span>
+              <select
+                aria-label="Select month"
+                value={currentMonth}
+                onChange={(e) => handleMonthChange(Number(e.target.value))}
+                className="px-2 py-1.5 rounded-md border border-input bg-background text-xs font-medium focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                {MONTH_NAMES.map((month, idx) => (
+                  <option key={month} value={idx}>
+                    {month}
+                  </option>
+                ))}
+              </select>
+
+              <select
+                aria-label="Select year"
+                value={currentYear}
+                onChange={(e) => handleYearChange(Number(e.target.value))}
+                className="px-2 py-1.5 rounded-md border border-input bg-background text-xs font-medium focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                {yearOptions.map((year) => (
+                  <option key={year} value={year}>
+                    {year}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Filters Bar */}
+          <div className="pt-2 border-t flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+              <input
+                type="text"
+                placeholder="Search entries in calendar..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full pl-8 pr-3 py-1.5 text-xs rounded-md border border-input bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Filter className="h-3.5 w-3.5 text-muted-foreground hidden sm:block" />
+
+              <select
+                aria-label="Severity filter"
+                value={severityFilter}
+                onChange={(e) => setSeverityFilter(e.target.value)}
+                className="px-2 py-1.5 rounded-md border border-input bg-background text-xs font-medium focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                <option value="all">All Severities</option>
+                <option value="high">High Severity</option>
+                <option value="moderate">Moderate Severity</option>
+                <option value="low">Low Severity</option>
+              </select>
+
+              <select
+                aria-label="Status filter"
+                value={statusFilter}
+                onChange={(e) => setStatusFilter(e.target.value)}
+                className="px-2 py-1.5 rounded-md border border-input bg-background text-xs font-medium focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                <option value="all">All Statuses</option>
+                <option value="active">Active Only</option>
+                <option value="resolved">Resolved Only</option>
+              </select>
+
+              {(severityFilter !== "all" || statusFilter !== "all" || searchQuery !== "") && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setSeverityFilter("all");
+                    setStatusFilter("all");
+                    setSearchQuery("");
+                  }}
+                  className="h-8 px-2 text-xs gap-1"
+                >
+                  <RotateCcw className="h-3 w-3" /> Reset
+                </Button>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Main Grid & Preview Section */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Calendar Grid Container */}
+        <Card className="lg:col-span-2 shadow-sm">
+          <CardHeader className="pb-3 border-b">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <CardTitle className="text-base font-semibold flex items-center gap-2">
+                <CalendarIcon className="h-4 w-4 text-teal-600 dark:text-teal-400" />
+                Monthly Overview
+              </CardTitle>
+
+              {/* Color-Coded Severity Legend */}
+              <div className="flex items-center gap-3 text-xs">
+                <span className="text-muted-foreground">Severity:</span>
+                <span className="flex items-center gap-1">
+                  <span className="w-2.5 h-2.5 rounded-full bg-red-500 inline-block" /> High
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="w-2.5 h-2.5 rounded-full bg-amber-500 inline-block" /> Moderate
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="w-2.5 h-2.5 rounded-full bg-teal-500 inline-block" /> Low
+                </span>
+              </div>
+            </div>
+          </CardHeader>
+
+          <CardContent className="p-4">
+            {/* Days of week header */}
+            <div className="grid grid-cols-7 gap-1 text-center font-medium text-xs text-muted-foreground mb-2">
+              {DAYS_OF_WEEK.map((day) => (
+                <div key={day} className="py-1.5">
+                  {day}
+                </div>
+              ))}
+            </div>
+
+            {/* Calendar Day Grid */}
+            <div className="grid grid-cols-7 gap-1.5">
+              {calendarDays.map(({ date, isCurrentMonth, dateStr }) => {
+                const dayEntries = entriesByDate[dateStr] || [];
+                const hasEntries = dayEntries.length > 0;
+                const isSelected = dateStr === selectedDateStr;
+                const isToday = dateStr === todayStr;
+                const highestSev = hasEntries ? getHighestSeverity(dayEntries) : null;
+
+                return (
+                  <button
+                    key={dateStr}
+                    onClick={() => setSelectedDateStr(dateStr)}
+                    className={`
+                      min-h-[72px] sm:min-h-[80px] p-1.5 rounded-lg border text-left transition-all relative flex flex-col justify-between
+                      ${!isCurrentMonth ? "opacity-35 bg-muted/20" : "bg-card hover:bg-accent/40"}
+                      ${isSelected ? "ring-2 ring-teal-600 dark:ring-teal-400 border-transparent shadow-sm" : ""}
+                      ${isToday ? "border-teal-500/80 font-bold" : "border-border"}
+                      ${hasEntries && highestSev ? getSeverityBorderColor(highestSev) : ""}
+                    `}
+                  >
+                    {/* Day number & Today Badge */}
+                    <div className="flex items-center justify-between w-full">
+                      <span
+                        className={`text-xs rounded-full w-5 h-5 flex items-center justify-center ${
+                          isToday
+                            ? "bg-teal-600 text-white font-bold"
+                            : isSelected
+                              ? "font-bold text-teal-600 dark:text-teal-400"
+                              : "text-foreground"
+                        }`}
+                      >
+                        {date.getDate()}
+                      </span>
+
+                      {hasEntries && (
+                        <span
+                          className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${
+                            highestSev
+                              ? getSeverityColorClasses(highestSev)
+                              : "bg-primary text-white"
+                          }`}
+                        >
+                          {dayEntries.length}
+                        </span>
+                      )}
+                    </div>
+
+                    {/* Daily Entry Indicators */}
+                    {hasEntries && (
+                      <div className="mt-1 space-y-1 w-full overflow-hidden">
+                        <div className="flex flex-wrap gap-1 items-center">
+                          {dayEntries.slice(0, 2).map((e) => (
+                            <span
+                              key={e.id}
+                              className={`w-1.5 h-1.5 rounded-full inline-block ${getSeverityColorClasses(
+                                e.severity_level?.toLowerCase()
+                              )}`}
+                              title={`${e.symptoms} (${e.severity_level})`}
+                            />
+                          ))}
+                          {dayEntries.length > 2 && (
+                            <span className="text-[9px] text-muted-foreground font-medium">
+                              +{dayEntries.length - 2}
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-[10px] text-muted-foreground truncate hidden sm:block">
+                          {dayEntries[0].symptoms}
+                        </p>
+                      </div>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Quick Entry Preview Side Panel */}
+        <Card className="shadow-sm border">
+          <CardHeader className="pb-3 border-b">
+            <CardTitle className="text-base font-semibold">Quick Entry Preview</CardTitle>
+            <CardDescription className="text-xs">
+              {new Date(selectedDateStr + "T00:00:00").toLocaleDateString(undefined, {
+                weekday: "long",
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent className="p-4 space-y-4 max-h-[600px] overflow-y-auto">
+            {selectedDateEntries.length === 0 ? (
+              <div className="py-12 text-center space-y-2">
+                <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mx-auto text-muted-foreground">
+                  <CalendarIcon className="h-6 w-6" />
+                </div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  No symptom entries logged for this date.
+                </p>
+                <p className="text-xs text-muted-foreground/80 max-w-[220px] mx-auto">
+                  Select another day on the calendar to view logged health consultations.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <p className="text-xs font-semibold text-muted-foreground">
+                  {selectedDateEntries.length}{" "}
+                  {selectedDateEntries.length === 1 ? "Entry" : "Entries"} Found
+                </p>
+
+                {selectedDateEntries.map((entry) => (
+                  <Card
+                    key={entry.id}
+                    className={`border ${entry.resolved ? "opacity-75 bg-muted/10" : ""}`}
+                  >
+                    <CardHeader className="p-3 pb-2 space-y-2">
+                      <div className="flex items-start justify-between gap-2">
+                        <h4 className="text-sm font-bold text-foreground break-words">
+                          {entry.symptoms}
+                        </h4>
+                        <Badge variant={getSeverityBadgeVariant(entry.severity_level)}>
+                          {entry.severity_level}
+                        </Badge>
+                      </div>
+
+                      <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                        <span>
+                          {new Date(entry.created_at).toLocaleTimeString([], {
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          })}
+                        </span>
+                        {entry.risk_score !== null && (
+                          <Badge variant="outline" className="text-[10px] py-0">
+                            Risk: {entry.risk_score}/100
+                          </Badge>
+                        )}
+                      </div>
+                    </CardHeader>
+
+                    <CardContent className="p-3 pt-0 space-y-2 text-xs">
+                      {entry.possible_causes && entry.possible_causes.length > 0 && (
+                        <div>
+                          <span className="font-semibold text-foreground">Possible Causes:</span>
+                          <ul className="list-disc list-inside text-muted-foreground pl-1 mt-0.5 space-y-0.5">
+                            {entry.possible_causes.map((c, i) => (
+                              <li key={i} className="truncate">
+                                {c}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+
+                      {entry.recommendations && entry.recommendations.length > 0 && (
+                        <div>
+                          <span className="font-semibold text-foreground">Recommendations:</span>
+                          <ul className="list-disc list-inside text-muted-foreground pl-1 mt-0.5 space-y-0.5">
+                            {entry.recommendations.map((r, i) => (
+                              <li key={i} className="truncate">
+                                {r}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+
+                      {/* Card Actions: Resolve & Delete */}
+                      <div className="pt-2 border-t flex items-center justify-between gap-2">
+                        <Button
+                          variant={entry.resolved ? "outline" : "default"}
+                          size="sm"
+                          onClick={() => onToggleResolved(entry.id, entry.resolved)}
+                          className="h-7 text-xs px-2"
+                        >
+                          {entry.resolved ? (
+                            <>
+                              <X className="w-3 h-3 mr-1" /> Reopen
+                            </>
+                          ) : (
+                            <>
+                              <CheckCircle className="w-3 h-3 mr-1" /> Resolve
+                            </>
+                          )}
+                        </Button>
+
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                              title="Delete record"
+                            >
+                              <Trash2 className="w-3.5 h-3.5" />
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>Delete Symptom Entry?</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                Are you sure you want to delete this entry logged on{" "}
+                                {new Date(entry.created_at).toLocaleDateString()}?
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => onDeleteEntry(entry.id)}
+                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                              >
+                                Delete
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default SymptomCalendarView;

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -11,9 +11,15 @@ import {
   Settings,
   Bot,
   Trophy,
+  Palette,
+  PanelLeftClose,
+  Check,
 } from "lucide-react";
 
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTheme } from "next-themes";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -55,12 +61,55 @@ const menuItems = [
   { title: "Settings", url: "/settings", icon: Settings },
 ];
 
+const themeOptions = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "cosmic", label: "Cosmic" },
+  { value: "deep-blue", label: "Deep Blue" },
+  { value: "forest", label: "Forest" },
+  { value: "orange", label: "Orange" },
+  { value: "pastel-pink", label: "Pastel Pink" },
+];
+
 export function AppSidebar() {
   const { state, setOpenMobile, isMobile } = useSidebar();
   const location = useLocation();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [themesOpen, setThemesOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
   const isCollapsed = state === "collapsed";
+  const themePopupRef = useRef<HTMLDivElement>(null);
+  const themeTriggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // ✅ Close the theme popup when clicking outside of it (but not when clicking the trigger, which toggles it itself)
+  useEffect(() => {
+    if (!themesOpen) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node;
+      if (
+        themePopupRef.current &&
+        !themePopupRef.current.contains(target) &&
+        themeTriggerRef.current &&
+        !themeTriggerRef.current.contains(target)
+      ) {
+        setThemesOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [themesOpen]);
+
+  const activeTheme = mounted ? (resolvedTheme ?? theme ?? "light") : "light";
 
   const handleMobileNavClick = () => {
     if (isMobile) {
@@ -122,9 +171,6 @@ export function AppSidebar() {
             {/* ✨ updated: small gap between rows so the tinted active state has breathing room */}
             <SidebarMenu className="px-1">
               {menuItems.map((item) => {
-                // Existing hover/animation is preserved verbatim; the active-tab
-                // styling (tinted pill + left accent border) is only appended for
-                // the current route.
                 const isActive = location.pathname === item.url;
                 return (
                   <SidebarMenuItem key={item.title}>
@@ -144,6 +190,23 @@ export function AppSidebar() {
                   </SidebarMenuItem>
                 );
               })}
+
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  ref={themeTriggerRef}
+                  onClick={() => setThemesOpen((prev) => !prev)}
+                  className="py-2 transition-all duration-300 ease-in-out hover:scale-[1.03] hover:-translate-y-1 hover:shadow-md"
+                  aria-label="Themes"
+                >
+                  <Palette className="h-[17px] w-[17px]" />
+                  {!isCollapsed && <span className="text-[13.5px]">Themes</span>}
+                  {!isCollapsed && (
+                    <span className="ml-auto text-muted-foreground">
+                      <PanelLeftClose className="h-4 w-4" />
+                    </span>
+                  )}
+                </SidebarMenuButton>
+              </SidebarMenuItem>
               <AlertDialog>
                 <AlertDialogTrigger asChild>
                   {/* ✨ updated: matching rounded-md + transition-colors for consistency with nav items */}
@@ -177,6 +240,42 @@ export function AppSidebar() {
       <SidebarFooter className="px-1 border-t border-sidebar-border/20 pt-2">
         <EmergencyQuickAccess />
       </SidebarFooter>
+      {!isCollapsed &&
+        themesOpen &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            ref={themePopupRef}
+            className="fixed top-[5.5rem] z-[999] hidden h-auto w-56 rounded-2xl border border-border bg-popover p-3 shadow-lg md:block"
+            style={{ left: 272 }}
+          >
+            <div className="mb-3 px-1 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+              Themes
+            </div>
+            <div className="flex flex-col gap-1.5">
+              {themeOptions.map((option) => {
+                const isActive = activeTheme === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setTheme(option.value)}
+                    className={`flex items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition-colors ${
+                      isActive
+                        ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium"
+                        : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                    }`}
+                    aria-label={option.label}
+                  >
+                    <span>{option.label}</span>
+                    {isActive ? <Check className="h-4 w-4" /> : null}
+                  </button>
+                );
+              })}
+            </div>
+          </div>,
+          document.body
+        )}
     </Sidebar>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,5 @@
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/layout/AppSidebar";
-import { AnimatedThemeToggler } from "@/components/theme/components/AnimatedThemeToggler";
 import { BackToTop } from "@/components/navigation/BackToTop";
 
 interface LayoutProps {
@@ -13,16 +12,10 @@ const Layout = ({ children }: LayoutProps) => {
       <div className="min-h-screen overflow-hidden flex w-full max-w-full bg-background">
         <AppSidebar />
         <div className="flex-1 flex flex-col min-h-0">
-          <header className="flex h-14 items-center justify-between border-b border-border bg-card px-4">
-            <div className="ml-auto flex items-center"></div>
-
-            <div className="flex items-center gap-2">
-              <AnimatedThemeToggler />
-
-              {/* ✅ Visible ONLY on mobile. Hidden on laptop/desktop. */}
-              <div className="md:hidden">
-                <SidebarTrigger />
-              </div>
+          {/* ✅ Header only renders on mobile now — on desktop it had no content and was just leaving an empty h-14 bar at the top of every page */}
+          <header className="flex h-14 items-center justify-between border-b border-border bg-card px-4 md:hidden">
+            <div className="ml-auto flex items-center">
+              <SidebarTrigger />
             </div>
           </header>
           <main id="main-scroll" className="flex-1 min-h-0 min-w-0 overflow-y-auto p-4 md:p-6">

--- a/src/components/navigation/BackToTop.tsx
+++ b/src/components/navigation/BackToTop.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export const BackToTop = () => {
   const [isVisible, setIsVisible] = useState(false);
+  const scrollerRef = useRef<HTMLElement | Window | null>(null);
 
   // The app shell scrolls inside <main id="main-scroll">, falling back to the
   // window for any context where that container isn't present.
@@ -20,14 +21,23 @@ export const BackToTop = () => {
     getScroller().scrollTo({ top: 0, behavior: "smooth" });
   };
 
-  useEffect(() => {
-    const scroller = getScroller();
-    const toggleVisibility = () => setIsVisible(getScrollTop(scroller) > 300);
+ useEffect(() => {
+  scrollerRef.current = getScroller();
 
-    toggleVisibility();
-    scroller.addEventListener("scroll", toggleVisibility);
-    return () => scroller.removeEventListener("scroll", toggleVisibility);
-  }, [getScroller, getScrollTop]);
+  const toggleVisibility = () => {
+    if (scrollerRef.current) {
+      setIsVisible(getScrollTop(scrollerRef.current) > 300);
+    }
+  };
+
+  toggleVisibility();
+
+  scrollerRef.current?.addEventListener("scroll", toggleVisibility);
+
+  return () => {
+    scrollerRef.current?.removeEventListener("scroll", toggleVisibility);
+  };
+}, [getScroller, getScrollTop]);
 
   return (
     <div className={cn(

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -532,10 +532,11 @@ const SidebarMenuSkeleton = React.forwardRef<
   }
 >(({ className, showIcon = false, ...props }, ref) => {
   // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
-
+const width = React.useMemo(() => {
+  const seed = 0x4d61766973; // "Mavis"
+  const result = ((seed * 1664525 + 1013904223) >>> 0) % 40 + 50;
+  return `${result}%`;
+}, []);
   return (
     <div
       ref={ref}

--- a/src/lib/encryption.test.ts
+++ b/src/lib/encryption.test.ts
@@ -7,11 +7,15 @@ import {
   encryptText,
   decryptText,
   deriveKeyFromToken,
+  getP2PSigningKeys,
+  signPayload,
+  verifyPayload,
 } from "./encryption";
 
-describe("Encryption Key Persistence", () => {
+describe("Encryption Key Persistence & Security", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it("successfully encrypts and decrypts text using derived keys", async () => {
@@ -35,5 +39,62 @@ describe("Encryption Key Persistence", () => {
     expect(keys.searchKey).toBe(key);
     expect(getKey()).toBe(key);
     expect(getSearchKey()).toBe(key);
+  });
+
+  it("generates a P2P signing keypair when no key material exists", async () => {
+    const p2pKeys = await getP2PSigningKeys();
+
+    expect(p2pKeys.privateKey).toBeDefined();
+    expect(p2pKeys.publicKey).toBeDefined();
+
+    const publicJwk = await crypto.subtle.exportKey("jwk", p2pKeys.publicKey);
+
+    await expect(crypto.subtle.exportKey("jwk", p2pKeys.privateKey)).rejects.toThrow();
+    expect(publicJwk.kty).toBe("EC");
+  });
+
+  it("shares a single in-flight P2P key generation across concurrent callers", async () => {
+    const [firstKeys, secondKeys] = await Promise.all([getP2PSigningKeys(), getP2PSigningKeys()]);
+
+    expect(firstKeys.privateKey).toBe(secondKeys.privateKey);
+    expect(firstKeys.publicKey).toBe(secondKeys.publicKey);
+  });
+
+  it("cleans up legacy P2P key entries and returns usable keys", async () => {
+    localStorage.setItem("symptom_scribe_p2p_private_key", "fake-unencrypted-private-key");
+    localStorage.setItem("symptom_scribe_p2p_enc_private_key", "fake-encrypted-private-key");
+    localStorage.setItem("symptom_scribe_p2p_public_key", "fake-public-key");
+
+    const p2pKeys = await getP2PSigningKeys();
+    expect(p2pKeys.privateKey).toBeDefined();
+    expect(p2pKeys.publicKey).toBeDefined();
+
+    expect(localStorage.getItem("symptom_scribe_p2p_private_key")).toBeNull();
+    expect(localStorage.getItem("symptom_scribe_p2p_enc_private_key")).toBeNull();
+    expect(localStorage.getItem("symptom_scribe_p2p_public_key")).toBeNull();
+  });
+
+  it("reuses cached P2P signing keys on repeated calls", async () => {
+    const firstKeys = await getP2PSigningKeys();
+    const secondKeys = await getP2PSigningKeys();
+
+    expect(secondKeys.privateKey).toBe(firstKeys.privateKey);
+    expect(secondKeys.publicKey).toBe(firstKeys.publicKey);
+  });
+
+  it("signs and verifies emergency mesh payloads using P2P keypair", async () => {
+    const p2pKeys = await getP2PSigningKeys();
+    const payload = "EMERGENCY_ALERT:SOS_LAT_37_LON_122";
+
+    const signature = await signPayload(payload, p2pKeys.privateKey);
+    expect(signature).toBeDefined();
+    expect(typeof signature).toBe("string");
+
+    const publicJwk = await crypto.subtle.exportKey("jwk", p2pKeys.publicKey);
+    const isValid = await verifyPayload(payload, signature, publicJwk);
+    expect(isValid).toBe(true);
+
+    const isTamperedValid = await verifyPayload(payload + "_TAMPERED", signature, publicJwk);
+    expect(isTamperedValid).toBe(false);
   });
 });

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -470,57 +470,53 @@ export async function decryptProfileArray(
 }
 
 // ─── P2P Emergency Mesh Signatures ──────────────────────────────────────────
+let cachedP2PKeys: { privateKey: CryptoKey; publicKey: CryptoKey } | null = null;
+let cachedP2PKeysPromise: Promise<{ privateKey: CryptoKey; publicKey: CryptoKey }> | null = null;
+
 export async function getP2PSigningKeys(): Promise<{ privateKey: CryptoKey; publicKey: CryptoKey }> {
-  const storedPrivate = localStorage.getItem("symptom_scribe_p2p_private_key");
-  const storedPublic = localStorage.getItem("symptom_scribe_p2p_public_key");
-
-  if (storedPrivate && storedPublic) {
+  // Remove any legacy P2P private key storage from browser storage.
+  // The private key is now kept only in memory for the current session.
+  // Public identity is session-scoped too, so it no longer persists across browser reloads.
+  if (typeof localStorage !== "undefined") {
     try {
-      const privateJwk = JSON.parse(storedPrivate);
-      const publicJwk = JSON.parse(storedPublic);
-
-      const privateKey = await crypto.subtle.importKey(
-        "jwk",
-        privateJwk,
-        { name: "ECDSA", namedCurve: "P-256" },
-        true,
-        ["sign"]
-      );
-
-      const publicKey = await crypto.subtle.importKey(
-        "jwk",
-        publicJwk,
-        { name: "ECDSA", namedCurve: "P-256" },
-        true,
-        ["verify"]
-      );
-
-      return { privateKey, publicKey };
+      localStorage.removeItem("symptom_scribe_p2p_private_key");
+      localStorage.removeItem("symptom_scribe_p2p_enc_private_key");
+      localStorage.removeItem("symptom_scribe_p2p_public_key");
     } catch (err) {
-      console.warn("Failed to load stored P2P keys, generating new ones:", err);
+      console.warn("Failed to remove legacy P2P keys:", err);
     }
   }
 
-  // Generate new ECDSA P-256 keypair
-  const keyPair = await crypto.subtle.generateKey(
-    {
-      name: "ECDSA",
-      namedCurve: "P-256",
-    },
-    true,
-    ["sign", "verify"]
-  );
+  if (cachedP2PKeys) {
+    return cachedP2PKeys;
+  }
 
-  const privateJwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);
-  const publicJwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+  if (cachedP2PKeysPromise) {
+    return cachedP2PKeysPromise;
+  }
 
-  localStorage.setItem("symptom_scribe_p2p_private_key", JSON.stringify(privateJwk));
-  localStorage.setItem("symptom_scribe_p2p_public_key", JSON.stringify(publicJwk));
+  cachedP2PKeysPromise = crypto.subtle
+    .generateKey(
+      {
+        name: "ECDSA",
+        namedCurve: "P-256",
+      },
+      false,
+      ["sign", "verify"]
+    )
+    .then((keyPair) => {
+      cachedP2PKeys = {
+        privateKey: keyPair.privateKey,
+        publicKey: keyPair.publicKey,
+      };
 
-  return {
-    privateKey: keyPair.privateKey,
-    publicKey: keyPair.publicKey,
-  };
+      return cachedP2PKeys;
+    })
+    .finally(() => {
+      cachedP2PKeysPromise = null;
+    });
+
+  return cachedP2PKeysPromise;
 }
 
 export async function signPayload(payload: string, privateKey: CryptoKey): Promise<string> {

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 
 import { Button } from "@/components/ui/button";
@@ -14,6 +14,7 @@ import { useToast } from "@/hooks/use-toast";
 
 import {
   Activity,
+  ArrowLeft,
   Loader2,
   Mail,
   Lock,
@@ -218,7 +219,16 @@ const handleForgotPassword= async () => {
       <div className="absolute inset-0 bg-[linear-gradient(120deg,rgba(6,182,212,0.16),transparent_34%,rgba(16,185,129,0.12)_78%)]" />
       <div className="absolute -bottom-32 left-0 h-72 w-full bg-[linear-gradient(165deg,transparent_18%,rgba(45,212,191,0.16)_19%,rgba(45,212,191,0.06)_36%,transparent_37%),linear-gradient(18deg,transparent_42%,rgba(125,211,252,0.12)_43%,rgba(125,211,252,0.04)_60%,transparent_61%)] blur-sm" />
       <div className="absolute inset-0 bg-slate-950/35" />
-
+      {/* Back to Home link */}
+      <div className="relative z-10 mx-auto w-full max-w-6xl pt-4">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-sm text-cyan-400 hover:text-cyan-300 transition-colors duration-200"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Home
+        </Link>
+      </div>
       <main className="relative z-10 mx-auto grid min-h-[calc(100vh-4rem)] w-full max-w-6xl items-center gap-8 lg:grid-cols-[1fr_460px]">
         <section className="hidden max-w-xl space-y-8 lg:block">
           <div className="inline-flex items-center gap-2 rounded-full border border-cyan-200/15 bg-white/8 px-4 py-2 text-sm font-medium text-cyan-100 shadow-lg shadow-slate-950/20 backdrop-blur-xl">

--- a/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/pages/Dashboard/Dashboard.test.tsx
@@ -20,7 +20,7 @@
  *                       without crashing.
  */
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, act } from "@testing-library/react";
 import { render } from "@/test/utils";
 import Dashboard from "@/pages/Dashboard/";
 
@@ -32,6 +32,7 @@ vi.mock("@/integrations/supabase/client", () => ({
     auth: {
       getUser: vi.fn(),
       getSession: vi.fn(),
+      onAuthStateChange: vi.fn(),
     },
     from: vi.fn(),
   },
@@ -120,7 +121,9 @@ function mockCachedSymptoms(data: unknown[] | null, error: unknown = null) {
 function mockAuthUser(user: typeof mockUser | null = mockUser) {
   (supabase.auth.getUser as Mock).mockResolvedValue({ data: { user } });
   (supabase.auth.getSession as Mock).mockResolvedValue({
-    data: { session: user ? { access_token: "mock-token" } : null },
+    data: {
+      session: user ? { user, access_token: "mock-token" } : null,
+    },
   });
 }
 (supabase.from as Mock).mockReturnValue({
@@ -192,7 +195,7 @@ describe("Dashboard", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/No symptom history yet/i)
+        screen.getByText(/No health data yet/i)
       ).toBeInTheDocument();
     });
   });
@@ -281,6 +284,29 @@ describe("Dashboard", () => {
     mockAuthUser(null);
 
     render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Health Dashboard")).toBeInTheDocument();
+    });
+  });
+
+  it("waits for an authenticated session before fetching dashboard data", async () => {
+    let authCallback: ((event: string, session: unknown) => void) | undefined;
+    (supabase.auth.getSession as Mock).mockResolvedValueOnce({ data: { session: null } });
+    (supabase.auth.onAuthStateChange as Mock).mockImplementation((callback: (event: string, session: unknown) => void) => {
+      authCallback = callback;
+      return { data: { subscription: { unsubscribe: vi.fn() } } } as never;
+    });
+    (supabase.auth.getUser as Mock).mockResolvedValue({ data: { user: mockUser } });
+    mockCachedSymptoms([]);
+
+    render(<Dashboard />);
+
+    expect(supabase.auth.getUser).not.toHaveBeenCalled();
+
+    await act(async () => {
+      authCallback?.("SIGNED_IN", { user: mockUser, access_token: "session-token" });
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Health Dashboard")).toBeInTheDocument();

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -306,7 +306,7 @@ const Dashboard = () => {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-fade-in">
       <Card className="border"
         style={{ background: "var(--welcome-bg)" }}>
         <CardContent className="flex items-center justify-between py-6">

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -15,6 +15,8 @@ import { motion } from "framer-motion";
 import { SmartAlertsBanner } from "@/components/dashboard/SmartAlertsBanner";
 import CardSkeleton from "@/components/ui/CardSkeleton";
 import { WeeklyHealthScoreCard } from "@/components/dashboard/WeeklyHealthScoreCard";
+import { useNavigate } from "react-router-dom";
+import { EmptyState } from "@/components/common/EmptyState";
 
 interface Stats {
   totalSymptoms: number;
@@ -154,6 +156,7 @@ const RadialWellnessGauge = ({ score }: { score: number }) => {
 };
 
 const Dashboard = () => {
+  const navigate = useNavigate();
   const [stats, setStats] = useState<Stats>({
     totalSymptoms: 0,
     unresolvedSymptoms: 0,
@@ -483,10 +486,14 @@ const Dashboard = () => {
         </CardHeader>
         <CardContent>
           {recentHistory.length === 0 ? (
-            <p className="text-muted-foreground text-center py-8">
-              No symptom history yet. Start by consulting with the AI Assistant!
-            </p>
-          ) : (
+              <EmptyState
+                  icon={<Activity className="w-8 h-8 text-teal-600 dark:text-teal-400" strokeWidth={1.5} />}
+                 title="No health data yet — start tracking!"
+                  description="Consult the AI Assistant to log your first symptom check."
+                  ctaText="Start Tracking"
+                  onCtaClick={() => navigate("/ai-health-assistant")}
+                  />
+                  ) : (
             <div className="space-y-4">
               {recentHistory.map((item) => (
                 <div

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -39,28 +39,25 @@ interface SymptomHistoryRecord {
 async function fetchSymptomHistory(
   userId: string
 ): Promise<{ data: SymptomHistoryRecord[] | null; source: "cache" | "direct" | "none" }> {
-  const { data: cachedData, error } =
-    await getCachedData<SymptomHistoryRecord[]>("symptom_history");
-
-  if (!error && cachedData && cachedData.length > 0) {
-    return { data: cachedData, source: "cache" };
-  }
-
   const { data: directData, error: directError } = await supabase
     .from("symptom_history")
     .select("*")
     .eq("user_id", userId)
     .order("created_at", { ascending: false });
 
-  if (directError) {
-    if (error) {
-      console.warn("Cached symptom_history fetch failed:", error);
-    }
-    throw directError;
+  if (!directError && directData && directData.length > 0) {
+    return { data: directData as SymptomHistoryRecord[], source: "direct" };
   }
 
-  if (directData && directData.length > 0) {
-    return { data: directData as SymptomHistoryRecord[], source: "direct" };
+  const { data: cachedData, error } = await getCachedData<SymptomHistoryRecord[]>("symptom_history");
+
+  if (!error && cachedData && cachedData.length > 0) {
+    return { data: cachedData, source: "cache" };
+  }
+
+  if (directError) {
+    console.warn("Direct symptom_history fetch failed, cache fallback failed:", directError, error);
+    throw directError;
   }
 
   return { data: [], source: "none" };
@@ -171,28 +168,77 @@ const Dashboard = () => {
   const [decryptedSymptomsList, setDecryptedSymptomsList] = useState<string[]>([]);
 
   useEffect(() => {
-    fetchDashboardData();
-  }, []);
+    let isMounted = true;
+    let authSubscription: { unsubscribe: () => void } | null = null;
 
-  const fetchDashboardData = async () => {
-    try {
+    const initializeDashboardSession = async () => {
       const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) {
+        data: { session },
+        error: sessionError,
+      } = await supabase.auth.getSession();
+
+      if (!isMounted) return;
+
+      if (sessionError) {
+        console.warn("Unable to resolve dashboard session:", sessionError);
         setLoading(false);
         return;
       }
-      setUserId(user.id);
-      const { data: profile, error: profileError } = await supabase
-        .from("profiles")
-        .select("*")
-        .eq("user_id", user.id)
-        .maybeSingle();
+
+      if (session?.user?.id) {
+        await fetchDashboardData(session.user.id);
+        return;
+      }
+
+      setLoading(false);
+
+      const authResult = supabase.auth.onAuthStateChange((_event, nextSession) => {
+        if (!isMounted || !nextSession?.user?.id) return;
+        void fetchDashboardData(nextSession.user.id);
+      });
+
+      authSubscription = authResult?.data?.subscription ?? null;
+    };
+
+    void initializeDashboardSession();
+
+    return () => {
+      isMounted = false;
+      authSubscription?.unsubscribe();
+    };
+  }, []);
+
+  const fetchDashboardData = async (providedUserId?: string) => {
+    let activeUserId = providedUserId ?? null;
+
+    try {
+      setLoading(true);
+
+      if (!activeUserId) {
+        const { data: sessionData } = await supabase.auth.getSession();
+        activeUserId = sessionData.session?.user?.id ?? null;
+      }
+
+      if (!activeUserId) {
+        return;
+      }
+
+      setUserId(activeUserId);
+
+      const [profileResult, symptomResult] = await Promise.all([
+        supabase
+          .from("profiles")
+          .select("*")
+          .eq("user_id", activeUserId)
+          .maybeSingle(),
+        fetchSymptomHistory(activeUserId),
+      ]);
+
+      const { data: profile } = profileResult;
+      const { data: rawSymptoms, source } = symptomResult;
+      const key = await whenEncryptionReady();
 
       if (profile?.full_name) {
-        const key = await whenEncryptionReady();
-
         try {
           const decryptedFullName = await decryptProfileField(
             profile.full_name,
@@ -205,13 +251,7 @@ const Dashboard = () => {
         }
       }
 
-
-
-      const { data: rawSymptoms, source } = await fetchSymptomHistory(user.id);
-
       if (rawSymptoms && rawSymptoms.length > 0) {
-        const key = await whenEncryptionReady();
-
         const decryptedResults = await Promise.allSettled(
           rawSymptoms.map((s) => decryptSymptom(s as unknown as OfflineSymptom, key))
         );

--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -4,7 +4,17 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { CheckCircle, X, Trash2, Search, ClipboardList, FileDown } from "lucide-react";
+import {
+  CheckCircle,
+  X,
+  Trash2,
+  Search,
+  ClipboardList,
+  FileDown,
+  Calendar as CalendarIcon,
+  List,
+} from "lucide-react";
+import SymptomCalendarView from "@/components/history/SymptomCalendarView";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 import { useNavigate } from "react-router-dom";
@@ -77,10 +87,11 @@ const HistorySkeleton = () => (
 
 const History = () => {
   const [history, setHistory] = useState<SymptomEntry[]>([]);
-  const [loading, setLoading] = useState(true); 
+  const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [severityFilter, setSeverityFilter] = useState("all");
+  const [viewMode, setViewMode] = useState<"list" | "calendar">("list");
   const { toast } = useToast();
   const navigate = useNavigate();
   const [isOnline, setIsOnline] = useState(
@@ -421,204 +432,236 @@ const History = () => {
           </div>
           <p className="text-muted-foreground">Review your past health consultations</p>
         </div>
-        {history.length > 0 && (
-          <div className="flex gap-2">
-            <Button onClick={exportCSV} variant="outline" size="sm">
-              Export CSV
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="inline-flex rounded-md border p-1 bg-muted/30">
+            <Button
+              variant={viewMode === "list" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => setViewMode("list")}
+              className="h-8 gap-1.5 text-xs font-medium"
+            >
+              <List className="w-3.5 h-3.5" />
+              List View
             </Button>
-            <Button onClick={exportPDF} variant="outline" size="sm">
-              <FileDown className="w-4 h-4 mr-1" />
-              Download PDF
+            <Button
+              variant={viewMode === "calendar" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => setViewMode("calendar")}
+              className="h-8 gap-1.5 text-xs font-medium"
+            >
+              <CalendarIcon className="w-3.5 h-3.5" />
+              Calendar View
             </Button>
           </div>
-        )}
+          {history.length > 0 && (
+            <div className="flex gap-2">
+              <Button onClick={exportCSV} variant="outline" size="sm">
+                Export CSV
+              </Button>
+              <Button onClick={exportPDF} variant="outline" size="sm">
+                <FileDown className="w-4 h-4 mr-1" />
+                Download PDF
+              </Button>
+            </div>
+          )}
+        </div>
       </div>
 
-      <div className="flex flex-col sm:flex-row gap-3">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <input
-            id="symptom-search-input"
-            type="text"
-            placeholder="Search symptoms... (Ctrl+K to focus)"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-9 pr-4 py-2 rounded-md border border-input bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          />
-        </div>
-        <select
-          value={severityFilter}
-          onChange={(e) => setSeverityFilter(e.target.value)}
-          className="px-3 py-2 rounded-md border border-input bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-        >
-          <option value="all">All Severities</option>
-          <option value="low">Low</option>
-          <option value="moderate">Moderate</option>
-          <option value="high">High</option>
-        </select>
-      </div>
-
-      {isFiltering && (
-        <div className="flex justify-end">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setSearchQuery("");
-              setSeverityFilter("all");
-            }}
-            className="gap-2"
-          >
-            <X className="h-4 w-4" />
-            Clear All Filters
-          </Button>
-        </div>
-      )}
-
-      {loading ? (
-        <HistorySkeleton />
-      ) : history.length === 0 ? (
-        /* ── IMPROVED EMPTY STATE ── */
-        <Card>
-          <CardContent className="py-14 flex flex-col items-center text-center gap-4">
-            <div className="flex items-center justify-center w-16 h-16 rounded-full bg-teal-50 dark:bg-teal-950">
-              <ClipboardList
-                className="w-8 h-8 text-teal-600 dark:text-teal-400"
-                strokeWidth={1.5}
+      {viewMode === "calendar" ? (
+        <SymptomCalendarView
+          history={history}
+          onToggleResolved={toggleResolved}
+          onDeleteEntry={deleteEntry}
+        />
+      ) : (
+        <>
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <input
+                id="symptom-search-input"
+                type="text"
+                placeholder="Search symptoms... (Ctrl+K to focus)"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full pl-9 pr-4 py-2 rounded-md border border-input bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
-            <div className="space-y-1">
-              <h3 className="text-base font-semibold text-foreground">No consultations yet</h3>
-              <p className="text-sm text-muted-foreground max-w-xs">
-                Your symptom history will appear here after your first AI consultation.
-              </p>
+            <select
+              value={severityFilter}
+              onChange={(e) => setSeverityFilter(e.target.value)}
+              className="px-3 py-2 rounded-md border border-input bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="all">All Severities</option>
+              <option value="low">Low</option>
+              <option value="moderate">Moderate</option>
+              <option value="high">High</option>
+            </select>
+          </div>
+
+          {isFiltering && (
+            <div className="flex justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setSearchQuery("");
+                  setSeverityFilter("all");
+                }}
+                className="gap-2"
+              >
+                <X className="h-4 w-4" />
+                Clear All Filters
+              </Button>
             </div>
-            <Button
-              onClick={() => navigate("/ai-health-assistant")}
-              className="bg-teal-600 hover:bg-teal-700 text-white mt-2"
-            >
-              Start AI Consultation
-            </Button>
-          </CardContent>
-        </Card>
-      ) : filteredHistory.length === 0 ? (
-        <Card>
-          <CardContent className="pt-6 text-center space-y-2">
-            <p className="text-muted-foreground">
-              No results match your search{isFiltering ? " or filter" : ""}. Try adjusting your
-              criteria.
-            </p>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setSearchQuery("");
-                setSeverityFilter("all");
-              }}
-            >
-              Clear filters
-            </Button>
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="space-y-4 animate-fade-in">
-          {filteredHistory.map((entry) => (
-            <Card key={entry.id} className={entry.resolved ? "opacity-70" : ""}>
-              <CardHeader>
-                <div className="flex flex-wrap items-start justify-between gap-2">
-                  <div className="flex-1 min-w-0">
-                    <CardTitle className="text-lg break-words">{entry.symptoms}</CardTitle>
-                    <p className="text-sm text-muted-foreground">
-                      {new Date(entry.created_at).toLocaleString()}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2 shrink-0">
-                    <Badge variant={getSeverityColor(entry.severity_level)}>
-                      {entry.severity_level}
-                    </Badge>
-                    <Button
-                      variant={entry.resolved ? "outline" : "default"}
-                      size="sm"
-                      onClick={() => toggleResolved(entry.id, entry.resolved)}
-                    >
-                      {entry.resolved ? (
-                        <>
-                          <X className="w-4 h-4 mr-1" />
-                          Reopen
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className="w-4 h-4 mr-1" />
-                          Resolve
-                        </>
-                      )}
-                    </Button>
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
-                          title="Permanently delete record"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>Delete Symptom History?</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            Are you sure you want to permanently delete this health consultation
-                            record? This action cannot be undone.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>Cancel</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={() => deleteEntry(entry.id)}
-                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                          >
-                            Delete
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  </div>
+          )}
+
+          {loading ? (
+            <HistorySkeleton />
+          ) : history.length === 0 ? (
+            /* ── IMPROVED EMPTY STATE ── */
+            <Card>
+              <CardContent className="py-14 flex flex-col items-center text-center gap-4">
+                <div className="flex items-center justify-center w-16 h-16 rounded-full bg-teal-50 dark:bg-teal-950">
+                  <ClipboardList
+                    className="w-8 h-8 text-teal-600 dark:text-teal-400"
+                    strokeWidth={1.5}
+                  />
                 </div>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-3">
-                  {entry.possible_causes && entry.possible_causes.length > 0 && (
-                    <div>
-                      <p className="text-sm font-semibold mb-1">Possible Causes:</p>
-                      <ul className="text-sm text-muted-foreground list-disc list-inside">
-                        {entry.possible_causes.map((cause, idx) => (
-                          <li key={idx}>{cause}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  {entry.recommendations && entry.recommendations.length > 0 && (
-                    <div className="mt-2">
-                      <p className="text-sm font-semibold mb-1">Recommendations:</p>
-                      <ul className="text-sm text-muted-foreground list-disc list-inside">
-                        {entry.recommendations.map((rec, idx) => (
-                          <li key={idx}>{rec}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  {entry.risk_score !== null && (
-                    <div className="flex items-center gap-2">
-                      <p className="text-sm font-semibold">Risk Score:</p>
-                      <Badge variant="outline">{entry.risk_score}/100</Badge>
-                    </div>
-                  )}
+                <div className="space-y-1">
+                  <h3 className="text-base font-semibold text-foreground">No consultations yet</h3>
+                  <p className="text-sm text-muted-foreground max-w-xs">
+                    Your symptom history will appear here after your first AI consultation.
+                  </p>
                 </div>
+                <Button
+                  onClick={() => navigate("/ai-health-assistant")}
+                  className="bg-teal-600 hover:bg-teal-700 text-white mt-2"
+                >
+                  Start AI Consultation
+                </Button>
               </CardContent>
             </Card>
-          ))}
-        </div>
+          ) : filteredHistory.length === 0 ? (
+            <Card>
+              <CardContent className="pt-6 text-center space-y-2">
+                <p className="text-muted-foreground">
+                  No results match your search{isFiltering ? " or filter" : ""}. Try adjusting your
+                  criteria.
+                </p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setSearchQuery("");
+                    setSeverityFilter("all");
+                  }}
+                >
+                  Clear filters
+                </Button>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-4">
+              {filteredHistory.map((entry) => (
+                <Card key={entry.id} className={entry.resolved ? "opacity-70" : ""}>
+                  <CardHeader>
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div className="flex-1 min-w-0">
+                        <CardTitle className="text-lg break-words">{entry.symptoms}</CardTitle>
+                        <p className="text-sm text-muted-foreground">
+                          {new Date(entry.created_at).toLocaleString()}
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2 shrink-0">
+                        <Badge variant={getSeverityColor(entry.severity_level)}>
+                          {entry.severity_level}
+                        </Badge>
+                        <Button
+                          variant={entry.resolved ? "outline" : "default"}
+                          size="sm"
+                          onClick={() => toggleResolved(entry.id, entry.resolved)}
+                        >
+                          {entry.resolved ? (
+                            <>
+                              <X className="w-4 h-4 mr-1" />
+                              Reopen
+                            </>
+                          ) : (
+                            <>
+                              <CheckCircle className="w-4 h-4 mr-1" />
+                              Resolve
+                            </>
+                          )}
+                        </Button>
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                              title="Permanently delete record"
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>Delete Symptom History?</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                Are you sure you want to permanently delete this health consultation
+                                record? This action cannot be undone.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => deleteEntry(entry.id)}
+                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                              >
+                                Delete
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-3">
+                      {entry.possible_causes && entry.possible_causes.length > 0 && (
+                        <div>
+                          <p className="text-sm font-semibold mb-1">Possible Causes:</p>
+                          <ul className="text-sm text-muted-foreground list-disc list-inside">
+                            {entry.possible_causes.map((cause, idx) => (
+                              <li key={idx}>{cause}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                      {entry.recommendations && entry.recommendations.length > 0 && (
+                        <div className="mt-2">
+                          <p className="text-sm font-semibold mb-1">Recommendations:</p>
+                          <ul className="text-sm text-muted-foreground list-disc list-inside">
+                            {entry.recommendations.map((rec, idx) => (
+                              <li key={idx}>{rec}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                      {entry.risk_score !== null && (
+                        <div className="flex items-center gap-2">
+                          <p className="text-sm font-semibold">Risk Score:</p>
+                          <Badge variant="outline">{entry.risk_score}/100</Badge>
+                        </div>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -521,7 +521,7 @@ const History = () => {
           </CardContent>
         </Card>
       ) : (
-        <div className="space-y-4">
+        <div className="space-y-4 animate-fade-in">
           {filteredHistory.map((entry) => (
             <Card key={entry.id} className={entry.resolved ? "opacity-70" : ""}>
               <CardHeader>

--- a/src/pages/History/tests/SymptomCalendarView.test.tsx
+++ b/src/pages/History/tests/SymptomCalendarView.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@/test/utils";
+import SymptomCalendarView, { SymptomEntry } from "@/components/history/SymptomCalendarView";
+
+const mockEntries: SymptomEntry[] = [
+  {
+    id: "entry-1",
+    symptoms: "Severe Migraine with Aura",
+    severity_level: "high",
+    possible_causes: ["Stress", "Dehydration"],
+    recommendations: ["Rest in dark room", "Hydrate"],
+    risk_score: 75,
+    resolved: false,
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: "entry-2",
+    symptoms: "Mild Fatigue and Cough",
+    severity_level: "low",
+    possible_causes: ["Seasonal Allergies"],
+    recommendations: ["Warm tea", "Antihistamine"],
+    risk_score: 25,
+    resolved: true,
+    created_at: new Date().toISOString(),
+  },
+];
+
+describe("SymptomCalendarView Component", () => {
+  it("renders monthly calendar overview and jump controls", () => {
+    render(
+      <SymptomCalendarView
+        history={mockEntries}
+        onToggleResolved={vi.fn()}
+        onDeleteEntry={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/Monthly Overview/i)).toBeInTheDocument();
+    expect(screen.getByText(/Quick Entry Preview/i)).toBeInTheDocument();
+    expect(screen.getByText("Today")).toBeInTheDocument();
+  });
+
+  it("allows switching months using previous and next month buttons", () => {
+    render(
+      <SymptomCalendarView
+        history={mockEntries}
+        onToggleResolved={vi.fn()}
+        onDeleteEntry={vi.fn()}
+      />
+    );
+
+    const prevButton = screen.getByRole("button", { name: /Previous Month/i });
+    const nextButton = screen.getByRole("button", { name: /Next Month/i });
+
+    expect(prevButton).toBeInTheDocument();
+    expect(nextButton).toBeInTheDocument();
+
+    fireEvent.click(prevButton);
+    fireEvent.click(nextButton);
+  });
+
+  it("filters entries by severity level", async () => {
+    render(
+      <SymptomCalendarView
+        history={mockEntries}
+        onToggleResolved={vi.fn()}
+        onDeleteEntry={vi.fn()}
+      />
+    );
+
+    const severitySelect = screen.getByLabelText(/Severity filter/i);
+    expect(severitySelect).toBeInTheDocument();
+
+    fireEvent.change(severitySelect, { target: { value: "high" } });
+    expect(severitySelect).toHaveValue("high");
+  });
+
+  it("filters entries by resolution status", async () => {
+    render(
+      <SymptomCalendarView
+        history={mockEntries}
+        onToggleResolved={vi.fn()}
+        onDeleteEntry={vi.fn()}
+      />
+    );
+
+    const statusSelect = screen.getByLabelText(/Status filter/i);
+    expect(statusSelect).toBeInTheDocument();
+
+    fireEvent.change(statusSelect, { target: { value: "active" } });
+    expect(statusSelect).toHaveValue("active");
+  });
+
+  it("displays quick entry preview for selected date with symptoms", () => {
+    render(
+      <SymptomCalendarView
+        history={mockEntries}
+        onToggleResolved={vi.fn()}
+        onDeleteEntry={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByText("Severe Migraine with Aura")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Mild Fatigue and Cough")[0]).toBeInTheDocument();
+  });
+
+  it("triggers onToggleResolved when resolve button is clicked", () => {
+    const handleToggle = vi.fn();
+    render(
+      <SymptomCalendarView
+        history={mockEntries}
+        onToggleResolved={handleToggle}
+        onDeleteEntry={vi.fn()}
+      />
+    );
+
+    const resolveButtons = screen.getAllByRole("button", { name: /Resolve|Reopen/i });
+    expect(resolveButtons.length).toBeGreaterThan(0);
+
+    fireEvent.click(resolveButtons[0]);
+    expect(handleToggle).toHaveBeenCalledWith("entry-1", false);
+  });
+
+  it("resets jump to date to current month when Today button is clicked", () => {
+    render(
+      <SymptomCalendarView
+        history={mockEntries}
+        onToggleResolved={vi.fn()}
+        onDeleteEntry={vi.fn()}
+      />
+    );
+
+    const todayButton = screen.getByText("Today");
+    fireEvent.click(todayButton);
+
+    const today = new Date();
+    const monthName = today.toLocaleString("default", { month: "long" });
+    expect(
+      screen.getByRole("heading", {
+        name: new RegExp(`${monthName}\\s+${today.getFullYear()}`, "i"),
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/Metrics/index.tsx
+++ b/src/pages/Metrics/index.tsx
@@ -599,7 +599,7 @@ const Metrics = () => {
           onCtaClick={() => setFormOpen(true)}
           />
           ) : (
-            <>
+            <div className="animate-fade-in">
               <div className="flex flex-wrap gap-3 mb-4">
                 <Select
                   value={historyMetricFilter}
@@ -785,7 +785,7 @@ const Metrics = () => {
                     </ResponsiveContainer>
                   </div>
                 ))}
-            </>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/pages/Metrics/index.tsx
+++ b/src/pages/Metrics/index.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { EmptyState } from "@/components/common/EmptyState";
+
 import {
   Card,
   CardContent,
@@ -583,13 +585,19 @@ const Metrics = () => {
         <CardContent>
           {historyLoading ? (
             historyView === "table" ? <MetricsTableSkeleton /> : <MetricsChartSkeleton />
-          ) : records.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-center">
-              <p className="text-lg font-medium">No health metrics yet</p>
-              <p className="text-sm text-muted-foreground mt-1">
-                Record your first measurement above to start tracking trends.
-              </p>
-            </div>
+        ) : records.length === 0 ? (
+          <EmptyState
+          icon={
+          <Activity
+            className="w-8 h-8 text-teal-600 dark:text-teal-400"
+            strokeWidth={1.5}
+           />
+           }
+          title="Add your first health metric"
+          description="Record a measurement above to start tracking trends over time."
+          ctaText="Add Metric"
+          onCtaClick={() => setFormOpen(true)}
+          />
           ) : (
             <>
               <div className="flex flex-wrap gap-3 mb-4">


### PR DESCRIPTION
## Summary
Adds actionable empty states with icons, descriptions, and CTA buttons to Dashboard, Metrics, and Chat History, matching the existing design pattern already used on the Symptom History page.

Closes #789

## Changes
- New reusable `EmptyState` component (`src/components/common/EmptyState.tsx`)
- Dashboard: "No health data yet — start tracking!" empty state with CTA to AI Assistant (see screenshot)
- Metrics: "Add your first health metric" empty state with CTA to open the record form (same pattern as Dashboard, verified via build/typecheck)
- Chat: added loading skeleton rows for session history + "Start a new conversation" empty state with New Chat CTA (see screenshot)
- - Added fade-in transitions on loaded content for Dashboard, History, Metrics, and Chat — completes all 4 requirements from the issue (`animate-fade-in`, no new dependency)

Note: Skeleton loaders and empty states for the Symptom History page and Metrics table/chart views already existed in the codebase and were verified working as part of this review.

## Screenshots
**Dashboard empty state:**
<img width="1470" height="956" alt="Screenshot 2026-08-02 at 12 48 40 AM" src="https://github.com/user-attachments/assets/8f9c356b-1bae-4c2d-b2d0-f440e205b860" />


**Chat History empty state:**
<img width="1470" height="956" alt="Screenshot 2026-08-02 at 12 49 34 AM" src="https://github.com/user-attachments/assets/b0d794f8-1220-43b1-a839-52cfcc3a4e8e" />


## Testing
- `npx tsc --noEmit` — passes
- `npm run build` — passes
- `npm run lint` — no new errors
- Manually verified empty states render correctly for Dashboard and Chat