### PR TITLE
feat: deduplicate dismissed alert IDs in localStorage

### DIFF
--- a/src/lib/alerts-engine.ts
+++ b/src/lib/alerts-engine.ts
@@ -12,6 +12,8 @@ export interface SmartAlert {
 
 const DISMISSED_ALERTS_KEY = "symptom_scribe_dismissed_alerts";
 
+const MAX_DISMISSED_ALERTS = 100;
+
 export function getDismissedAlerts(): string[] {
   try {
     const stored = localStorage.getItem(DISMISSED_ALERTS_KEY);
@@ -24,10 +26,20 @@ export function getDismissedAlerts(): string[] {
 export function dismissAlert(alertId: string) {
   try {
     const dismissed = getDismissedAlerts();
-    if (!dismissed.includes(alertId)) {
-      dismissed.push(alertId);
-      localStorage.setItem(DISMISSED_ALERTS_KEY, JSON.stringify(dismissed));
+
+    const updated = [
+      ...dismissed.filter((id) => id !== alertId),
+      alertId,
+    ];
+
+    if (updated.length > MAX_DISMISSED_ALERTS) {
+      updated.splice(0, updated.length - MAX_DISMISSED_ALERTS);
     }
+
+    localStorage.setItem(
+      DISMISSED_ALERTS_KEY,
+      JSON.stringify(updated)
+    );
   } catch (err) {
     console.warn("Failed to dismiss alert:", err);
   }


### PR DESCRIPTION
## **Pull Request Description**

This pull request improves how dismissed alert IDs are stored in localStorage by preventing duplicate entries and limiting the stored list to a reasonable maximum size. This helps keep local storage lightweight while preserving the existing alert dismissal behavior.
---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [x] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #869 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Dismissed the same alert multiple times and verified that duplicate IDs were not stored in localStorage.

   2. Confirmed that the stored dismissed alert list remained within the configured maximum size while existing dismissal functionality continued to work correctly.
  

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

N/A

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
