### PR TITLE
test(#887): cover storage graceful degradation on restricted browsers

### DIFF
--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,12 +1,18 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   getSafeLocalStorage,
   setSafeLocalStorage,
+  getSafeSessionStorage,
+  setSafeSessionStorage,
   getTypedStorage,
   setTypedStorage,
   removeSafeStorage,
   clearSafeStorage,
   setValidatedStorage,
+  isStorageAvailable,
+  getStorageSize,
+  getStorageSizeFormatted,
+  getAllStorageKeys,
 } from "./storage";
 
 const createStorageMock = () => {
@@ -60,7 +66,7 @@ describe("Storage Utilities", () => {
     it("should handle objects with optional TTL", () => {
       const data = { theme: "dark", size: 12 };
       setTypedStorage("config", data);
-      
+
       const loaded = getTypedStorage("config", { theme: "light", size: 10 });
       expect(loaded).toEqual(data);
     });
@@ -88,6 +94,148 @@ describe("Storage Utilities", () => {
       const result = setValidatedStorage("valid_key", "value");
       expect(result).toBe(true);
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith("valid_key", "value");
+    });
+  });
+
+  describe("getSafeSessionStorage / setSafeSessionStorage", () => {
+    it("should write and read from session storage", () => {
+      setSafeSessionStorage("session_key", "hello");
+      expect(mockSessionStorage.setItem).toHaveBeenCalledWith("session_key", "hello");
+
+      const val = getSafeSessionStorage("session_key", "fallback");
+      expect(val).toBe("hello");
+    });
+
+    it("should return fallback when key does not exist", () => {
+      const val = getSafeSessionStorage("non_existent", "fallback");
+      expect(val).toBe("fallback");
+    });
+
+    it("should return fallback when the stored value is empty", () => {
+      setSafeSessionStorage("empty_key", "");
+
+      expect(getSafeSessionStorage("empty_key", "fallback")).toBe("fallback");
+    });
+
+    it("should keep session and local storage separate", () => {
+      setSafeSessionStorage("shared_key", "session_value");
+
+      expect(getSafeLocalStorage("shared_key", "fallback")).toBe("fallback");
+    });
+  });
+});
+
+/**
+ * Safari in private browsing mode — and any browser with site data blocked —
+ * throws on storage access instead of returning null. Every helper in this
+ * module is expected to degrade gracefully: warn, and hand back the fallback
+ * rather than letting the exception escape and take a render down with it.
+ */
+describe("Storage Utilities — restricted storage environments", () => {
+  const accessDenied = new DOMException("The operation is insecure.", "QuotaExceededError");
+
+  const createThrowingStorageMock = () => ({
+    getItem: vi.fn(() => {
+      throw accessDenied;
+    }),
+    setItem: vi.fn(() => {
+      throw accessDenied;
+    }),
+    removeItem: vi.fn(() => {
+      throw accessDenied;
+    }),
+    clear: vi.fn(() => {
+      throw accessDenied;
+    }),
+    get length(): number {
+      throw accessDenied;
+    },
+    key: vi.fn(() => {
+      throw accessDenied;
+    }),
+  });
+
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createThrowingStorageMock());
+    vi.stubGlobal("sessionStorage", createThrowingStorageMock());
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  describe("session storage", () => {
+    it("returns the fallback when sessionStorage.getItem throws", () => {
+      expect(() => getSafeSessionStorage("theme", "light")).not.toThrow();
+      expect(getSafeSessionStorage("theme", "light")).toBe("light");
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it("swallows the error when sessionStorage.setItem throws", () => {
+      expect(() => setSafeSessionStorage("theme", "dark")).not.toThrow();
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it("swallows the error when removing a session key", () => {
+      expect(() => removeSafeStorage("theme", "session")).not.toThrow();
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("local storage", () => {
+    it("returns the fallback when localStorage.getItem throws", () => {
+      expect(getSafeLocalStorage("theme", "light")).toBe("light");
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it("swallows the error when localStorage.setItem throws", () => {
+      expect(() => setSafeLocalStorage("theme", "dark")).not.toThrow();
+    });
+
+    it("swallows the error when removing a local key", () => {
+      expect(() => removeSafeStorage("theme")).not.toThrow();
+    });
+  });
+
+  describe("typed storage", () => {
+    it("returns the fallback when the underlying read throws", () => {
+      const fallback = { theme: "light" };
+
+      expect(getTypedStorage("config", fallback)).toBe(fallback);
+    });
+
+    it("swallows the error when the underlying write throws", () => {
+      expect(() => setTypedStorage("config", { theme: "dark" }, 1000)).not.toThrow();
+    });
+  });
+
+  describe("validated and bulk helpers", () => {
+    it("reports failure instead of throwing on a validated write", () => {
+      expect(setValidatedStorage("valid_key", "value")).toBe(false);
+    });
+
+    it("clears both storages without propagating either failure", () => {
+      expect(() => clearSafeStorage()).not.toThrow();
+      // One warning per storage — neither failure short-circuits the other.
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("reports storage as unavailable", () => {
+      expect(isStorageAvailable("localStorage")).toBe(false);
+      expect(isStorageAvailable("sessionStorage")).toBe(false);
+    });
+
+    it("reports a zero size rather than throwing", () => {
+      expect(getStorageSize("sessionStorage")).toBe(0);
+      expect(getStorageSizeFormatted("sessionStorage")).toBe("0 B");
+    });
+
+    it("returns no keys rather than throwing", () => {
+      expect(getAllStorageKeys("sessionStorage")).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## **Pull Request Description**

### First, a correction to the issue

The issue asks to wrap `sessionStorage.getItem` in a try-catch. **That guard already exists.** `src/lib/storage.ts` lines 82–89:

```ts
export const getSafeSessionStorage = (key: string, fallback: string): string => {
  try {
    return sessionStorage.getItem(key) || fallback;
  } catch (error) {
    console.warn("SessionStorage access denied:", error);
    return fallback;
  }
};
```

It has been there since commit `e251b8c` — *"fix(storage): prevent uncaught DOMExceptions on localStorage/sessionStorage access"*. The function named in the issue, `getSessionItem`, does not exist anywhere in the repo; the session helpers are `getSafeSessionStorage` / `setSafeSessionStorage`, and both are already guarded. I also grepped for `sessionStorage` across `src/` — there is no unguarded access outside this module.

So re-adding the try-catch would be a no-op.

### What this PR does instead

The behaviour the issue actually cares about — *"prevents crashes in Safari private browsing mode"*, *"maintains graceful degradation"* — was **completely untested**. `storage.test.ts` covered only local-storage happy paths: nothing exercised the session helpers, and nothing exercised any error path. The guards could have been dropped in a refactor without a single test going red.

This PR locks that behaviour in with **17 new tests** (6 → 23):

**Session storage happy path** (previously zero coverage)
- write/read round trip, fallback for a missing key, fallback for an empty stored value, and isolation from local storage.

**Restricted storage environments** — both storages stubbed with mocks that throw `QuotaExceededError`, the way Safari behaves in private browsing:

| Helper | Asserted behaviour |
| :--- | :--- |
| `getSafeSessionStorage` | returns the fallback, does not throw, warns ← **the exact behaviour #887 asks for** |
| `setSafeSessionStorage` | swallows the write failure |
| `getSafeLocalStorage` / `setSafeLocalStorage` | fallback / swallowed |
| `getTypedStorage` / `setTypedStorage` | fallback / swallowed |
| `removeSafeStorage` | swallowed for both `"local"` and `"session"` |
| `clearSafeStorage` | warns twice — neither storage's failure short-circuits the other |
| `setValidatedStorage` | returns `false` rather than throwing |
| `isStorageAvailable` | reports `false` |
| `getStorageSize` / `getStorageSizeFormatted` | `0` / `"0 B"` |
| `getAllStorageKeys` | `[]` |

I also removed a stray trailing whitespace so the file passes `prettier --check`.

**No production code is changed by this PR.**

### Verifying the tests are real

I confirmed the key test genuinely guards the issue's concern rather than merely passing. Temporarily removing the try-catch from `getSafeSessionStorage` — exactly the regression #887 is worried about — turns it red:

```
FAIL  src/lib/storage.test.ts > Storage Utilities — restricted storage environments
      > session storage > returns the fallback when sessionStorage.getItem throws
      Tests  1 failed | 22 passed (23)
```

Restoring the guard returns the suite to 23 passed.

@mohdmaazgani — if you would rather close #887 as already-resolved than merge test coverage for it, that is completely reasonable; happy either way. I opted for the tests because the guard was unprotected against future regressions.

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [x] **Other**: Test coverage — no production code is touched

---

### **2. Related Issue**
Addresses #887 (the requested guard already exists — see above; this adds the missing regression coverage)

---

### **3. How Has This Been Tested?**
- [x] **Local Build**: `npm run build` succeeds.
- [x] **Lint/Format Checks**: `npm run lint` reports 0 errors (only the 9 pre-existing `react-refresh` warnings in unrelated files). `src/lib/storage.test.ts` now passes `prettier --check`, which it did not before this PR.
- [x] **Unit Tests**: `npm test` — **96 passed**, of which **17 are new**. No existing test was modified.
- [x] **Regression-checked**: removing the `getSafeSessionStorage` try-catch makes the corresponding test fail (output above), proving the test guards the behaviour rather than passing vacuously.

---

### **4. Visual Verification (If applicable)**
Not applicable — test-only change, no UI or behaviour is affected.

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
