### PR TITLE
security : normalized decrypt errors to prevent information leakage

### DIFF
--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -225,14 +225,21 @@ export async function decryptText(encryptedText: string, key: CryptoKey): Promis
   const iv = hexToUint8Array(ivHex);
   const ciphertext = hexToUint8Array(ciphertextHex);
 
-  const decryptedBuffer = await crypto.subtle.decrypt(
-    {
-      name: "AES-GCM",
-      iv: iv,
-    },
-    key,
-    ciphertext
-  );
+  let decryptedBuffer: ArrayBuffer;
+  try {
+    decryptedBuffer = await crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: iv,
+      },
+      key,
+      ciphertext
+    );
+  } catch (err) {
+    // Normalize all Web Crypto API errors to a generic message to avoid
+    // leaking implementation details through error messages
+    throw new Error("Decryption failed");
+  }
 
   const decoder = new TextDecoder();
   return decoder.decode(decryptedBuffer);
@@ -465,8 +472,18 @@ export async function decryptProfileArray(
   key: CryptoKey
 ): Promise<string[]> {
   if (!value) return [];
-  const jsonString = await decryptText(value, key);
-  return JSON.parse(jsonString);
+  let jsonString: string;
+  try {
+    jsonString = await decryptText(value, key);
+  } catch {
+    // Decryption failed — return empty array rather than crashing
+    return [];
+  }
+  try {
+    return JSON.parse(jsonString);
+  } catch {
+    return [];
+  }
 }
 
 // ─── P2P Emergency Mesh Signatures ──────────────────────────────────────────


### PR DESCRIPTION
## Summary of What Has Been Done
Modified `src/lib/encryption.ts` to normalize Web Crypto API errors in decryption functions, preventing browser-specific error messages from leaking through to callers.

## Changes Made
- `decryptText()`: Wrapped `crypto.subtle.decrypt` call in a try-catch. On failure, throws a generic `Error("Decryption failed")` instead of the raw `DOMException`
- `decryptProfileArray()`: Added try-catch around `decryptText` and `JSON.parse` to return an empty array on failure instead of propagating errors

## Impact it Made
- Prevents sensitive implementation details from leaking through error messages
- Consistent error handling for decryption failures across all callers
- Callers of `decryptProfileArray` no longer need their own try-catch for decryption failures

## Note: Please assign this PR to the `tmdeveloper007` account.
