### PR TITLE
fix: replace console.error with console.warn in Emergency health page

### DIFF
--- a/src/pages/Health/Emergency.tsx
+++ b/src/pages/Health/Emergency.tsx
@@ -244,7 +244,7 @@ const Emergency = () => {
         alerts.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
         setMeshAlerts(alerts);
       } catch (err) {
-        console.error("Failed to load mesh alerts:", err);
+        console.warn("Failed to load mesh alerts:", err);
       }
     };
 
@@ -299,7 +299,7 @@ const Emergency = () => {
           .maybeSingle();
 
         if (error) {
-          console.error("Error loading emergency profile info:", error);
+          console.warn("Error loading emergency profile info:", error);
         } else if (data) {
           const key = await whenEncryptionReady();
           const decryptedFullName = await decryptProfileField(data.full_name, key);
@@ -314,7 +314,7 @@ const Emergency = () => {
         }
 
       } catch (err) {
-        console.error("Error loading profile:", err);
+        console.warn("Error loading profile:", err);
       } finally {
         setProfileLoading(false);
       }
@@ -390,7 +390,7 @@ const Emergency = () => {
         await executeMeshAlert(latitude, longitude);
       },
       async (error) => {
-        console.error("Geolocation failed:", error);
+        console.warn("Geolocation failed:", error);
         setAlertProgressMessage("Unable to get location. Starting broadcast without coordinates...");
         await executeMeshAlert(null, null);
       },
@@ -415,7 +415,7 @@ const Emergency = () => {
         }
       })
       .catch((err) => {
-        console.error("Geolocation fetch failed:", err);
+        console.warn("Geolocation fetch failed:", err);
       });
   }, []);
 
@@ -457,7 +457,7 @@ const Emergency = () => {
       oscillator.start(ctx.currentTime);
       oscillator.stop(ctx.currentTime + 0.4);
     } catch (err) {
-      console.error("Audio beep failed:", err);
+      console.warn("Audio beep failed:", err);
     }
   };
 


### PR DESCRIPTION
## Pull Request Description

### 1. Type of Change
- [x] Bug Fix

### 2. Related Issue
Fixes #770

### 3. How Has This Been Tested?
- [x] Local Build
- [x] Manual Verification

1. Verified non-critical logs now use `console.warn`.
2. Confirmed no functional behavior changes.

### 4. Visual Verification
N/A

### 5. Contributor Quality Checklist
- [x] My code follows the project style guidelines.
- [x] I have performed a self-review.
- [x] My changes generate no new warnings or console errors.
- [x] No commented-out code or debug logs remain.