### PR TITLE
 Fix P2P private key storage in encryption flow

### DIFF
--- a/src/lib/encryption.test.ts
+++ b/src/lib/encryption.test.ts
@@ -7,11 +7,15 @@ import {
   encryptText,
   decryptText,
   deriveKeyFromToken,
+  getP2PSigningKeys,
+  signPayload,
+  verifyPayload,
 } from "./encryption";
 
-describe("Encryption Key Persistence", () => {
+describe("Encryption Key Persistence & Security", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it("successfully encrypts and decrypts text using derived keys", async () => {
@@ -35,5 +39,37 @@ describe("Encryption Key Persistence", () => {
     expect(keys.searchKey).toBe(key);
     expect(getKey()).toBe(key);
     expect(getSearchKey()).toBe(key);
+  });
+
+  it("generates P2P signing keys without persisting private key material to localStorage", async () => {
+    // Pre-populate legacy storage entries to verify cleanup
+    localStorage.setItem("symptom_scribe_p2p_private_key", "fake-unencrypted-private-key");
+    localStorage.setItem("symptom_scribe_p2p_enc_private_key", "fake-encrypted-private-key");
+    localStorage.setItem("symptom_scribe_p2p_public_key", "fake-public-key");
+
+    const p2pKeys = await getP2PSigningKeys();
+    expect(p2pKeys.privateKey).toBeDefined();
+    expect(p2pKeys.publicKey).toBeDefined();
+
+    // Verify no private-key material is persisted to browser storage
+    expect(localStorage.getItem("symptom_scribe_p2p_private_key")).toBeNull();
+    expect(localStorage.getItem("symptom_scribe_p2p_enc_private_key")).toBeNull();
+    expect(localStorage.getItem("symptom_scribe_p2p_public_key")).toBeNull();
+  });
+
+  it("signs and verifies emergency mesh payloads using P2P keypair", async () => {
+    const p2pKeys = await getP2PSigningKeys();
+    const payload = "EMERGENCY_ALERT:SOS_LAT_37_LON_122";
+
+    const signature = await signPayload(payload, p2pKeys.privateKey);
+    expect(signature).toBeDefined();
+    expect(typeof signature).toBe("string");
+
+    const publicJwk = await crypto.subtle.exportKey("jwk", p2pKeys.publicKey);
+    const isValid = await verifyPayload(payload, signature, publicJwk);
+    expect(isValid).toBe(true);
+
+    const isTamperedValid = await verifyPayload(payload + "_TAMPERED", signature, publicJwk);
+    expect(isTamperedValid).toBe(false);
   });
 });

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -470,38 +470,22 @@ export async function decryptProfileArray(
 }
 
 // ─── P2P Emergency Mesh Signatures ──────────────────────────────────────────
+let cachedP2PKeys: { privateKey: CryptoKey; publicKey: CryptoKey } | null = null;
+
 export async function getP2PSigningKeys(): Promise<{ privateKey: CryptoKey; publicKey: CryptoKey }> {
-  const storedPrivate = localStorage.getItem("symptom_scribe_p2p_private_key");
-  const storedPublic = localStorage.getItem("symptom_scribe_p2p_public_key");
-
-  if (storedPrivate && storedPublic) {
-    try {
-      const privateJwk = JSON.parse(storedPrivate);
-      const publicJwk = JSON.parse(storedPublic);
-
-      const privateKey = await crypto.subtle.importKey(
-        "jwk",
-        privateJwk,
-        { name: "ECDSA", namedCurve: "P-256" },
-        true,
-        ["sign"]
-      );
-
-      const publicKey = await crypto.subtle.importKey(
-        "jwk",
-        publicJwk,
-        { name: "ECDSA", namedCurve: "P-256" },
-        true,
-        ["verify"]
-      );
-
-      return { privateKey, publicKey };
-    } catch (err) {
-      console.warn("Failed to load stored P2P keys, generating new ones:", err);
-    }
+  if (cachedP2PKeys) {
+    return cachedP2PKeys;
   }
 
-  // Generate new ECDSA P-256 keypair
+  // Remove any legacy P2P private key storage from browser storage.
+  // The private key is now kept only in memory for the current session.
+  if (typeof localStorage !== "undefined") {
+    localStorage.removeItem("symptom_scribe_p2p_private_key");
+    localStorage.removeItem("symptom_scribe_p2p_enc_private_key");
+    localStorage.removeItem("symptom_scribe_p2p_public_key");
+  }
+
+  // Generate a new ECDSA P-256 keypair for the current session.
   const keyPair = await crypto.subtle.generateKey(
     {
       name: "ECDSA",
@@ -511,16 +495,12 @@ export async function getP2PSigningKeys(): Promise<{ privateKey: CryptoKey; publ
     ["sign", "verify"]
   );
 
-  const privateJwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);
-  const publicJwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
-
-  localStorage.setItem("symptom_scribe_p2p_private_key", JSON.stringify(privateJwk));
-  localStorage.setItem("symptom_scribe_p2p_public_key", JSON.stringify(publicJwk));
-
-  return {
+  cachedP2PKeys = {
     privateKey: keyPair.privateKey,
     publicKey: keyPair.publicKey,
   };
+
+  return cachedP2PKeys;
 }
 
 export async function signPayload(payload: string, privateKey: CryptoKey): Promise<string> {


### PR DESCRIPTION
## **Pull Request Description**
A clear and concise description of the changes introduced by this pull request.

This PR fixes the security issue where the P2P ECDSA private key could be persisted in browser storage and exposed to XSS or malicious scripts.

What changed
Removed persistence of the P2P private key to localStorage
Kept the signing key in memory only for the active session
Cleared any legacy stored P2P key values
Added regression tests to ensure private key material is no longer written to browser storage

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [x] **Other** (please specify): security

---

### **2. Related Issue**
- Fixes #679 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.


---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
