### PR TITLE
feat: move dashboard theme selector into expandable sidebar menu

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
@@ -79,10 +79,34 @@ export function AppSidebar() {
   const [themesOpen, setThemesOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
   const isCollapsed = state === "collapsed";
+  const themePopupRef = useRef<HTMLDivElement>(null);
+  const themeTriggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  // ✅ Close the theme popup when clicking outside of it (but not when clicking the trigger, which toggles it itself)
+  useEffect(() => {
+    if (!themesOpen) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node;
+      if (
+        themePopupRef.current &&
+        !themePopupRef.current.contains(target) &&
+        themeTriggerRef.current &&
+        !themeTriggerRef.current.contains(target)
+      ) {
+        setThemesOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [themesOpen]);
 
   const activeTheme = mounted ? (resolvedTheme ?? theme ?? "light") : "light";
 
@@ -168,6 +192,7 @@ export function AppSidebar() {
 
               <SidebarMenuItem>
                 <SidebarMenuButton
+                  ref={themeTriggerRef}
                   onClick={() => setThemesOpen((prev) => !prev)}
                   className="py-2 transition-all duration-300 ease-in-out hover:scale-[1.03] hover:-translate-y-1 hover:shadow-md"
                   aria-label="Themes"
@@ -216,7 +241,8 @@ export function AppSidebar() {
       </SidebarFooter>
       {!isCollapsed && themesOpen && (
         <div
-          className="fixed top-[5.5rem] z-50 hidden h-auto w-56 rounded-2xl border border-border/70 bg-popover/95 p-3 shadow-2xl backdrop-blur supports-[backdrop-filter]:bg-popover/80 md:block"
+          ref={themePopupRef}
+          className="fixed top-[5.5rem] z-50 hidden h-auto w-56 rounded-2xl border border-border bg-popover p-3 shadow-lg md:block"
           style={{ left: 272 }}
         >
           <div className="mb-3 px-1 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -11,9 +11,14 @@ import {
   Settings,
   Bot,
   Trophy,
+  Palette,
+  PanelLeftClose,
+  Check,
 } from "lucide-react";
 
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -55,12 +60,31 @@ const menuItems = [
   { title: "Settings", url: "/settings", icon: Settings },
 ];
 
+const themeOptions = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "cosmic", label: "Cosmic" },
+  { value: "deep-blue", label: "Deep Blue" },
+  { value: "forest", label: "Forest" },
+  { value: "orange", label: "Orange" },
+  { value: "pastel-pink", label: "Pastel Pink" },
+];
+
 export function AppSidebar() {
   const { state, setOpenMobile, isMobile } = useSidebar();
   const location = useLocation();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [themesOpen, setThemesOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
   const isCollapsed = state === "collapsed";
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const activeTheme = mounted ? (resolvedTheme ?? theme ?? "light") : "light";
 
   const handleMobileNavClick = () => {
     if (isMobile) {
@@ -122,9 +146,6 @@ export function AppSidebar() {
             {/* ✨ updated: small gap between rows so the tinted active state has breathing room */}
             <SidebarMenu className="px-1">
               {menuItems.map((item) => {
-                // Existing hover/animation is preserved verbatim; the active-tab
-                // styling (tinted pill + left accent border) is only appended for
-                // the current route.
                 const isActive = location.pathname === item.url;
                 return (
                   <SidebarMenuItem key={item.title}>
@@ -144,6 +165,22 @@ export function AppSidebar() {
                   </SidebarMenuItem>
                 );
               })}
+
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  onClick={() => setThemesOpen((prev) => !prev)}
+                  className="py-2 transition-all duration-300 ease-in-out hover:scale-[1.03] hover:-translate-y-1 hover:shadow-md"
+                  aria-label="Themes"
+                >
+                  <Palette className="h-[17px] w-[17px]" />
+                  {!isCollapsed && <span className="text-[13.5px]">Themes</span>}
+                  {!isCollapsed && (
+                    <span className="ml-auto text-muted-foreground">
+                      <PanelLeftClose className="h-4 w-4" />
+                    </span>
+                  )}
+                </SidebarMenuButton>
+              </SidebarMenuItem>
               <AlertDialog>
                 <AlertDialogTrigger asChild>
                   {/* ✨ updated: matching rounded-md + transition-colors for consistency with nav items */}
@@ -177,6 +214,37 @@ export function AppSidebar() {
       <SidebarFooter className="px-1 border-t border-sidebar-border/20 pt-2">
         <EmergencyQuickAccess />
       </SidebarFooter>
+      {!isCollapsed && themesOpen && (
+        <div
+          className="fixed top-[5.5rem] z-50 hidden h-auto w-56 rounded-2xl border border-border/70 bg-popover/95 p-3 shadow-2xl backdrop-blur supports-[backdrop-filter]:bg-popover/80 md:block"
+          style={{ left: 272 }}
+        >
+          <div className="mb-3 px-1 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+            Themes
+          </div>
+          <div className="flex flex-col gap-1.5">
+            {themeOptions.map((option) => {
+              const isActive = activeTheme === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setTheme(option.value)}
+                  className={`flex items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition-colors ${
+                    isActive
+                      ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                  }`}
+                  aria-label={option.label}
+                >
+                  <span>{option.label}</span>
+                  {isActive ? <Check className="h-4 w-4" /> : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </Sidebar>
   );
 }

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -18,6 +18,7 @@ import {
 
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTheme } from "next-themes";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
@@ -239,38 +240,42 @@ export function AppSidebar() {
       <SidebarFooter className="px-1 border-t border-sidebar-border/20 pt-2">
         <EmergencyQuickAccess />
       </SidebarFooter>
-      {!isCollapsed && themesOpen && (
-        <div
-          ref={themePopupRef}
-          className="fixed top-[5.5rem] z-50 hidden h-auto w-56 rounded-2xl border border-border bg-popover p-3 shadow-lg md:block"
-          style={{ left: 272 }}
-        >
-          <div className="mb-3 px-1 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-            Themes
-          </div>
-          <div className="flex flex-col gap-1.5">
-            {themeOptions.map((option) => {
-              const isActive = activeTheme === option.value;
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  onClick={() => setTheme(option.value)}
-                  className={`flex items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition-colors ${
-                    isActive
-                      ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
-                  }`}
-                  aria-label={option.label}
-                >
-                  <span>{option.label}</span>
-                  {isActive ? <Check className="h-4 w-4" /> : null}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
+      {!isCollapsed &&
+        themesOpen &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            ref={themePopupRef}
+            className="fixed top-[5.5rem] z-[999] hidden h-auto w-56 rounded-2xl border border-border bg-popover p-3 shadow-lg md:block"
+            style={{ left: 272 }}
+          >
+            <div className="mb-3 px-1 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+              Themes
+            </div>
+            <div className="flex flex-col gap-1.5">
+              {themeOptions.map((option) => {
+                const isActive = activeTheme === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setTheme(option.value)}
+                    className={`flex items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition-colors ${
+                      isActive
+                        ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium"
+                        : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                    }`}
+                    aria-label={option.label}
+                  >
+                    <span>{option.label}</span>
+                    {isActive ? <Check className="h-4 w-4" /> : null}
+                  </button>
+                );
+              })}
+            </div>
+          </div>,
+          document.body
+        )}
     </Sidebar>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,5 @@
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/layout/AppSidebar";
-import { AnimatedThemeToggler } from "@/components/theme/components/AnimatedThemeToggler";
 import { BackToTop } from "@/components/navigation/BackToTop";
 
 interface LayoutProps {
@@ -17,8 +16,6 @@ const Layout = ({ children }: LayoutProps) => {
             <div className="ml-auto flex items-center"></div>
 
             <div className="flex items-center gap-2">
-              <AnimatedThemeToggler />
-
               {/* ✅ Visible ONLY on mobile. Hidden on laptop/desktop. */}
               <div className="md:hidden">
                 <SidebarTrigger />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -12,14 +12,10 @@ const Layout = ({ children }: LayoutProps) => {
       <div className="min-h-screen overflow-hidden flex w-full max-w-full bg-background">
         <AppSidebar />
         <div className="flex-1 flex flex-col min-h-0">
-          <header className="flex h-14 items-center justify-between border-b border-border bg-card px-4">
-            <div className="ml-auto flex items-center"></div>
-
-            <div className="flex items-center gap-2">
-              {/* ✅ Visible ONLY on mobile. Hidden on laptop/desktop. */}
-              <div className="md:hidden">
-                <SidebarTrigger />
-              </div>
+          {/* ✅ Header only renders on mobile now — on desktop it had no content and was just leaving an empty h-14 bar at the top of every page */}
+          <header className="flex h-14 items-center justify-between border-b border-border bg-card px-4 md:hidden">
+            <div className="ml-auto flex items-center">
+              <SidebarTrigger />
             </div>
           </header>
           <main id="main-scroll" className="flex-1 min-h-0 min-w-0 overflow-y-auto p-4 md:p-6">


### PR DESCRIPTION
## Pull Request Description

This PR refines the dashboard theme management experience by relocating theme selection from the header into an expandable sidebar section. Instead of introducing a separate Themes page, the implementation reuses the existing theme switching functionality within the sidebar, reducing navigation overhead while preserving all existing behavior.

---

## 1. Type of Change

- [x] New Feature (non-breaking change which adds functionality)
- [ ] Bug Fix
- [ ] Refactoring / Performance
- [ ] Documentation Update
- [ ] Other

---

## 2. What Changed

### Dashboard Navigation
- Removed the theme toggle from the authenticated dashboard header.
- Added a dedicated **Themes** item to the dashboard sidebar.
- Implemented an expandable theme selector that opens beside the sidebar.

### Theme Management
- Reused the existing theme switching logic.
- Preserved all available themes.
- Displayed the active theme with a check indicator.
- No changes were made to the underlying theme provider or theme functionality.

### UI Improvements
- Replaced inconsistent icons with Lucide icons.
- Reduced unnecessary page navigation by embedding theme selection directly into the sidebar.
- Kept the dashboard header cleaner for future actions.

---

## 3. Files Changed

- `src/components/layout/AppSidebar.tsx`
- `src/components/layout/Layout.tsx`

---

### Before 
<img width="1334" height="630" alt="image" src="https://github.com/user-attachments/assets/83e1bd15-158a-4b1e-91e9-395ac306862f" />

### After
<img width="1328" height="619" alt="image" src="https://github.com/user-attachments/assets/f10a3cc2-15a0-4e31-8a88-b3bbc3a4d939" />

## 4. Testing

### Manual Testing

- [x] Theme toggle removed from dashboard header.
- [x] Sidebar displays Themes item.
- [x] Theme selector expands correctly.
- [x] All themes switch successfully.
- [x] Theme persists after refresh.
- [x] Landing/Login/Signup pages remain unchanged.
- [x] Mobile layout continues to function correctly.

### Automated Testing

- [x] Existing test suite passes successfully.

 ## Closes #778
