### PR TITLE
feat(#776): debounce and rate limit symptom analysis API calls

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -32,6 +32,7 @@ import {
   shouldPersistConsultation,
 } from "@/lib/symptom-consultation";
 import { compressImage, uploadSymptomImage } from "@/lib/image-utils";
+import { useSubmitGuard, getRejectionMessage } from "@/hooks/useSubmitGuard";
 import ChatLoading from "./ChatLoading";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { type Json } from "@/integrations/supabase/types";
@@ -82,6 +83,10 @@ const ChatInterface = () => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
+
+  // Throttles the analysis endpoint: no overlapping requests, a short cooldown
+  // between sends, and a per-minute budget.
+  const runGuardedSend = useSubmitGuard();
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
@@ -168,9 +173,7 @@ const ChatInterface = () => {
     setIsMobileOpen(false);
   };
 
-  const handleSend = async () => {
-    if (!input.trim() || isLoading) return;
-
+  const sendMessage = async () => {
     const userMessage: Message = { role: "user", content: input.trim() };
     const newMessages = [...messages, userMessage];
     setMessages(newMessages);
@@ -251,6 +254,10 @@ const ChatInterface = () => {
         },
         body: JSON.stringify({ messages: [...recentContext, userMessage] }),
       });
+
+      if (response.status === 429) {
+        throw new Error("Too many requests. Please wait a moment before trying again.");
+      }
 
       if (!response.ok || !response.body) {
         throw new Error("Failed to start stream");
@@ -426,6 +433,16 @@ const ChatInterface = () => {
       setIsLoading(false);
       setSelectedFiles([]);
       if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const handleSend = async () => {
+    if (!input.trim() || isLoading) return;
+
+    const outcome = await runGuardedSend(sendMessage);
+
+    if (outcome.status === "rejected") {
+      showWarning("Too many requests", getRejectionMessage(outcome.reason, outcome.retryAfterMs));
     }
   };
 

--- a/src/components/dashboard/SymptomPredictions.tsx
+++ b/src/components/dashboard/SymptomPredictions.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Sparkles, AlertTriangle, CheckCircle, Info, Loader2 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { browserEnv } from "@/lib/env";
+import { useDebounce } from "@/hooks/useDebounce";
 
 interface Prediction {
   risk: string;
@@ -17,29 +18,60 @@ interface SymptomPredictionsProps {
   symptoms: string[];
 }
 
+/**
+ * Idle time before a changed symptom list is sent for analysis. The dashboard
+ * can refresh this list several times in a row (initial load, cache hydration,
+ * offline sync), and only the final list is worth an edge function call.
+ */
+const PREDICTION_DEBOUNCE_MS = 800;
+
 export default function SymptomPredictions({ userId, symptoms }: SymptomPredictionsProps) {
   const [predictions, setPredictions] = useState<Prediction[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const symptomsHash = useMemo(() => symptoms.join("|"), [symptoms]);
+  const debouncedSymptomsHash = useDebounce(symptomsHash, PREDICTION_DEBOUNCE_MS);
+
+  // The effect below is keyed on the debounced hash rather than on the array
+  // itself, so a new array carrying the same symptoms never refires it. The ref
+  // hands the effect the matching list without widening its dependencies.
+  const symptomsRef = useRef(symptoms);
+  symptomsRef.current = symptoms;
+
+  // Identifies the request currently in flight, and the one the UI is waiting
+  // on, so the same analysis is never fired twice and a response that arrives
+  // after the symptom list has moved on is discarded.
+  const inFlightRequestRef = useRef<string | null>(null);
+  const latestRequestRef = useRef<string | null>(null);
+
   useEffect(() => {
-    if (!userId || symptoms.length === 0) {
+    const currentSymptoms = symptomsRef.current;
+    const requestKey = `${userId}:${debouncedSymptomsHash}`;
+    latestRequestRef.current = requestKey;
+
+    if (!userId || currentSymptoms.length === 0) {
       setPredictions([]);
       return;
     }
+
+    // A request for this exact symptom list is already running — reuse it
+    // instead of paying for a second identical call.
+    if (inFlightRequestRef.current === requestKey) return;
+
+    const isStale = () => latestRequestRef.current !== requestKey;
 
     const fetchPredictions = async () => {
       // 1. Check local storage cache
       const cacheKey = `ai_health_predictions_${userId}`;
       const cached = localStorage.getItem(cacheKey);
-      const symptomsHash = symptoms.join("|");
 
       if (cached) {
         try {
           const parsed = JSON.parse(cached);
           const age = Date.now() - parsed.timestamp;
           // Refresh if cache is > 24 hours OR if symptoms list changed
-          if (age < 24 * 60 * 60 * 1000 && parsed.symptomsHash === symptomsHash) {
+          if (age < 24 * 60 * 60 * 1000 && parsed.symptomsHash === debouncedSymptomsHash) {
             setPredictions(parsed.predictions);
             return;
           }
@@ -47,6 +79,8 @@ export default function SymptomPredictions({ userId, symptoms }: SymptomPredicti
           console.warn("Failed to parse cached predictions", e);
         }
       }
+
+      inFlightRequestRef.current = requestKey;
 
       setLoading(true);
       setError(null);
@@ -65,7 +99,7 @@ export default function SymptomPredictions({ userId, symptoms }: SymptomPredicti
           },
           body: JSON.stringify({
             mode: "predict",
-            symptoms,
+            symptoms: currentSymptoms,
           }),
         });
 
@@ -75,6 +109,8 @@ export default function SymptomPredictions({ userId, symptoms }: SymptomPredicti
 
           if (response.status === 401 || response.status === 403) {
             errorMessage = "Authentication failed. Please log in again.";
+          } else if (response.status === 429) {
+            errorMessage = "Too many requests. Predictions will refresh shortly.";
           } else if (response.status === 0 || response.type === "opaque" || response.type === "error") {
             errorMessage = "Network error. Please check your connection and try again.";
           } else if (response.status >= 500) {
@@ -100,30 +136,36 @@ export default function SymptomPredictions({ userId, symptoms }: SymptomPredicti
           cacheKey,
           JSON.stringify({
             predictions: preds,
-            symptomsHash,
+            symptomsHash: debouncedSymptomsHash,
             timestamp: Date.now(),
           })
         );
 
-        setPredictions(preds);
+        if (!isStale()) setPredictions(preds);
       } catch (err) {
         console.error("Error fetching AI predictions:", err);
 
-        // Handle specific error types for better error messages
-        if (err instanceof TypeError && err.message.includes("fetch")) {
-          setError("Network error. Please check your internet connection and try again.");
-        } else if (err instanceof Error) {
-          setError(err.message);
-        } else {
-          setError("Failed to load predictions");
+        // Handle specific error types for better error messages. A response for
+        // a symptom list that has since moved on is dropped rather than shown.
+        if (!isStale()) {
+          if (err instanceof TypeError && err.message.includes("fetch")) {
+            setError("Network error. Please check your internet connection and try again.");
+          } else if (err instanceof Error) {
+            setError(err.message);
+          } else {
+            setError("Failed to load predictions");
+          }
         }
       } finally {
-        setLoading(false);
+        if (inFlightRequestRef.current === requestKey) {
+          inFlightRequestRef.current = null;
+        }
+        if (!isStale()) setLoading(false);
       }
     };
 
     fetchPredictions();
-  }, [userId, symptoms]);
+  }, [userId, debouncedSymptomsHash]);
 
   const getConfidenceColor = (conf: string) => {
     switch (conf) {

--- a/src/hooks/useDebounce.test.ts
+++ b/src/hooks/useDebounce.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useDebounce } from "./useDebounce";
+
+describe("useDebounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the initial value straight away", () => {
+    const { result } = renderHook(() => useDebounce("fever", 300));
+
+    expect(result.current).toBe("fever");
+  });
+
+  it("keeps the previous value until the delay has fully elapsed", () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 300), {
+      initialProps: { value: "fever" },
+    });
+
+    rerender({ value: "fever and cough" });
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(result.current).toBe("fever");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe("fever and cough");
+  });
+
+  it("publishes only the last value of a rapid burst", () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 300), {
+      initialProps: { value: "a" },
+    });
+
+    rerender({ value: "ab" });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    rerender({ value: "abc" });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // The timer restarted on every change, so nothing has been published yet.
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe("abc");
+  });
+
+  it("cancels a pending update when the component unmounts", () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const { unmount, rerender } = renderHook(({ value }) => useDebounce(value, 300), {
+      initialProps: { value: "a" },
+    });
+
+    rerender({ value: "b" });
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a copy of `value` that is only published once `value` has stayed
+ * unchanged for `delay` milliseconds.
+ *
+ * Used to collapse a burst of rapid updates (typing, re-renders, a symptom list
+ * that is decrypted in stages) into a single downstream effect, so an expensive
+ * call such as the `symptom-analyzer` edge function runs once instead of once
+ * per intermediate value.
+ *
+ * @param value Value to debounce.
+ * @param delay Idle time in milliseconds before the value is published.
+ * @returns The most recent value that has been stable for the full delay.
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+
+    // Clearing on every change (and on unmount) means the timer only ever
+    // fires for the last value of a burst.
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/hooks/useSubmitGuard.test.ts
+++ b/src/hooks/useSubmitGuard.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { getRejectionMessage, useSubmitGuard } from "./useSubmitGuard";
+
+describe("useSubmitGuard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs the task and hands back its result", async () => {
+    const { result } = renderHook(() => useSubmitGuard());
+    const task = vi.fn().mockResolvedValue("analysis");
+
+    await expect(result.current(task)).resolves.toEqual({
+      status: "accepted",
+      result: "analysis",
+    });
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a second submission while the first is still in flight", async () => {
+    const { result } = renderHook(() => useSubmitGuard({ cooldownMs: 0 }));
+
+    let releaseFirst: (() => void) | undefined;
+    const firstTask = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          releaseFirst = () => resolve("first");
+        })
+    );
+    const secondTask = vi.fn().mockResolvedValue("second");
+
+    const firstOutcome = result.current(firstTask);
+
+    // The ref flips synchronously, so the double-click is turned away before
+    // the loading state has had a chance to re-render the button.
+    await expect(result.current(secondTask)).resolves.toEqual({
+      status: "rejected",
+      reason: "in-flight",
+      retryAfterMs: 0,
+    });
+    expect(secondTask).not.toHaveBeenCalled();
+
+    releaseFirst?.();
+    await expect(firstOutcome).resolves.toEqual({ status: "accepted", result: "first" });
+  });
+
+  it("enforces the cooldown between two accepted submissions", async () => {
+    const { result } = renderHook(() =>
+      useSubmitGuard({ cooldownMs: 1500, maxRequests: 10, windowMs: 60_000 })
+    );
+
+    await result.current(async () => "first");
+
+    await expect(result.current(async () => "second")).resolves.toEqual({
+      status: "rejected",
+      reason: "cooldown",
+      retryAfterMs: 1500,
+    });
+
+    vi.advanceTimersByTime(1500);
+
+    await expect(result.current(async () => "third")).resolves.toEqual({
+      status: "accepted",
+      result: "third",
+    });
+  });
+
+  it("enforces the rolling request quota and recovers once the window rolls over", async () => {
+    const { result } = renderHook(() =>
+      useSubmitGuard({ cooldownMs: 0, maxRequests: 2, windowMs: 1000 })
+    );
+
+    await result.current(async () => 1);
+    await result.current(async () => 2);
+
+    const blocked = await result.current(async () => 3);
+    expect(blocked).toEqual({ status: "rejected", reason: "quota", retryAfterMs: 1000 });
+
+    vi.advanceTimersByTime(1000);
+
+    await expect(result.current(async () => 4)).resolves.toEqual({ status: "accepted", result: 4 });
+  });
+
+  it("releases the in-flight flag when the task throws", async () => {
+    const { result } = renderHook(() => useSubmitGuard({ cooldownMs: 0 }));
+
+    await expect(
+      result.current(async () => {
+        throw new Error("network down");
+      })
+    ).rejects.toThrow("network down");
+
+    await expect(result.current(async () => "recovered")).resolves.toEqual({
+      status: "accepted",
+      result: "recovered",
+    });
+  });
+});
+
+describe("getRejectionMessage", () => {
+  it("explains an overlapping request", () => {
+    expect(getRejectionMessage("in-flight", 0)).toContain("still being analyzed");
+  });
+
+  it("rounds the cooldown wait up to whole seconds", () => {
+    expect(getRejectionMessage("cooldown", 1200)).toBe(
+      "Please wait 2s before sending another request."
+    );
+  });
+
+  it("reports the wait once the quota is exhausted", () => {
+    expect(getRejectionMessage("quota", 30_000)).toBe(
+      "You have reached the request limit. Please try again in 30s."
+    );
+  });
+});

--- a/src/hooks/useSubmitGuard.ts
+++ b/src/hooks/useSubmitGuard.ts
@@ -1,0 +1,124 @@
+import { useCallback, useRef } from "react";
+
+/** Why a submission was turned away by the guard. */
+export type SubmitGuardRejectionReason = "in-flight" | "cooldown" | "quota";
+
+export interface SubmitGuardOptions {
+  /** Minimum gap, in milliseconds, between two accepted submissions. */
+  cooldownMs?: number;
+  /** Maximum number of accepted submissions inside `windowMs`. */
+  maxRequests?: number;
+  /** Length, in milliseconds, of the rolling window used for `maxRequests`. */
+  windowMs?: number;
+}
+
+/**
+ * Result of a guarded submission. A string discriminant is used instead of a
+ * boolean flag because this project compiles with `strictNullChecks` disabled,
+ * where TypeScript cannot narrow a union on a boolean literal.
+ */
+export type SubmitGuardOutcome<T> =
+  | { status: "accepted"; result: T }
+  | { status: "rejected"; reason: SubmitGuardRejectionReason; retryAfterMs: number };
+
+/** One and a half seconds is long enough to swallow a double-click. */
+const DEFAULT_COOLDOWN_MS = 1500;
+/** Mirrors the per-minute budget enforced by the `symptom-analyzer` function. */
+const DEFAULT_MAX_REQUESTS = 8;
+const DEFAULT_WINDOW_MS = 60_000;
+
+/**
+ * Builds a guarded runner that keeps a user (or a script driving the UI) from
+ * flooding the symptom analysis endpoints.
+ *
+ * It applies three checks before the task is allowed to run:
+ * 1. **In-flight guard** — a `useRef` flag rejects a second submission while the
+ *    first request is still awaiting a response. This closes the gap that a
+ *    `useState` loading flag leaves open, because the ref updates synchronously
+ *    while a state update only lands on the next render.
+ * 2. **Cooldown** — a minimum delay between two accepted submissions.
+ * 3. **Rolling quota** — at most `maxRequests` accepted submissions per window.
+ *
+ * The guard never throws for a rejection; callers inspect `status` and can
+ * surface {@link getRejectionMessage} to the user. Errors raised by the task
+ * itself still propagate, and the in-flight flag is always released.
+ *
+ * @param options Cooldown, quota, and window overrides.
+ * @returns A runner that executes `task` only when the limits allow it.
+ */
+export function useSubmitGuard(options: SubmitGuardOptions = {}) {
+  const {
+    cooldownMs = DEFAULT_COOLDOWN_MS,
+    maxRequests = DEFAULT_MAX_REQUESTS,
+    windowMs = DEFAULT_WINDOW_MS,
+  } = options;
+
+  const isSubmittingRef = useRef(false);
+  const lastAcceptedAtRef = useRef(0);
+  const acceptedAtRef = useRef<number[]>([]);
+
+  return useCallback(
+    async <T>(task: () => Promise<T>): Promise<SubmitGuardOutcome<T>> => {
+      if (isSubmittingRef.current) {
+        return { status: "rejected", reason: "in-flight", retryAfterMs: 0 };
+      }
+
+      const now = Date.now();
+      const sinceLastAccepted = now - lastAcceptedAtRef.current;
+
+      if (lastAcceptedAtRef.current > 0 && sinceLastAccepted < cooldownMs) {
+        return {
+          status: "rejected",
+          reason: "cooldown",
+          retryAfterMs: cooldownMs - sinceLastAccepted,
+        };
+      }
+
+      // Drop the timestamps that have aged out of the rolling window.
+      const recentAccepted = acceptedAtRef.current.filter(
+        (timestamp) => now - timestamp < windowMs
+      );
+      acceptedAtRef.current = recentAccepted;
+
+      if (recentAccepted.length >= maxRequests) {
+        return {
+          status: "rejected",
+          reason: "quota",
+          retryAfterMs: windowMs - (now - recentAccepted[0]),
+        };
+      }
+
+      isSubmittingRef.current = true;
+      lastAcceptedAtRef.current = now;
+      recentAccepted.push(now);
+
+      try {
+        return { status: "accepted", result: await task() };
+      } finally {
+        isSubmittingRef.current = false;
+      }
+    },
+    [cooldownMs, maxRequests, windowMs]
+  );
+}
+
+/**
+ * Turns a rejection into a message that can be dropped straight into a toast.
+ *
+ * @param reason Why the submission was rejected.
+ * @param retryAfterMs How long the caller should wait before retrying.
+ */
+export function getRejectionMessage(
+  reason: SubmitGuardRejectionReason,
+  retryAfterMs: number
+): string {
+  if (reason === "in-flight") {
+    return "Your previous request is still being analyzed. Please wait for it to finish.";
+  }
+
+  const seconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+
+  return reason === "cooldown"
+    ? `Please wait ${seconds}s before sending another request.`
+    : `You have reached the request limit. Please try again in ${seconds}s.`;
+}

--- a/src/pages/Health/AIHealthAssistant.tsx
+++ b/src/pages/Health/AIHealthAssistant.tsx
@@ -9,6 +9,7 @@ import { encryptSymptom, db, type OfflineSymptom } from "@/lib/offline-db";
 import ReactMarkdown from "react-markdown";
 
 import { parseSymptomConsultation, shouldPersistConsultation } from "@/lib/symptom-consultation";
+import { useSubmitGuard, getRejectionMessage } from "@/hooks/useSubmitGuard";
 import {
   Volume2,
   VolumeX,
@@ -81,6 +82,11 @@ const AIHealthAssistant = () => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const recognitionRef = useRef<ISpeechRecognition | null>(null);
   const { toast } = useToast();
+
+  // Throttles the analysis endpoint: no overlapping requests, a short cooldown
+  // between sends, and a per-minute budget. Also covers the suggestion chips,
+  // which are easy to click repeatedly.
+  const runGuardedAnalyze = useSubmitGuard();
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -180,10 +186,7 @@ const AIHealthAssistant = () => {
     recognition.start();
   };
 
-  const handleAnalyze = async (text?: string) => {
-    const userMessage = (text ?? symptoms).trim();
-    if (!userMessage || loading) return;
-
+  const analyzeSymptoms = async (userMessage: string) => {
     setSymptoms("");
     setCharCount(0);
     const time = getTime();
@@ -233,6 +236,8 @@ const AIHealthAssistant = () => {
       if (!response.ok || !response.body) {
         if (response.status === 401 || response.status === 403) {
           throw new Error("AUTH_ERROR");
+        } else if (response.status === 429) {
+          throw new Error("RATE_LIMITED");
         } else if (response.status >= 500) {
           throw new Error("SERVER_ERROR");
         } else {
@@ -376,6 +381,8 @@ const AIHealthAssistant = () => {
       } else if (error instanceof Error) {
         if (error.message === "AUTH_ERROR") {
           errorMessage = "Session expired. Please log in again.";
+        } else if (error.message === "RATE_LIMITED") {
+          errorMessage = "Too many requests. Please wait a moment before trying again.";
         } else if (error.message === "SERVER_ERROR") {
           errorMessage = "Server error. Please try again later.";
         }
@@ -385,6 +392,17 @@ const AIHealthAssistant = () => {
       setMessages((prev) => prev.filter((m) => !(m.role === "user" && m.text === userMessage)));
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleAnalyze = async (text?: string) => {
+    const userMessage = (text ?? symptoms).trim();
+    if (!userMessage || loading) return;
+
+    const outcome = await runGuardedAnalyze(() => analyzeSymptoms(userMessage));
+
+    if (outcome.status === "rejected") {
+      showWarning("Too many requests", getRejectionMessage(outcome.reason, outcome.retryAfterMs));
     }
   };
 

--- a/supabase/functions/symptom-analyzer/index.ts
+++ b/supabase/functions/symptom-analyzer/index.ts
@@ -68,15 +68,22 @@ serve(async (req: Request): Promise<Response> => {
     const ip =
       req.headers.get("x-forwarded-for") || req.headers.get("cf-connecting-ip") || "unknown";
 
-    const rateLimitResult = await rateLimit(ip);
+    // Two buckets, both capped at the same per-minute budget:
+    // - by IP, which blunts a flood coming from a single machine;
+    // - by user, so one account cannot burn the AI and Supabase quota by
+    //   spreading the same flood across devices, tabs, or networks.
+    const [ipRateLimit, userRateLimit] = await Promise.all([
+      rateLimit(`ip:${ip}`),
+      rateLimit(`user:${user.id}`),
+    ]);
 
-    if (!rateLimitResult.success) {
+    if (!ipRateLimit.success || !userRateLimit.success) {
       return jsonResponse(
         {
           error: "Rate limit exceeded. Please try again later.",
         },
         429,
-        getCorsHeaders(origin)
+        { ...getCorsHeaders(origin), "Retry-After": "60" }
       );
     }
 


### PR DESCRIPTION
## **Pull Request Description**

Symptom analysis calls the `symptom-analyzer` Supabase edge function on every user interaction. There was no debounce and no client-side guard, so a double-click, a stuck Enter key, or a script could fire several identical analyses back to back — burning Supabase/AI quota and risking duplicate rows in `symptom_history`.

This PR adds debouncing and a submission guard on the client, and a per-user bucket to the rate limiter on the API side.

### What changed

**1. `useDebounce` hook (`src/hooks/useDebounce.ts`)**
Generic hook that publishes a value only once it has stayed unchanged for the given delay, so a burst of updates collapses into a single downstream effect.

**2. `useSubmitGuard` hook (`src/hooks/useSubmitGuard.ts`)**
Wraps a submission in three checks before it is allowed to run:
- **In-flight guard** — a `useRef` flag rejects a second submission while the first is still awaiting a response. A `useState` loading flag cannot do this on its own, because it only lands on the next render, which leaves a double-click window open.
- **Cooldown** — a minimum gap (1.5s) between two accepted submissions.
- **Rolling quota** — at most 8 accepted submissions per minute, matching the budget the edge function enforces.

Rejections never throw: the caller reads `outcome.status` and shows the message from `getRejectionMessage()`.

**3. Guarded the symptom analysis entry points**
- `src/components/chat/ChatInterface.tsx` — `handleSend`
- `src/pages/Health/AIHealthAssistant.tsx` — `handleAnalyze` (also covers the suggestion chips, which are easy to click repeatedly)

A blocked request now shows a "Too many requests" warning toast instead of silently doing nothing.

**4. Debounced the dashboard predictions (`src/components/dashboard/SymptomPredictions.tsx`)**
This call fires from an effect whenever the symptom list changes. It is now debounced by 800ms and keyed on a hash of the list, so a new array holding the same symptoms no longer refires it. Duplicate in-flight requests are dropped, and a response for a symptom list that has since moved on is discarded instead of overwriting fresher predictions.

**5. Per-user rate limiting (`supabase/functions/symptom-analyzer/index.ts`)**
The function only bucketed by IP, so one account could spread a flood across devices, tabs, or networks, while users behind a shared IP (offices, mobile carriers, NAT) were throttled collectively. It now checks an IP bucket **and** a per-authenticated-user bucket, and returns `Retry-After: 60` alongside the 429.

**6. 429 handling in the UI**
All three call sites now recognise a 429 and surface a clear "Too many requests" message instead of a generic failure.

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [x] **New Feature** (non-breaking change which adds functionality)
- [x] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
Fixes #776

---

### **3. How Has This Been Tested?**
- [x] **Local Build**: `npm run build` succeeds.
- [x] **Lint/Format Checks**: `npm run lint` reports 0 errors (only the 9 pre-existing `react-refresh` warnings in files this PR does not touch). New files pass `prettier --check`.
- [x] **Unit Tests**: `npm test` — **91 passed**, including **12 new tests** for the two hooks (`src/hooks/useDebounce.test.ts`, `src/hooks/useSubmitGuard.test.ts`) covering the debounce window, burst collapsing, timer cleanup, the in-flight guard, the cooldown, the rolling quota and its recovery, and guard release when a task throws.
- [x] **Type-check**: no new TypeScript errors — the error list is byte-identical to `main` apart from two pre-existing errors whose line numbers shifted.
- [x] **Manual Verification**:
  1. AI chat — clicked **Send** rapidly / held Enter: only one request leaves the browser, the extra attempts show the warning toast, and only one entry is written to symptom history.
  2. AI Health Assistant — clicked several suggestion chips in quick succession: same behaviour.
  3. Dashboard — the predictions call now fires once after the symptom list settles rather than on every intermediate update.

> **Note on `useSubmitGuard`'s result type:** it uses a string discriminant (`status: "accepted" | "rejected"`) rather than a boolean flag, because this project compiles with `strictNullChecks: false`, where TypeScript cannot narrow a union on a boolean literal.

---

### **4. Visual Verification (If applicable)**
No layout changes. The only visible addition is a warning toast when a request is throttled:

> **Too many requests** — Your previous request is still being analyzed. Please wait for it to finish.

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
