### PR TITLE
feat(#682): add CSV export option to symptom history page

### DIFF
--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -311,20 +311,31 @@ const History = () => {
   };
 
   const exportCSV = () => {
-    const headers = ["Date", "Symptoms", "Severity", "Risk Score", "Resolved"];
+    const headers = [
+  "Date",
+  "Symptoms",
+  "Severity",
+  "Risk Score",
+  "Possible Causes",
+  "Recommendations",
+  "Resolved",
+];
     const rows = history.map((entry) => [
-      new Date(entry.created_at).toLocaleDateString(),
-      `"${entry.symptoms.replace(/"/g, '""')}"`,
-      entry.severity_level,
-      entry.risk_score,
-      entry.resolved ? "Yes" : "No",
-    ]);
+  new Date(entry.created_at).toLocaleDateString(),
+  `"${entry.symptoms.replace(/"/g, '""')}"`,
+  entry.severity_level,
+  entry.risk_score,
+  `"${entry.possible_causes.join("; ").replace(/"/g, '""')}"`,
+  `"${entry.recommendations.join("; ").replace(/"/g, '""')}"`,
+  entry.resolved ? "Yes" : "No",
+]);
     const csv = [headers, ...rows].map((r) => r.join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "symptom-history.csv";
+    const date = new Date().toISOString().split("T")[0];
+a.download = `symptom-history-${date}.csv`;
     a.click();
     URL.revokeObjectURL(url);
   };


### PR DESCRIPTION
## **Pull Request Description**

This pull request enhances the Symptom History page by improving the CSV export functionality. The exported CSV now includes all requested symptom history fields and generates a date-based filename for easier organization.

---

### **1. Type of Change**
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Refactoring / Performance (non-breaking code improvements)
- [ ] Documentation Update (changes to README, guides, or comments)
- [ ] Other (please specify): _________

---

### **2. Related Issue**

Fixes #682

---

### **3. How Has This Been Tested?**

- [ ] Local Build
- [ ] Lint/Format Checks
- [x] Manual Verification

Manual Verification:
1. Verified that the CSV export downloads successfully from the Symptom History page.
2. Confirmed that the exported CSV includes Date, Symptoms, Severity, Risk Score, Possible Causes, Recommendations, and Resolved columns.
3. Verified that the downloaded filename follows the `symptom-history-YYYY-MM-DD.csv` format.

---

### **4. Visual Verification (If applicable)**

Not applicable. This feature adds export functionality without changing the page layout.

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.