### PR TITLE
fix(history): strip raw markdown bold markers from symptom history display

### DIFF
--- a/src/components/history/SymptomCalendarView.tsx
+++ b/src/components/history/SymptomCalendarView.tsx
@@ -24,6 +24,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { stripMarkdownFormatting } from "@/lib/symptom-consultation";
 
 export interface SymptomEntry {
   id: string;
@@ -550,7 +551,7 @@ export const SymptomCalendarView = ({
                           <ul className="list-disc list-inside text-muted-foreground pl-1 mt-0.5 space-y-0.5">
                             {entry.possible_causes.map((c, i) => (
                               <li key={i} className="truncate">
-                                {c}
+                                {stripMarkdownFormatting(c)}
                               </li>
                             ))}
                           </ul>
@@ -563,7 +564,7 @@ export const SymptomCalendarView = ({
                           <ul className="list-disc list-inside text-muted-foreground pl-1 mt-0.5 space-y-0.5">
                             {entry.recommendations.map((r, i) => (
                               <li key={i} className="truncate">
-                                {r}
+                                {stripMarkdownFormatting(r)}
                               </li>
                             ))}
                           </ul>

--- a/src/lib/symptom-consultation.test.ts
+++ b/src/lib/symptom-consultation.test.ts
@@ -3,6 +3,7 @@ import {
   computeRiskScore,
   parseSymptomConsultation,
   shouldPersistConsultation,
+  stripMarkdownFormatting,
 } from "@/lib/symptom-consultation";
 
 describe("symptom consultation helpers", () => {
@@ -24,6 +25,31 @@ RECOMMENDATIONS
     expect(parsed.severityLevel).toBe("moderate");
   });
 
+  it("strips markdown bold markers from parsed causes and recommendations", () => {
+    const parsed = parseSymptomConsultation(`
+### Possible Causes
+- **Viral Infections:** Common cold, flu, COVID-19, or other viral illnesses
+- **Bacterial Infections:** Conditions like strep throat or UTIs
+- **Inflammation:** The body's response to inflammation
+
+### Recommendations
+- **Monitor Temperature:** Keep track of your temperature
+- **Rest:** Get plenty of rest to help your body recover
+- **Stay Hydrated:** Drink plenty of fluids
+`);
+
+    expect(parsed.possibleCauses).toEqual([
+      "Viral Infections: Common cold, flu, COVID-19, or other viral illnesses",
+      "Bacterial Infections: Conditions like strep throat or UTIs",
+      "Inflammation: The body's response to inflammation",
+    ]);
+    expect(parsed.recommendations).toEqual([
+      "Monitor Temperature: Keep track of your temperature",
+      "Rest: Get plenty of rest to help your body recover",
+      "Stay Hydrated: Drink plenty of fluids",
+    ]);
+  });
+
   it("persists completed consultations even when the AI response format varies", () => {
     expect(shouldPersistConsultation("Likely a mild viral illness. Please rest and hydrate.")).toBe(
       true
@@ -36,5 +62,29 @@ RECOMMENDATIONS
     expect(computeRiskScore("moderate", 1, 1)).toBeGreaterThanOrEqual(40);
     expect(computeRiskScore("moderate", 1, 1)).toBeLessThanOrEqual(69);
     expect(computeRiskScore("low", 0, 0)).toBeLessThanOrEqual(39);
+  });
+});
+
+describe("stripMarkdownFormatting", () => {
+  it("strips bold markers (**text**)", () => {
+    expect(stripMarkdownFormatting("**Viral Infections:** Common cold")).toBe(
+      "Viral Infections: Common cold"
+    );
+  });
+
+  it("strips italic markers (*text*)", () => {
+    expect(stripMarkdownFormatting("*Important* note")).toBe("Important note");
+  });
+
+  it("strips multiple bold markers in the same string", () => {
+    expect(stripMarkdownFormatting("**A** and **B** together")).toBe("A and B together");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(stripMarkdownFormatting("No markdown here")).toBe("No markdown here");
+  });
+
+  it("handles empty string", () => {
+    expect(stripMarkdownFormatting("")).toBe("");
   });
 });

--- a/src/lib/symptom-consultation.ts
+++ b/src/lib/symptom-consultation.ts
@@ -4,6 +4,16 @@ export interface ParsedSymptomConsultation {
   severityLevel: "low" | "moderate" | "high";
 }
 
+/**
+ * Strips markdown bold (`**text**`) and italic (`*text*`) markers from a string.
+ * This prevents raw `**` from appearing as literal characters in the UI when
+ * the AI model returns markdown-formatted text in structured fields.
+ */
+export function stripMarkdownFormatting(text: string): string {
+  // First strip bold (**text**), then italic (*text*)
+  return text.replace(/\*\*(.+?)\*\*/g, "$1").replace(/\*(.+?)\*/g, "$1");
+}
+
 export function parseSymptomConsultation(assistantContent: string): ParsedSymptomConsultation {
   const possibleCauses: string[] = [];
   const recommendations: string[] = [];
@@ -41,7 +51,7 @@ export function parseSymptomConsultation(assistantContent: string): ParsedSympto
 
     if (!listMatch) continue;
 
-    const item = listMatch[1].trim();
+    const item = stripMarkdownFormatting(listMatch[1].trim());
     if (!item) continue;
 
     if (currentSection === "causes") {

--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -23,6 +23,7 @@ import { showSuccess, showError } from "@/lib/toast-helpers";
 import { db, syncOfflineData, encryptSymptom, decryptSymptom } from "@/lib/offline-db";
 import { whenKeysReady, generateSearchTokens } from "@/lib/encryption";
 import { getCachedData, invalidateCache } from "@/lib/cached-queries";
+import { stripMarkdownFormatting } from "@/lib/symptom-consultation";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -634,7 +635,7 @@ const History = () => {
                           <p className="text-sm font-semibold mb-1">Possible Causes:</p>
                           <ul className="text-sm text-muted-foreground list-disc list-inside">
                             {entry.possible_causes.map((cause, idx) => (
-                              <li key={idx}>{cause}</li>
+                              <li key={idx}>{stripMarkdownFormatting(cause)}</li>
                             ))}
                           </ul>
                         </div>
@@ -644,7 +645,7 @@ const History = () => {
                           <p className="text-sm font-semibold mb-1">Recommendations:</p>
                           <ul className="text-sm text-muted-foreground list-disc list-inside">
                             {entry.recommendations.map((rec, idx) => (
-                              <li key={idx}>{rec}</li>
+                              <li key={idx}>{stripMarkdownFormatting(rec)}</li>
                             ))}
                           </ul>
                         </div>


### PR DESCRIPTION
…ry display

Fixes #986
- Add stripMarkdownFormatting() helper to remove ** and * markers from strings
- Apply the helper at parse time for new consultations so they are saved clean
- Apply the helper at render time in History/index.tsx and SymptomCalendarView.tsx to sanitize existing records
- Add unit tests for the helper and updated parser behavior

## **Pull Request Description**
A clear and concise description of the changes introduced by this pull request.
Fixes #986
---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes # (e.g., `Fixes #100`) or links to the relevant issue.

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [ ] **Manual Verification**: Briefly list the steps/features verified manually.
  1. 
  2. 

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

---

### **5. Contributor Quality Checklist**
- [ ] My code follows the code style and formatting guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings or console errors.
- [ ] There is no commented-out code or debug logs left in the codebase.
