### PR TITLE
fix(#704): replace Math.random() in SidebarMenuSkeleton with deterministic width

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -532,10 +532,11 @@ const SidebarMenuSkeleton = React.forwardRef<
   }
 >(({ className, showIcon = false, ...props }, ref) => {
   // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
-
+const width = React.useMemo(() => {
+  const seed = 0x4d61766973; // "Mavis"
+  const result = ((seed * 1664525 + 1013904223) >>> 0) % 40 + 50;
+  return `${result}%`;
+}, []);
   return (
     <div
       ref={ref}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -532,11 +532,7 @@ const SidebarMenuSkeleton = React.forwardRef<
   }
 >(({ className, showIcon = false, ...props }, ref) => {
   // Random width between 50 to 90%.
-const width = React.useMemo(() => {
-  const seed = 0x4d61766973; // "Mavis"
-  const result = ((seed * 1664525 + 1013904223) >>> 0) % 40 + 50;
-  return `${result}%`;
-}, []);
+const width = "75%";
   return (
     <div
       ref={ref}


### PR DESCRIPTION
## **Pull Request Description**

This pull request replaces the `Math.random()`-based width calculation in the `SidebarMenuSkeleton` component with a deterministic width value to ensure consistent rendering and eliminate unnecessary randomness.

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [x] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**

**Fixes #704**

---

### **3. How Has This Been Tested?**

- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**

Manual Verification:
1. Verified that the `SidebarMenuSkeleton` renders correctly after replacing the random width calculation.
2. Confirmed that the skeleton width remains deterministic and consistent across re-renders.

---

### **4. Visual Verification (If applicable)**

Not applicable. This change does not introduce any visible UI changes. It only replaces the random width generation with a deterministic implementation.

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.