### PR TITLE
fix : added deduplication for dismissed alert IDs in alerts-engine

### DIFF
--- a/src/lib/alerts-engine.ts
+++ b/src/lib/alerts-engine.ts
@@ -15,7 +15,11 @@ const DISMISSED_ALERTS_KEY = "symptom_scribe_dismissed_alerts";
 export function getDismissedAlerts(): string[] {
   try {
     const stored = localStorage.getItem(DISMISSED_ALERTS_KEY);
-    return stored ? JSON.parse(stored) : [];
+    if (!stored) return [];
+    // Deduplicate IDs using a Set to handle corrupt or duplicate entries in storage
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return [...new Set(parsed.filter((id): id is string => typeof id === "string"))];
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary of What Has Been Done
Modified `src/lib/alerts-engine.ts` to use a `Set` for deduplication when reading dismissed alert IDs from localStorage. The `getDismissedAlerts` function now:
- Parses the stored JSON
- Validates that the parsed result is an array
- Filters out non-string values
- Returns a deduplicated array via `new Set(...)`

This ensures that corrupt or duplicate entries in localStorage cannot cause the same alert ID to appear multiple times.

## Changes Made
- `getDismissedAlerts()`: Added `new Set(...)` deduplication and type validation
- No changes to `dismissAlert` or `detectSmartAlerts` logic

## Impact it Made
- Prevents potential duplicate alert filtering failures if localStorage contains duplicates
- Improves robustness of the alerts engine for edge-case storage states
- No behavioral change for normal operation

## Note: Please assign this PR to the `tmdeveloper007` account.
