### PR TITLE
fix : removed overflow-hidden from Hero section to prevent blur/transparent appearance

### DIFF
--- a/src/components/hero/Hero.tsx
+++ b/src/components/hero/Hero.tsx
@@ -181,7 +181,7 @@ const Hero = () => {
         duration: 0.8,
         ease: [0.22, 1, 0.36, 1],
       }}
-      className="relative overflow-hidden bg-background pt-16 pb-24 md:pt-24 md:pb-32 px-4 group"
+      className="relative bg-background pt-16 pb-24 md:pt-24 md:pb-32 px-4 group"
       onMouseMove={handleMouseMove}
     >
       {/* Interactive Mouse Spotlight */}


### PR DESCRIPTION
## Summary of What Has Been Done
Removed the `overflow-hidden` CSS class from the Hero section in `src/components/hero/Hero.tsx`. This prevents the Hero section from clipping decorative glow blobs and causing a blur/transparent visual artifact.

## Changes Made
- `src/components/hero/Hero.tsx`: Removed `overflow-hidden` from the Hero section's className

## Impact it Made
- Hero section decorative elements (glow blobs, floating icons) are no longer clipped
- No more blur/transparent appearance on the landing page Hero
- Consistent visual rendering across all screen sizes

Closes #937

## Note: Please assign this PR to the `tmdeveloper007` account.