### PR TITLE
Fix/encryption test coverage

### DIFF
--- a/src/lib/encryption.test.ts
+++ b/src/lib/encryption.test.ts
@@ -41,8 +41,20 @@ describe("Encryption Key Persistence & Security", () => {
     expect(getSearchKey()).toBe(key);
   });
 
-  it("generates P2P signing keys without persisting private key material to localStorage", async () => {
-    // Pre-populate legacy storage entries to verify cleanup
+  it("generates a P2P signing keypair when no key material exists", async () => {
+    const p2pKeys = await getP2PSigningKeys();
+
+    expect(p2pKeys.privateKey).toBeDefined();
+    expect(p2pKeys.publicKey).toBeDefined();
+
+    const privateJwk = await crypto.subtle.exportKey("jwk", p2pKeys.privateKey);
+    const publicJwk = await crypto.subtle.exportKey("jwk", p2pKeys.publicKey);
+
+    expect(privateJwk.kty).toBe("EC");
+    expect(publicJwk.kty).toBe("EC");
+  });
+
+  it("cleans up legacy P2P key entries and returns usable keys", async () => {
     localStorage.setItem("symptom_scribe_p2p_private_key", "fake-unencrypted-private-key");
     localStorage.setItem("symptom_scribe_p2p_enc_private_key", "fake-encrypted-private-key");
     localStorage.setItem("symptom_scribe_p2p_public_key", "fake-public-key");
@@ -51,10 +63,17 @@ describe("Encryption Key Persistence & Security", () => {
     expect(p2pKeys.privateKey).toBeDefined();
     expect(p2pKeys.publicKey).toBeDefined();
 
-    // Verify no private-key material is persisted to browser storage
     expect(localStorage.getItem("symptom_scribe_p2p_private_key")).toBeNull();
     expect(localStorage.getItem("symptom_scribe_p2p_enc_private_key")).toBeNull();
     expect(localStorage.getItem("symptom_scribe_p2p_public_key")).toBeNull();
+  });
+
+  it("reuses cached P2P signing keys on repeated calls", async () => {
+    const firstKeys = await getP2PSigningKeys();
+    const secondKeys = await getP2PSigningKeys();
+
+    expect(secondKeys.privateKey).toBe(firstKeys.privateKey);
+    expect(secondKeys.publicKey).toBe(firstKeys.publicKey);
   });
 
   it("signs and verifies emergency mesh payloads using P2P keypair", async () => {

--- a/src/lib/encryption.test.ts
+++ b/src/lib/encryption.test.ts
@@ -7,11 +7,15 @@ import {
   encryptText,
   decryptText,
   deriveKeyFromToken,
+  getP2PSigningKeys,
+  signPayload,
+  verifyPayload,
 } from "./encryption";
 
-describe("Encryption Key Persistence", () => {
+describe("Encryption Key Persistence & Security", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it("successfully encrypts and decrypts text using derived keys", async () => {
@@ -35,5 +39,37 @@ describe("Encryption Key Persistence", () => {
     expect(keys.searchKey).toBe(key);
     expect(getKey()).toBe(key);
     expect(getSearchKey()).toBe(key);
+  });
+
+  it("generates P2P signing keys without persisting private key material to localStorage", async () => {
+    // Pre-populate legacy storage entries to verify cleanup
+    localStorage.setItem("symptom_scribe_p2p_private_key", "fake-unencrypted-private-key");
+    localStorage.setItem("symptom_scribe_p2p_enc_private_key", "fake-encrypted-private-key");
+    localStorage.setItem("symptom_scribe_p2p_public_key", "fake-public-key");
+
+    const p2pKeys = await getP2PSigningKeys();
+    expect(p2pKeys.privateKey).toBeDefined();
+    expect(p2pKeys.publicKey).toBeDefined();
+
+    // Verify no private-key material is persisted to browser storage
+    expect(localStorage.getItem("symptom_scribe_p2p_private_key")).toBeNull();
+    expect(localStorage.getItem("symptom_scribe_p2p_enc_private_key")).toBeNull();
+    expect(localStorage.getItem("symptom_scribe_p2p_public_key")).toBeNull();
+  });
+
+  it("signs and verifies emergency mesh payloads using P2P keypair", async () => {
+    const p2pKeys = await getP2PSigningKeys();
+    const payload = "EMERGENCY_ALERT:SOS_LAT_37_LON_122";
+
+    const signature = await signPayload(payload, p2pKeys.privateKey);
+    expect(signature).toBeDefined();
+    expect(typeof signature).toBe("string");
+
+    const publicJwk = await crypto.subtle.exportKey("jwk", p2pKeys.publicKey);
+    const isValid = await verifyPayload(payload, signature, publicJwk);
+    expect(isValid).toBe(true);
+
+    const isTamperedValid = await verifyPayload(payload + "_TAMPERED", signature, publicJwk);
+    expect(isTamperedValid).toBe(false);
   });
 });

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -470,38 +470,22 @@ export async function decryptProfileArray(
 }
 
 // ─── P2P Emergency Mesh Signatures ──────────────────────────────────────────
+let cachedP2PKeys: { privateKey: CryptoKey; publicKey: CryptoKey } | null = null;
+
 export async function getP2PSigningKeys(): Promise<{ privateKey: CryptoKey; publicKey: CryptoKey }> {
-  const storedPrivate = localStorage.getItem("symptom_scribe_p2p_private_key");
-  const storedPublic = localStorage.getItem("symptom_scribe_p2p_public_key");
-
-  if (storedPrivate && storedPublic) {
-    try {
-      const privateJwk = JSON.parse(storedPrivate);
-      const publicJwk = JSON.parse(storedPublic);
-
-      const privateKey = await crypto.subtle.importKey(
-        "jwk",
-        privateJwk,
-        { name: "ECDSA", namedCurve: "P-256" },
-        true,
-        ["sign"]
-      );
-
-      const publicKey = await crypto.subtle.importKey(
-        "jwk",
-        publicJwk,
-        { name: "ECDSA", namedCurve: "P-256" },
-        true,
-        ["verify"]
-      );
-
-      return { privateKey, publicKey };
-    } catch (err) {
-      console.warn("Failed to load stored P2P keys, generating new ones:", err);
-    }
+  if (cachedP2PKeys) {
+    return cachedP2PKeys;
   }
 
-  // Generate new ECDSA P-256 keypair
+  // Remove any legacy P2P private key storage from browser storage.
+  // The private key is now kept only in memory for the current session.
+  if (typeof localStorage !== "undefined") {
+    localStorage.removeItem("symptom_scribe_p2p_private_key");
+    localStorage.removeItem("symptom_scribe_p2p_enc_private_key");
+    localStorage.removeItem("symptom_scribe_p2p_public_key");
+  }
+
+  // Generate a new ECDSA P-256 keypair for the current session.
   const keyPair = await crypto.subtle.generateKey(
     {
       name: "ECDSA",
@@ -511,16 +495,12 @@ export async function getP2PSigningKeys(): Promise<{ privateKey: CryptoKey; publ
     ["sign", "verify"]
   );
 
-  const privateJwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);
-  const publicJwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
-
-  localStorage.setItem("symptom_scribe_p2p_private_key", JSON.stringify(privateJwk));
-  localStorage.setItem("symptom_scribe_p2p_public_key", JSON.stringify(publicJwk));
-
-  return {
+  cachedP2PKeys = {
     privateKey: keyPair.privateKey,
     publicKey: keyPair.publicKey,
   };
+
+  return cachedP2PKeys;
 }
 
 export async function signPayload(payload: string, privateKey: CryptoKey): Promise<string> {

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -473,16 +473,16 @@ export async function decryptProfileArray(
 let cachedP2PKeys: { privateKey: CryptoKey; publicKey: CryptoKey } | null = null;
 
 export async function getP2PSigningKeys(): Promise<{ privateKey: CryptoKey; publicKey: CryptoKey }> {
-  if (cachedP2PKeys) {
-    return cachedP2PKeys;
-  }
-
   // Remove any legacy P2P private key storage from browser storage.
   // The private key is now kept only in memory for the current session.
   if (typeof localStorage !== "undefined") {
     localStorage.removeItem("symptom_scribe_p2p_private_key");
     localStorage.removeItem("symptom_scribe_p2p_enc_private_key");
     localStorage.removeItem("symptom_scribe_p2p_public_key");
+  }
+
+  if (cachedP2PKeys) {
+    return cachedP2PKeys;
   }
 
   // Generate a new ECDSA P-256 keypair for the current session.

--- a/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/pages/Dashboard/Dashboard.test.tsx
@@ -20,7 +20,7 @@
  *                       without crashing.
  */
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, act } from "@testing-library/react";
 import { render } from "@/test/utils";
 import Dashboard from "@/pages/Dashboard/";
 
@@ -32,6 +32,7 @@ vi.mock("@/integrations/supabase/client", () => ({
     auth: {
       getUser: vi.fn(),
       getSession: vi.fn(),
+      onAuthStateChange: vi.fn(),
     },
     from: vi.fn(),
   },
@@ -120,7 +121,9 @@ function mockCachedSymptoms(data: unknown[] | null, error: unknown = null) {
 function mockAuthUser(user: typeof mockUser | null = mockUser) {
   (supabase.auth.getUser as Mock).mockResolvedValue({ data: { user } });
   (supabase.auth.getSession as Mock).mockResolvedValue({
-    data: { session: user ? { access_token: "mock-token" } : null },
+    data: {
+      session: user ? { user, access_token: "mock-token" } : null,
+    },
   });
 }
 (supabase.from as Mock).mockReturnValue({
@@ -281,6 +284,29 @@ describe("Dashboard", () => {
     mockAuthUser(null);
 
     render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Health Dashboard")).toBeInTheDocument();
+    });
+  });
+
+  it("waits for an authenticated session before fetching dashboard data", async () => {
+    let authCallback: ((event: string, session: unknown) => void) | undefined;
+    (supabase.auth.getSession as Mock).mockResolvedValueOnce({ data: { session: null } });
+    (supabase.auth.onAuthStateChange as Mock).mockImplementation((callback: (event: string, session: unknown) => void) => {
+      authCallback = callback;
+      return { data: { subscription: { unsubscribe: vi.fn() } } } as never;
+    });
+    (supabase.auth.getUser as Mock).mockResolvedValue({ data: { user: mockUser } });
+    mockCachedSymptoms([]);
+
+    render(<Dashboard />);
+
+    expect(supabase.auth.getUser).not.toHaveBeenCalled();
+
+    await act(async () => {
+      authCallback?.("SIGNED_IN", { user: mockUser, access_token: "session-token" });
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Health Dashboard")).toBeInTheDocument();

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -168,23 +168,63 @@ const Dashboard = () => {
   const [decryptedSymptomsList, setDecryptedSymptomsList] = useState<string[]>([]);
 
   useEffect(() => {
-    fetchDashboardData();
-  }, []);
+    let isMounted = true;
+    let authSubscription: { unsubscribe: () => void } | null = null;
 
-  const fetchDashboardData = async () => {
-    try {
+    const initializeDashboardSession = async () => {
       const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) {
+        data: { session },
+        error: sessionError,
+      } = await supabase.auth.getSession();
+
+      if (!isMounted) return;
+
+      if (sessionError) {
+        console.warn("Unable to resolve dashboard session:", sessionError);
         setLoading(false);
         return;
       }
-      setUserId(user.id);
+
+      if (session?.user?.id) {
+        await fetchDashboardData(session.user.id);
+        return;
+      }
+
+      setLoading(false);
+
+      const authResult = supabase.auth.onAuthStateChange((_event, nextSession) => {
+        if (!isMounted || !nextSession?.user?.id) return;
+        void fetchDashboardData(nextSession.user.id);
+      });
+
+      authSubscription = authResult?.data?.subscription ?? null;
+    };
+
+    void initializeDashboardSession();
+
+    return () => {
+      isMounted = false;
+      authSubscription?.unsubscribe();
+    };
+  }, []);
+
+  const fetchDashboardData = async (providedUserId?: string) => {
+    try {
+      setLoading(true);
+
+      const { data: sessionData } = await supabase.auth.getSession();
+      const activeUserId = providedUserId ?? sessionData.session?.user?.id;
+
+      if (!activeUserId) {
+        setLoading(false);
+        return;
+      }
+
+      setUserId(activeUserId);
       const { data: profile, error: profileError } = await supabase
         .from("profiles")
         .select("*")
-        .eq("user_id", user.id)
+        .eq("user_id", activeUserId)
         .maybeSingle();
 
       if (profile?.full_name) {
@@ -202,9 +242,7 @@ const Dashboard = () => {
         }
       }
 
-
-
-      const { data: rawSymptoms, source } = await fetchSymptomHistory(user.id);
+      const { data: rawSymptoms, source } = await fetchSymptomHistory(activeUserId);
 
       if (rawSymptoms && rawSymptoms.length > 0) {
         const key = await whenEncryptionReady();


### PR DESCRIPTION
## **Pull Request Description**
A clear and concise description of the changes introduced by this pull request.

This PR hardens the P2P signing-key flow by ensuring any legacy private-key material stored in browser storage is removed and that keys remain in-memory only for the active session.

## Changes
- remove legacy P2P signing key storage entries on access
- keep private signing keys in memory only
- add regression tests for key generation, cleanup, cached reuse, and signing/verification


---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [x] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): testing
---

### **2. Related Issue**
- Fixes #680 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- npm run test -- --run src/lib/encryption.test.ts
- npm run build

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
