### PR TITLE
fix : normalized decrypt errors with DecryptionError class

### DIFF
--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -215,27 +215,40 @@ export async function encryptText(text: string, key: CryptoKey): Promise<string>
   return `${ivHex}:${ciphertextHex}`;
 }
 
+export class DecryptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DecryptionError";
+  }
+}
+
 export async function decryptText(encryptedText: string, key: CryptoKey): Promise<string> {
   const parts = encryptedText.split(":");
   if (parts.length !== 2) {
-    throw new Error("Invalid encrypted text format");
+    throw new DecryptionError("Invalid encrypted text format");
   }
 
   const [ivHex, ciphertextHex] = parts;
   const iv = hexToUint8Array(ivHex);
   const ciphertext = hexToUint8Array(ciphertextHex);
 
-  const decryptedBuffer = await crypto.subtle.decrypt(
-    {
-      name: "AES-GCM",
-      iv: iv,
-    },
-    key,
-    ciphertext
-  );
+  try {
+    const decryptedBuffer = await crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: iv,
+      },
+      key,
+      ciphertext
+    );
 
-  const decoder = new TextDecoder();
-  return decoder.decode(decryptedBuffer);
+    const decoder = new TextDecoder();
+    return decoder.decode(decryptedBuffer);
+  } catch (err) {
+    throw new DecryptionError(
+      err instanceof Error ? `Decryption failed: ${err.message}` : "Decryption failed"
+    );
+  }
 }
 
 // Callbacks registered by offline-db


### PR DESCRIPTION
## Summary of What Has Been Done

Normalized error handling in `decryptText` in `src/lib/encryption.ts`.

Previously, `decryptText` threw raw browser `DOMException` errors from `crypto.subtle.decrypt` when decryption failed (wrong key, corrupted ciphertext, etc.). This made it impossible for callers to handle decryption failures in a type-safe, consistent way without browser-specific instanceof checks.

The fix introduces a `DecryptionError` class that extends `Error` with `name = "DecryptionError"`. The `crypto.subtle.decrypt` call is now wrapped in a `try/catch` that converts all failures into `DecryptionError`. Both invalid format errors and crypto failures now throw `DecryptionError`.

## Changes Made

- Added `DecryptionError` class exported from `encryption.ts`
- Wrapped `crypto.subtle.decrypt` in try/catch, converting all errors to `DecryptionError`
- Both invalid format and crypto failures now throw `DecryptionError`
- `DecryptionError` is exported so callers can `instanceof` check it

## Impact it Made

- Consistent, typed error surface for all decryption failures
- Callers can catch `DecryptionError` without browser-specific instanceof checks
- Makes the encryption module easier to test and reason about

Closes #910

Note: Please assign this PR to the `tmdeveloper007` account.