### PR TITLE
feat: add empty states with CTAs for Dashboard, Metrics, and Chat History

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -12,12 +12,15 @@ import {
   Thermometer,
   Brain,
   HeartPulse,
+  MessageSquarePlus,
 } from "lucide-react";
 import ChatMessage from "./ChatMessage";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { browserEnv } from "@/lib/env";
 import { showSuccess, showError, showInfo, showLoading, showWarning } from "@/lib/toast-helpers";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/common/EmptyState";
 import { invalidateCache } from "@/lib/cached-queries";
 import { whenKeysReady } from "@/lib/encryption";
 import { encryptSymptom, db, type OfflineSymptom } from "@/lib/offline-db";
@@ -402,22 +405,38 @@ const ChatInterface = () => {
   const isWelcomeState = messages.length === 1 && messages[0] === INITIAL_GREETING;
 
   const renderHistoryList = () => {
-    if (sessionsLoading) {
-      return (
-        <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
-          <Loader2 className="w-4 h-4 animate-spin mr-2" />
-          Loading history...
-        </div>
-      );
-    }
+  if (sessionsLoading) {
+    return (
+      <div className="space-y-2 p-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 rounded-lg border border-border/60 px-3 py-2.5"
+          >
+            <Skeleton className="h-4 w-4 rounded-full shrink-0" />
+            <Skeleton className="h-4 flex-1 rounded" />
+          </div>
+        ))}
+      </div>
+    );
+  }
 
-    if (sessions.length === 0) {
-      return (
-        <div className="text-center py-8 text-sm text-muted-foreground px-4">
-          No previous sessions found. Start a conversation to save one!
-        </div>
-      );
-    }
+  if (sessions.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <MessageSquarePlus
+            className="w-8 h-8 text-teal-600 dark:text-teal-400"
+            strokeWidth={1.5}
+          />
+        }
+        title="Start a new conversation"
+        description="Your saved chat sessions will appear here once you begin talking with the AI assistant."
+        ctaText="New Chat"
+        onCtaClick={handleNewChat}
+      />
+    );
+  }
 
     return (
       <div className="space-y-1 p-2 overflow-y-auto flex-1 select-none chat-scrollbar">

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -439,7 +439,7 @@ const ChatInterface = () => {
   }
 
     return (
-      <div className="space-y-1 p-2 overflow-y-auto flex-1 select-none chat-scrollbar">
+       <div className="space-y-1 p-2 overflow-y-auto flex-1 select-none chat-scrollbar animate-fade-in">
         {sessions.map((session) => {
           const isActive = session.id === activeSessionId;
           return (

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface EmptyStateProps {
+  icon: ReactNode;
+  title: string;
+  description?: string;
+  ctaText?: string;
+  onCtaClick?: () => void;
+  className?: string;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  ctaText,
+  onCtaClick,
+  className = "",
+}: EmptyStateProps) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center text-center py-12 px-4 gap-4 animate-in fade-in duration-300 ${className}`}
+    >
+      <div className="flex items-center justify-center w-16 h-16 rounded-full bg-teal-50 dark:bg-teal-950">
+        {icon}
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+        {description && (
+          <p className="text-sm text-muted-foreground max-w-xs">{description}</p>
+        )}
+      </div>
+      {ctaText && onCtaClick && (
+        <Button
+          onClick={onCtaClick}
+          className="bg-teal-600 hover:bg-teal-700 text-white mt-2"
+        >
+          {ctaText}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/pages/Dashboard/Dashboard.test.tsx
@@ -192,7 +192,7 @@ describe("Dashboard", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/No symptom history yet/i)
+        screen.getByText(/No health data yet/i)
       ).toBeInTheDocument();
     });
   });

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -15,6 +15,8 @@ import { motion } from "framer-motion";
 import { SmartAlertsBanner } from "@/components/dashboard/SmartAlertsBanner";
 import CardSkeleton from "@/components/ui/CardSkeleton";
 import { WeeklyHealthScoreCard } from "@/components/dashboard/WeeklyHealthScoreCard";
+import { useNavigate } from "react-router-dom";
+import { EmptyState } from "@/components/common/EmptyState";
 
 interface Stats {
   totalSymptoms: number;
@@ -154,6 +156,7 @@ const RadialWellnessGauge = ({ score }: { score: number }) => {
 };
 
 const Dashboard = () => {
+  const navigate = useNavigate();
   const [stats, setStats] = useState<Stats>({
     totalSymptoms: 0,
     unresolvedSymptoms: 0,
@@ -490,10 +493,14 @@ const Dashboard = () => {
         </CardHeader>
         <CardContent>
           {recentHistory.length === 0 ? (
-            <p className="text-muted-foreground text-center py-8">
-              No symptom history yet. Start by consulting with the AI Assistant!
-            </p>
-          ) : (
+              <EmptyState
+                  icon={<Activity className="w-8 h-8 text-teal-600 dark:text-teal-400" strokeWidth={1.5} />}
+                 title="No health data yet — start tracking!"
+                  description="Consult the AI Assistant to log your first symptom check."
+                  ctaText="Start Tracking"
+                  onCtaClick={() => navigate("/ai-health-assistant")}
+                  />
+                  ) : (
             <div className="space-y-4">
               {recentHistory.map((item) => (
                 <div

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -308,7 +308,7 @@ const Dashboard = () => {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-fade-in">
       <Card className="border"
         style={{ background: "var(--welcome-bg)" }}>
         <CardContent className="flex items-center justify-between py-6">

--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -562,7 +562,7 @@ const History = () => {
               </CardContent>
             </Card>
           ) : (
-            <div className="space-y-4">
+            <div className="space-y-4 animate-fade-in">
               {filteredHistory.map((entry) => (
                 <Card key={entry.id} className={entry.resolved ? "opacity-70" : ""}>
                   <CardHeader>

--- a/src/pages/Metrics/index.tsx
+++ b/src/pages/Metrics/index.tsx
@@ -599,7 +599,7 @@ const Metrics = () => {
           onCtaClick={() => setFormOpen(true)}
           />
           ) : (
-            <>
+            <div className="animate-fade-in">
               <div className="flex flex-wrap gap-3 mb-4">
                 <Select
                   value={historyMetricFilter}
@@ -785,7 +785,7 @@ const Metrics = () => {
                     </ResponsiveContainer>
                   </div>
                 ))}
-            </>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/pages/Metrics/index.tsx
+++ b/src/pages/Metrics/index.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { EmptyState } from "@/components/common/EmptyState";
+
 import {
   Card,
   CardContent,
@@ -583,13 +585,19 @@ const Metrics = () => {
         <CardContent>
           {historyLoading ? (
             historyView === "table" ? <MetricsTableSkeleton /> : <MetricsChartSkeleton />
-          ) : records.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-center">
-              <p className="text-lg font-medium">No health metrics yet</p>
-              <p className="text-sm text-muted-foreground mt-1">
-                Record your first measurement above to start tracking trends.
-              </p>
-            </div>
+        ) : records.length === 0 ? (
+          <EmptyState
+          icon={
+          <Activity
+            className="w-8 h-8 text-teal-600 dark:text-teal-400"
+            strokeWidth={1.5}
+           />
+           }
+          title="Add your first health metric"
+          description="Record a measurement above to start tracking trends over time."
+          ctaText="Add Metric"
+          onCtaClick={() => setFormOpen(true)}
+          />
           ) : (
             <>
               <div className="flex flex-wrap gap-3 mb-4">


### PR DESCRIPTION
## Summary
Clean re-submission of the empty-state / skeleton work previously in #854, rebased onto latest `main` so the PR only contains the required feature files (no unrelated merge noise).

Adds actionable empty states with icons, descriptions, and CTA buttons to **Dashboard**, **Metrics**, and **Chat History**, plus fade-in transitions when content loads — matching the existing design pattern on the Symptom History page.

Closes #789

## Changes
- New reusable `EmptyState` component (`src/components/common/EmptyState.tsx`)
- **Dashboard**: "No health data yet — start tracking!" empty state with CTA to AI Assistant
- **Metrics**: "Add your first health metric" empty state with CTA to open the record form
- **Chat**: loading skeleton rows for session history + "Start a new conversation" empty state with New Chat CTA
- Fade-in transitions on loaded content for Dashboard, History, Metrics, and Chat (`animate-fade-in`, no new dependency)
- Updated Dashboard test assertion to match the new empty-state copy

## Why a new PR?
Per maintainer feedback on #854: the previous branch picked up unrelated files after merging `main`. This branch was created fresh from latest `main` and only re-applies the feature commits.

## Testing
- [x] `npx tsc --noEmit` — passes
- [ ] Manual: Dashboard empty state renders with CTA
- [ ] Manual: Metrics empty state renders with CTA
- [ ] Manual: Chat History empty state + skeleton loading

## Screenshots
(Before/after screenshots for Dashboard, Metrics, and Chat will be attached in a follow-up comment.)