### PR TITLE
security: enforce Row Level Security (RLS) policies on health_metrics…

### DIFF
--- a/supabase/migrations/20260802000000_enforce_rls_health_metrics_symptom_logs.sql
+++ b/supabase/migrations/20260802000000_enforce_rls_health_metrics_symptom_logs.sql
@@ -1,0 +1,38 @@
+-- Enforce Row Level Security (RLS) policies on health_metrics, symptom_logs, and symptom_history tables
+
+-- 1. Ensure symptom_logs table exists and is secured with RLS
+CREATE TABLE IF NOT EXISTS public.symptom_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  symptoms TEXT,
+  severity_level TEXT,
+  notes TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+ALTER TABLE public.symptom_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "symptom_logs_own_rows" ON public.symptom_logs;
+CREATE POLICY "symptom_logs_own_rows" ON public.symptom_logs
+  FOR ALL TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- 2. Enable Row Level Security and enforce owner access policies on health_metrics table
+ALTER TABLE public.health_metrics ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "health_metrics_own_rows" ON public.health_metrics;
+CREATE POLICY "health_metrics_own_rows" ON public.health_metrics
+  FOR ALL TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- 3. Enable Row Level Security and enforce owner access policies on symptom_history table
+ALTER TABLE public.symptom_history ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "symptom_history_own_rows" ON public.symptom_history;
+CREATE POLICY "symptom_history_own_rows" ON public.symptom_history
+  FOR ALL TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
# security: enforce Row Level Security (RLS) policies on health_metrics and symptom_logs tables (#781)

## **Pull Request Description**
Enforces Row Level Security (RLS) policies on the `health_metrics`, `symptom_logs`, and `symptom_history` tables in Supabase via a dedicated database migration (`20260802000000_enforce_rls_health_metrics_symptom_logs.sql`). This ensures authenticated users can only query, insert, update, or delete their own health metrics and symptom records (`auth.uid() = user_id`), preventing unauthorized cross-user data access.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): Security patch

---

### **2. Related Issue**
- Fixes #781

---

### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks and test suite passed (`npm test` - 72/72 tests passed).
- [x] **Manual Verification**:
  1. Created migration `20260802000000_enforce_rls_health_metrics_symptom_logs.sql` adding `ENABLE ROW LEVEL SECURITY` and owner-matching policies (`auth.uid() = user_id`) for `health_metrics`, `symptom_logs`, and `symptom_history`.
  2. Verified project builds cleanly with `npm run build` and all 72 automated test cases pass without regressions.

---

### **4. Visual Verification (If applicable)**
N/A (Backend / Supabase database migration change)

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.

