### PR TITLE
Fix: Enable Row Level Security policies on all user-data tables

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,48 @@ Before committing:
 - Use environment variables for all secrets
 - Run `git status` to verify no secret files are staged
 
+## Row-Level Security (RLS) - Critical Security Boundary
+
+**Issue #795**: The Supabase anon key is public. RLS policies are the ONLY security mechanism preventing unauthorized cross-user data access.
+
+All user-data tables have RLS enabled with strict `auth.uid()` checks:
+
+### Protected Tables
+- **symptom_history**: Users can only access their own symptom records
+- **health_metrics**: Users can only access their own health metrics
+- **chat_sessions**: Users can only access their own chat sessions
+- **profiles**: Public read (for peer discovery), user-restricted write
+
+### RLS Policy Pattern
+```sql
+-- Example: Users can only view their own data
+CREATE POLICY "users_can_only_access_own_data"
+  ON symptom_history
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+```
+
+### Verification
+To verify RLS is enabled on all tables:
+```sql
+SELECT schemaname, tablename, rowsecurity
+FROM pg_tables
+WHERE schemaname = 'public'
+ORDER BY tablename;
+```
+
+All user-data tables should show `rowsecurity = true`.
+
+### Attack Scenarios Prevented
+1. **Cross-user data access**: Without RLS, anon key could query all users' symptoms
+2. **Data exposure**: Health metrics, chat history isolated by user_id
+3. **Session hijacking**: Chat sessions strictly user-scoped
+
+**Never disable RLS on these tables.** If you must modify RLS policies, update the migration and test thoroughly before deployment.
+
 ## Incident History
 
 Initial commit (93fbbcf) contained exposed Supabase credentials in the .env file. These credentials have been invalidated. The .env file was removed from tracking in commit b6bfb80. Developers should be aware that cloning from commit 93fbbcf exposes the old (now invalidated) credentials from git history.
+
+Issue #795 discovered that RLS policies were not enforced, allowing potential cross-user data access with the exposed anon key. This was fixed by enabling RLS on all user-data tables with strict `auth.uid()` policies.

--- a/supabase/migrations/20260804000001_enable_rls_policies_all_tables.sql
+++ b/supabase/migrations/20260804000001_enable_rls_policies_all_tables.sql
@@ -1,0 +1,183 @@
+-- Enable Row Level Security (RLS) policies on all user data tables
+-- Issue: https://github.com/mohdmaazgani/symptom-scribe-clean/issues/795
+--
+-- Fixes critical vulnerability where exposed anon key could access all users' data
+-- when RLS policies were not enforced. Each table now has policies restricting
+-- access to the authenticated user's own data.
+
+-- ===========================
+-- symptom_history Table
+-- ===========================
+
+-- Enable RLS on symptom_history
+ALTER TABLE symptom_history ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can only view their own symptom history
+CREATE POLICY "Users can only access their own symptom history"
+  ON symptom_history
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Policy: Users can only insert their own symptom records
+CREATE POLICY "Users can only insert their own symptom history"
+  ON symptom_history
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can only update their own symptom records
+CREATE POLICY "Users can only update their own symptom history"
+  ON symptom_history
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can only delete their own symptom records
+CREATE POLICY "Users can only delete their own symptom history"
+  ON symptom_history
+  FOR DELETE
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- ===========================
+-- health_metrics Table
+-- ===========================
+
+-- Enable RLS on health_metrics
+ALTER TABLE health_metrics ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can only view their own health metrics
+CREATE POLICY "Users can only access their own health metrics"
+  ON health_metrics
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Policy: Users can only insert their own health metrics
+CREATE POLICY "Users can only insert their own health metrics"
+  ON health_metrics
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can only update their own health metrics
+CREATE POLICY "Users can only update their own health metrics"
+  ON health_metrics
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can only delete their own health metrics
+CREATE POLICY "Users can only delete their own health metrics"
+  ON health_metrics
+  FOR DELETE
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- ===========================
+-- profiles Table
+-- ===========================
+
+-- Enable RLS on profiles
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can view all profiles (for peer discovery)
+CREATE POLICY "Everyone can view profiles"
+  ON profiles
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Policy: Users can only update their own profile
+CREATE POLICY "Users can only update their own profile"
+  ON profiles
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- ===========================
+-- chat_sessions Table
+-- ===========================
+
+-- Enable RLS on chat_sessions
+ALTER TABLE chat_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can only view their own chat sessions
+CREATE POLICY "Users can only access their own chat sessions"
+  ON chat_sessions
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Policy: Users can only insert their own chat sessions
+CREATE POLICY "Users can only create their own chat sessions"
+  ON chat_sessions
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can only update their own chat sessions
+CREATE POLICY "Users can only update their own chat sessions"
+  ON chat_sessions
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can only delete their own chat sessions
+CREATE POLICY "Users can only delete their own chat sessions"
+  ON chat_sessions
+  FOR DELETE
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- ===========================
+-- Documentation
+-- ===========================
+
+COMMENT ON TABLE symptom_history IS
+'Symptom history table with RLS enabled.
+
+Row Level Security Policies:
+- SELECT: Users can only view records where auth.uid() = user_id
+- INSERT: Users can only insert records with their own user_id
+- UPDATE: Users can only update their own records
+- DELETE: Users can only delete their own records
+
+With the anon key exposed in .env, RLS is the critical security boundary.
+All authenticated users must verify they own a record before accessing it.';
+
+COMMENT ON TABLE health_metrics IS
+'Health metrics table with RLS enabled.
+
+Row Level Security Policies:
+- SELECT: Users can only view records where auth.uid() = user_id
+- INSERT: Users can only insert records with their own user_id
+- UPDATE: Users can only update their own records
+- DELETE: Users can only delete their own records
+
+Prevents cross-user health data leakage even with exposed anon key.';
+
+COMMENT ON TABLE profiles IS
+'Profiles table with RLS enabled.
+
+Row Level Security Policies:
+- SELECT: All authenticated users can view all profiles (public directory)
+- UPDATE: Users can only update their own profile
+
+Allows peer discovery while protecting profile updates.';
+
+COMMENT ON TABLE chat_sessions IS
+'Chat sessions table with RLS enabled.
+
+Row Level Security Policies:
+- SELECT: Users can only view their own sessions
+- INSERT: Users can only create sessions for themselves
+- UPDATE: Users can only update their own sessions
+- DELETE: Users can only delete their own sessions
+
+Prevents users from accessing or manipulating other users'' chat history.';


### PR DESCRIPTION
## Summary

Enables Row Level Security (RLS) policies on all tables containing user data, fixing a critical vulnerability where the exposed anon key could access all users' symptom history, health metrics, and chat sessions.

## Problem

The `.env` file containing `VITE_SUPABASE_ANON_KEY` was accidentally committed (and since invalidated). Without RLS policies, the public anon key can be used to access ALL users' data:

```javascript
// Without RLS, this query returns EVERY user's symptoms
const { data } = await supabaseClient
  .from('symptom_history')
  .select('*'); // No user_id filter!
```

## Solution

Enabled RLS with strict `auth.uid()` policies on all user-data tables:

### Protected Tables

**symptom_history**
- SELECT: Users only see their own records
- INSERT/UPDATE/DELETE: Users only modify their own records

**health_metrics**
- SELECT: Users only see their own metrics
- INSERT/UPDATE/DELETE: Users only modify their own metrics

**chat_sessions**
- SELECT: Users only see their own sessions
- INSERT/UPDATE/DELETE: Users only manage their own sessions

**profiles**
- SELECT: Open to all (enables peer discovery)
- UPDATE: Users only modify their own profile

## Changes

### supabase/migrations/20260804000001_enable_rls_policies_all_tables.sql
- Enables RLS on all user-data tables
- Creates SELECT/INSERT/UPDATE/DELETE policies with `auth.uid() = user_id` checks
- Includes comprehensive documentation in table comments

### SECURITY.md
- Documents RLS as the critical security boundary
- Provides RLS verification SQL queries
- Lists attack scenarios prevented by RLS
- Best practices for maintaining RLS policies

## Security Architecture

```
Client (with public anon key)
    ↓
Supabase REST API
    ↓
RLS Policies (CHECK: auth.uid() = user_id)
    ↓
PostgreSQL Database
    ↓
User's Data Only
```

## Verification

RLS status can be verified with:
```sql
-- Check that RLS is enabled
SELECT schemaname, tablename, rowsecurity
FROM pg_tables
WHERE schemaname = 'public';

-- List all policies
SELECT tablename, policyname, cmd, permissive, qual
FROM pg_policies
WHERE schemaname = 'public';
```

## Deployment

1. Apply migration: `supabase db push`
2. Verify RLS is enabled using provided SQL queries
3. Test that cross-user queries are blocked
4. Monitor logs for any RLS-related errors

## Impact

✅ Fixes critical data exposure vulnerability
✅ Restricts users to their own data
✅ Enables secure peer discovery (profiles)
✅ Prevents chat session access by other users
✅ RLS is now the enforced security boundary

Fixes #795