### PR TITLE
feat: validate persisted accessibility settings before applying

### DIFF
--- a/src/hooks/useAccessibility.test.ts
+++ b/src/hooks/useAccessibility.test.ts
@@ -1,0 +1,172 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useAccessibility } from "./useAccessibility";
+
+describe("useAccessibility", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = "";
+    vi.restoreAllMocks();
+  });
+
+  it("loads default settings when localStorage is empty", () => {
+    const { result } = renderHook(() => useAccessibility());
+
+    expect(result.current.settings).toEqual({
+      fontSize: "normal",
+      highContrast: false,
+      dyslexiaFont: false,
+      reducedMotion: false,
+      improvedSpacing: false,
+    });
+  });
+
+  it("loads persisted settings from localStorage", () => {
+    localStorage.setItem(
+      "symptom-scribe-accessibility",
+      JSON.stringify({
+        fontSize: "large",
+        highContrast: true,
+      })
+    );
+
+    const { result } = renderHook(() => useAccessibility());
+
+    expect(result.current.settings.fontSize).toBe("large");
+    expect(result.current.settings.highContrast).toBe(true);
+    expect(result.current.settings.dyslexiaFont).toBe(false);
+  });
+
+  it("falls back to defaults when localStorage contains invalid JSON", () => {
+    localStorage.setItem(
+      "symptom-scribe-accessibility",
+      "{invalid json"
+    );
+
+    const { result } = renderHook(() => useAccessibility());
+
+    expect(result.current.settings.fontSize).toBe("normal");
+    expect(result.current.settings.highContrast).toBe(false);
+  });
+
+  it("updates an accessibility setting", () => {
+    const { result } = renderHook(() => useAccessibility());
+
+    act(() => {
+      result.current.updateSetting("highContrast", true);
+    });
+
+    expect(result.current.settings.highContrast).toBe(true);
+  });
+
+  it("persists updated settings to localStorage", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem");
+
+    const { result } = renderHook(() => useAccessibility());
+
+    act(() => {
+      result.current.updateSetting("fontSize", "x-large");
+    });
+
+    expect(spy).toHaveBeenCalled();
+
+    expect(localStorage.getItem("symptom-scribe-accessibility")).toContain(
+      '"fontSize":"x-large"'
+    );
+  });
+
+  it("applies accessibility classes to the document root", () => {
+    const { result } = renderHook(() => useAccessibility());
+
+    act(() => {
+      result.current.updateSetting("fontSize", "large");
+      result.current.updateSetting("highContrast", true);
+    });
+
+    expect(document.documentElement.classList.contains("a11y-font-large")).toBe(true);
+    expect(document.documentElement.classList.contains("a11y-high-contrast")).toBe(true);
+  });
+
+  it("removes obsolete classes when settings change", () => {
+    const { result } = renderHook(() => useAccessibility());
+
+    act(() => {
+      result.current.updateSetting("fontSize", "large");
+    });
+
+    expect(document.documentElement.classList.contains("a11y-font-large")).toBe(true);
+
+    act(() => {
+      result.current.updateSetting("fontSize", "x-large");
+    });
+
+    expect(document.documentElement.classList.contains("a11y-font-large")).toBe(false);
+    expect(document.documentElement.classList.contains("a11y-font-x-large")).toBe(true);
+  });
+
+  it("resets all settings back to defaults", () => {
+    const { result } = renderHook(() => useAccessibility());
+
+    act(() => {
+      result.current.updateSetting("highContrast", true);
+      result.current.updateSetting("fontSize", "x-large");
+    });
+
+    act(() => {
+      result.current.resetSettings();
+    });
+
+    expect(result.current.settings).toEqual({
+      fontSize: "normal",
+      highContrast: false,
+      dyslexiaFont: false,
+      reducedMotion: false,
+      improvedSpacing: false,
+    });
+  });
+
+  it("falls back to the default font size for invalid persisted values", () => {
+    localStorage.setItem(
+      "symptom-scribe-accessibility",
+      JSON.stringify({
+        fontSize: "huge",
+      })
+    );
+
+    const { result } = renderHook(() => useAccessibility());
+
+    expect(result.current.settings.fontSize).toBe("normal");
+  });
+
+  it("ignores non-boolean persisted accessibility settings", () => {
+    localStorage.setItem(
+      "symptom-scribe-accessibility",
+      JSON.stringify({
+        highContrast: "true",
+        dyslexiaFont: 1,
+        reducedMotion: {},
+        improvedSpacing: null,
+      })
+    );
+
+    const { result } = renderHook(() => useAccessibility());
+
+    expect(result.current.settings.highContrast).toBe(false);
+    expect(result.current.settings.dyslexiaFont).toBe(false);
+    expect(result.current.settings.reducedMotion).toBe(false);
+    expect(result.current.settings.improvedSpacing).toBe(false);
+  });
+
+  it("ignores unknown persisted properties", () => {
+    localStorage.setItem(
+      "symptom-scribe-accessibility",
+      JSON.stringify({
+        unknownSetting: true,
+      })
+    );
+
+    const { result } = renderHook(() => useAccessibility());
+
+    expect(result.current.settings).not.toHaveProperty("unknownSetting");
+  });
+});

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -20,16 +20,50 @@ const DEFAULT_SETTINGS: AccessibilitySettings = {
   improvedSpacing: false,
 };
 
+const VALID_FONT_SIZES: FontSize[] = ["normal", "large", "x-large"];
+
+function isValidFontSize(value: unknown): value is FontSize {
+  return VALID_FONT_SIZES.includes(value as FontSize);
+}
+
 function loadSettings(): AccessibilitySettings {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      return { ...DEFAULT_SETTINGS, ...JSON.parse(stored) };
+
+    if (!stored) {
+      return DEFAULT_SETTINGS;
     }
+
+    const parsed = JSON.parse(stored);
+
+    return {
+      fontSize: isValidFontSize(parsed.fontSize)
+        ? parsed.fontSize
+        : DEFAULT_SETTINGS.fontSize,
+
+      highContrast:
+        typeof parsed.highContrast === "boolean"
+          ? parsed.highContrast
+          : DEFAULT_SETTINGS.highContrast,
+
+      dyslexiaFont:
+        typeof parsed.dyslexiaFont === "boolean"
+          ? parsed.dyslexiaFont
+          : DEFAULT_SETTINGS.dyslexiaFont,
+
+      reducedMotion:
+        typeof parsed.reducedMotion === "boolean"
+          ? parsed.reducedMotion
+          : DEFAULT_SETTINGS.reducedMotion,
+
+      improvedSpacing:
+        typeof parsed.improvedSpacing === "boolean"
+          ? parsed.improvedSpacing
+          : DEFAULT_SETTINGS.improvedSpacing,
+    };
   } catch {
-    // ignore parse errors
+    return DEFAULT_SETTINGS;
   }
-  return DEFAULT_SETTINGS;
 }
 
 function applyClasses(settings: AccessibilitySettings) {


### PR DESCRIPTION
## **Pull Request Description**

Added validation for persisted accessibility settings before applying them.
Ensured fontSize only accepts supported values (normal, large, x-large).
Validated all accessibility flags to ensure they are booleans.
Ignored unknown persisted properties.
Fell back to default values for invalid or malformed entries.
Expanded unit test coverage to verify validation behavior and prevent regressions.
---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [x] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #868 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. ```npm test -- useAccessibility.test.ts``` passed all 11 tests.


---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

N/A
---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
