### PR TITLE
fix(broadcast-emergency): add rate limiting and update CORS origin handling

### DIFF
--- a/supabase/functions/broadcast-emergency/index.ts
+++ b/supabase/functions/broadcast-emergency/index.ts
@@ -1,15 +1,23 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.7.1";
+import { rateLimit } from "../_shared/rateLimit.ts";
 
 const ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:8080",
   "https://symptom-scribe.vercel.app",
+  "https://symptom-scribe-clean.netlify.app",
 ];
+
+const NETLIFY_PREVIEW_ORIGIN = /^https:\/\/deploy-preview-\d+--symptom-scribe-clean\.netlify\.app$/;
+
+function isAllowedOrigin(origin: string): boolean {
+  return ALLOWED_ORIGINS.includes(origin) || NETLIFY_PREVIEW_ORIGIN.test(origin);
+}
 
 const getCorsHeaders = (origin: string | null) => ({
   "Access-Control-Allow-Origin":
-    origin && ALLOWED_ORIGINS.includes(origin) ? origin : "null",
+    origin && isAllowedOrigin(origin) ? origin : "null",
   "Access-Control-Allow-Headers":
     "authorization, x-client-info, apikey, content-type",
 });
@@ -22,7 +30,7 @@ function hexToUint8Array(hex: string): Uint8Array {
 serve(async (req) => {
   const origin = req.headers.get("origin");
 
-  if (origin && !ALLOWED_ORIGINS.includes(origin)) {
+  if (origin && !isAllowedOrigin(origin)) {
     return new Response(
       JSON.stringify({ error: "Origin not allowed" }),
       {
@@ -37,6 +45,26 @@ serve(async (req) => {
   }
 
   try {
+    // Enforce rate limiting before processing the request
+    const ip =
+      req.headers.get("x-forwarded-for") ||
+      req.headers.get("cf-connecting-ip") ||
+      "unknown";
+
+    const rateLimitResult = await rateLimit(ip);
+    if (!rateLimitResult.success) {
+      return new Response(
+        JSON.stringify({ error: "Rate limit exceeded. Please try again later." }),
+        {
+          status: 429,
+          headers: {
+            ...getCorsHeaders(origin),
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    }
+
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) {
       return new Response(


### PR DESCRIPTION
Added rateLimit import from _shared/rateLimit.ts, NETLIFY_PREVIEW_ORIGIN regex, isAllowedOrigin() helper, and IP-based rate limit check. JWT auth was already present. Contributing under GSSoC 26.