### PR TITLE
fix(auth): use dynamic origin for password reset redirect

### DIFF
--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -201,8 +201,9 @@ const handleForgotPassword= async () => {
   const { error } = await supabase.auth.resetPasswordForEmail(
     signInEmail,
     {
-    redirectTo: "https://symptom-scribe-15.lovable.app/reset-password",
-    });
+      redirectTo: `${window.location.origin}/reset-password`,
+    }
+  );
 
   if (error) {
     showError("Reset Failed", error.message);


### PR DESCRIPTION
### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)

---

### **2. Related Issue**
Addresses #959

Note: this PR does not fully close #959 — it fixes a related hardcoded-URL bug found during investigation. The actual root cause of #959 requires a Supabase dashboard change from a maintainer with access — see "What this PR does NOT fix" below.

---

### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint`).
- [x] **Manual Verification**:
  1. Confirmed `MultiStepSignUp.tsx` already builds the correct dynamic redirect via `${window.location.origin}/dashboard`
  2. Traced the reported bug in #959 to Supabase dashboard config (Site URL / Redirect URLs allow-list), not application code
  3. Found and fixed a related hardcoded stale domain in `handleForgotPassword` (`src/pages/Auth/index.tsx`), replacing it with `window.location.origin` to match the signup flow's correct pattern
  4. Verified no remaining references to the stale domain: `grep -rn "lovable.app" src/` returns nothing

---

### **4. Visual Verification**
Not applicable — this is a redirect URL logic fix, no visual/layout changes.

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.

---

### **What this PR fixes**
`handleForgotPassword` in `src/pages/Auth/index.tsx` hardcoded a stale, dead preview domain (`https://symptom-scribe-15.lovable.app/reset-password`) for password reset redirects, instead of using `window.location.origin` like the signup flow (`MultiStepSignUp.tsx`) already correctly does. This meant password reset emails were sending users to a URL that no longer resolves.

**Before:**
```tsx
redirectTo: "https://symptom-scribe-15.lovable.app/reset-password",
```

**After:**
```tsx
redirectTo: `${window.location.origin}/reset-password`,
```

---

### **What this PR does NOT fix**
The originally reported bug in #959 — signup confirmation links redirecting to `localhost:3000` with `otp_expired` — is **not a code bug**. `MultiStepSignUp.tsx` already builds the redirect correctly via `${window.location.origin}/dashboard`. Supabase falls back to the dashboard's **Site URL** (currently `http://localhost:3000`) whenever the passed `emailRedirectTo` isn't in the **Redirect URLs allow-list**, and the Netlify domain was never added to that list.

@mohdmaazgani — this needs a dashboard change to fully resolve #959:
1. **Authentication → URL Configuration → Site URL**: update to `https://symptom-scribe-clean.netlify.app`
2. **Redirect URLs**: add `https://symptom-scribe-clean.netlify.app/**` (and `https://deploy-preview-*--symptom-scribe-clean.netlify.app/**` for PR previews)
3. Optionally review **Email OTP Expiration** under Authentication → Providers → Email if links are also expiring too quickly

I don't have dashboard access to this project to apply that part myself. Happy to help further if there's anything code-side I can contribute, such as a friendlier in-app error page for expired/invalid confirmation links.