### PR TITLE
feat: add Back to Home link on Auth page for better navigation UX

### DIFF
--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 
 import { Button } from "@/components/ui/button";
@@ -14,6 +14,7 @@ import { useToast } from "@/hooks/use-toast";
 
 import {
   Activity,
+  ArrowLeft,
   Loader2,
   Mail,
   Lock,
@@ -218,7 +219,16 @@ const handleForgotPassword= async () => {
       <div className="absolute inset-0 bg-[linear-gradient(120deg,rgba(6,182,212,0.16),transparent_34%,rgba(16,185,129,0.12)_78%)]" />
       <div className="absolute -bottom-32 left-0 h-72 w-full bg-[linear-gradient(165deg,transparent_18%,rgba(45,212,191,0.16)_19%,rgba(45,212,191,0.06)_36%,transparent_37%),linear-gradient(18deg,transparent_42%,rgba(125,211,252,0.12)_43%,rgba(125,211,252,0.04)_60%,transparent_61%)] blur-sm" />
       <div className="absolute inset-0 bg-slate-950/35" />
-
+      {/* Back to Home link */}
+      <div className="relative z-10 mx-auto w-full max-w-6xl pt-4">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-sm text-cyan-400 hover:text-cyan-300 transition-colors duration-200"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Home
+        </Link>
+      </div>
       <main className="relative z-10 mx-auto grid min-h-[calc(100vh-4rem)] w-full max-w-6xl items-center gap-8 lg:grid-cols-[1fr_460px]">
         <section className="hidden max-w-xl space-y-8 lg:block">
           <div className="inline-flex items-center gap-2 rounded-full border border-cyan-200/15 bg-white/8 px-4 py-2 text-sm font-medium text-cyan-100 shadow-lg shadow-slate-950/20 backdrop-blur-xl">


### PR DESCRIPTION
## **Pull Request Description**
Adds a "← Back to Home" link at the top of the authentication page (`/auth`), 
allowing users to navigate back to the landing page without using the browser's 
back button. This is a small UX improvement that follows standard web navigation 
patterns.

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [x] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #845 

---

### **3. How Has This Been Tested?**
- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**:
  1. Navigated to `/auth` page
  2. Verified "← Back to Home" link appears at top left
  3. Verified clicking the link navigates back to `/` (landing page)
  4. Verified link styling matches existing cyan color scheme

---

### **4. Visual Verification (If applicable)**

| Before | After |
|  
<img width="1710" height="982" alt="Screenshot 2026-08-02 at 11 15 16 AM" src="https://github.com/user-attachments/assets/485c1e4c-960e-479b-b56a-c65725d2ac83" />
|
<img width="1710" height="1032" alt="Screenshot 2026-08-02 at 11 14 15 AM" src="https://github.com/user-attachments/assets/10491f2a-1218-4f4b-be33-ada2d7c982e9" />
 |
| No way to go back to home from auth page | "← Back to Home" link visible at top of auth page |


---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.