### PR TITLE
fix : replaced console.error with console.warn in PasswordStrengthMeter component

### DIFF
--- a/src/components/registration/shared/PasswordStrengthMeter.tsx
+++ b/src/components/registration/shared/PasswordStrengthMeter.tsx
@@ -58,7 +58,7 @@ export function PasswordStrengthMeter({
       setCopiedGenerator(true);
       setTimeout(() => setCopiedGenerator(false), 2000);
     } catch {
-      console.error("Failed to copy password");
+      console.warn("Failed to copy password");
     }
   };
 


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced the `console.error` call with `console.warn` in the `PasswordStrengthMeter` component's clipboard copy error handler.

## Changes Made
- `src/components/registration/shared/PasswordStrengthMeter.tsx`: Changed `console.error` to `console.warn`

## Impact it Made
- Appropriate log severity for non-critical clipboard permission failures
- Consistent log severity across the application

Closes #771

## Note: Please assign this PR to the `tmdeveloper007` account.