### PR TITLE
Fix/strip markdown bold from symptom history v2

### DIFF
--- a/src/components/history/SymptomCalendarView.tsx
+++ b/src/components/history/SymptomCalendarView.tsx
@@ -24,6 +24,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { stripMarkdownFormatting } from "@/lib/symptom-consultation";
 
 export interface SymptomEntry {
   id: string;
@@ -550,7 +551,7 @@ export const SymptomCalendarView = ({
                           <ul className="list-disc list-inside text-muted-foreground pl-1 mt-0.5 space-y-0.5">
                             {entry.possible_causes.map((c, i) => (
                               <li key={i} className="truncate">
-                                {c}
+                                {stripMarkdownFormatting(c)}
                               </li>
                             ))}
                           </ul>
@@ -563,7 +564,7 @@ export const SymptomCalendarView = ({
                           <ul className="list-disc list-inside text-muted-foreground pl-1 mt-0.5 space-y-0.5">
                             {entry.recommendations.map((r, i) => (
                               <li key={i} className="truncate">
-                                {r}
+                                {stripMarkdownFormatting(r)}
                               </li>
                             ))}
                           </ul>

--- a/src/lib/symptom-consultation.test.ts
+++ b/src/lib/symptom-consultation.test.ts
@@ -3,6 +3,7 @@ import {
   computeRiskScore,
   parseSymptomConsultation,
   shouldPersistConsultation,
+  stripMarkdownFormatting,
 } from "@/lib/symptom-consultation";
 
 describe("symptom consultation helpers", () => {
@@ -24,6 +25,31 @@ RECOMMENDATIONS
     expect(parsed.severityLevel).toBe("moderate");
   });
 
+  it("strips markdown bold markers from parsed causes and recommendations", () => {
+    const parsed = parseSymptomConsultation(`
+### Possible Causes
+- **Viral Infections:** Common cold, flu, COVID-19, or other viral illnesses
+- **Bacterial Infections:** Conditions like strep throat or UTIs
+- **Inflammation:** The body's response to inflammation
+
+### Recommendations
+- **Monitor Temperature:** Keep track of your temperature
+- **Rest:** Get plenty of rest to help your body recover
+- **Stay Hydrated:** Drink plenty of fluids
+`);
+
+    expect(parsed.possibleCauses).toEqual([
+      "Viral Infections: Common cold, flu, COVID-19, or other viral illnesses",
+      "Bacterial Infections: Conditions like strep throat or UTIs",
+      "Inflammation: The body's response to inflammation",
+    ]);
+    expect(parsed.recommendations).toEqual([
+      "Monitor Temperature: Keep track of your temperature",
+      "Rest: Get plenty of rest to help your body recover",
+      "Stay Hydrated: Drink plenty of fluids",
+    ]);
+  });
+
   it("persists completed consultations even when the AI response format varies", () => {
     expect(shouldPersistConsultation("Likely a mild viral illness. Please rest and hydrate.")).toBe(
       true
@@ -36,5 +62,29 @@ RECOMMENDATIONS
     expect(computeRiskScore("moderate", 1, 1)).toBeGreaterThanOrEqual(40);
     expect(computeRiskScore("moderate", 1, 1)).toBeLessThanOrEqual(69);
     expect(computeRiskScore("low", 0, 0)).toBeLessThanOrEqual(39);
+  });
+});
+
+describe("stripMarkdownFormatting", () => {
+  it("strips bold markers (**text**)", () => {
+    expect(stripMarkdownFormatting("**Viral Infections:** Common cold")).toBe(
+      "Viral Infections: Common cold"
+    );
+  });
+
+  it("strips italic markers (*text*)", () => {
+    expect(stripMarkdownFormatting("*Important* note")).toBe("Important note");
+  });
+
+  it("strips multiple bold markers in the same string", () => {
+    expect(stripMarkdownFormatting("**A** and **B** together")).toBe("A and B together");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(stripMarkdownFormatting("No markdown here")).toBe("No markdown here");
+  });
+
+  it("handles empty string", () => {
+    expect(stripMarkdownFormatting("")).toBe("");
   });
 });

--- a/src/lib/symptom-consultation.test.ts
+++ b/src/lib/symptom-consultation.test.ts
@@ -80,11 +80,41 @@ describe("stripMarkdownFormatting", () => {
     expect(stripMarkdownFormatting("**A** and **B** together")).toBe("A and B together");
   });
 
+  it("strips nested/repeated markers (***text***)", () => {
+    expect(stripMarkdownFormatting("***Important***")).toBe("Important");
+    expect(stripMarkdownFormatting("****Bold Bold****")).toBe("Bold Bold");
+  });
+
+  it("handles whitespace around markers", () => {
+    expect(stripMarkdownFormatting("**  spaced  **")).toBe("spaced");
+    expect(stripMarkdownFormatting("*  italic  *")).toBe("italic");
+  });
+
   it("returns plain text unchanged", () => {
     expect(stripMarkdownFormatting("No markdown here")).toBe("No markdown here");
   });
 
   it("handles empty string", () => {
     expect(stripMarkdownFormatting("")).toBe("");
+  });
+
+  it("handles whitespace-only string", () => {
+    expect(stripMarkdownFormatting("   ")).toBe("");
+  });
+
+  it("handles invalid input gracefully", () => {
+    expect(stripMarkdownFormatting(null as unknown as string)).toBe("");
+    expect(stripMarkdownFormatting(undefined as unknown as string)).toBe("");
+  });
+
+  it("handles malformed/unclosed markers gracefully", () => {
+    // Unclosed markers are left as-is (expected behavior)
+    expect(stripMarkdownFormatting("**unclosed")).toBe("**unclosed");
+    expect(stripMarkdownFormatting("*unclosed")).toBe("*unclosed");
+  });
+
+  it("handles mixed bold and italic", () => {
+    expect(stripMarkdownFormatting("**bold** and *italic*")).toBe("bold and italic");
+    expect(stripMarkdownFormatting("***bold italic***")).toBe("bold italic");
   });
 });

--- a/src/lib/symptom-consultation.ts
+++ b/src/lib/symptom-consultation.ts
@@ -4,6 +4,16 @@ export interface ParsedSymptomConsultation {
   severityLevel: "low" | "moderate" | "high";
 }
 
+/**
+ * Strips markdown bold (`**text**`) and italic (`*text*`) markers from a string.
+ * This prevents raw `**` from appearing as literal characters in the UI when
+ * the AI model returns markdown-formatted text in structured fields.
+ */
+export function stripMarkdownFormatting(text: string): string {
+  // First strip bold (**text**), then italic (*text*)
+  return text.replace(/\*\*(.+?)\*\*/g, "$1").replace(/\*(.+?)\*/g, "$1");
+}
+
 export function parseSymptomConsultation(assistantContent: string): ParsedSymptomConsultation {
   const possibleCauses: string[] = [];
   const recommendations: string[] = [];
@@ -41,7 +51,7 @@ export function parseSymptomConsultation(assistantContent: string): ParsedSympto
 
     if (!listMatch) continue;
 
-    const item = listMatch[1].trim();
+    const item = stripMarkdownFormatting(listMatch[1].trim());
     if (!item) continue;
 
     if (currentSection === "causes") {

--- a/src/lib/symptom-consultation.ts
+++ b/src/lib/symptom-consultation.ts
@@ -6,12 +6,50 @@ export interface ParsedSymptomConsultation {
 
 /**
  * Strips markdown bold (`**text**`) and italic (`*text*`) markers from a string.
- * This prevents raw `**` from appearing as literal characters in the UI when
- * the AI model returns markdown-formatted text in structured fields.
+ *
+ * Handles:
+ * - Basic bold: **text** → text
+ * - Basic italic: *text* → text
+ * - Multiple markers: **A** and **B** → A and B
+ * - Nested markers: ***text*** → text (via iterative stripping)
+ * - Whitespace: **  text  ** → text (trimmed)
+ *
+ * Does NOT handle:
+ * - Underscore variants (_text_)
+ * - Other markdown (links, code blocks, etc.)
+ *
+ * @param text - The string to process
+ * @returns Cleaned string with markdown markers removed, or empty string if input is invalid
  */
 export function stripMarkdownFormatting(text: string): string {
-  // First strip bold (**text**), then italic (*text*)
-  return text.replace(/\*\*(.+?)\*\*/g, "$1").replace(/\*(.+?)\*/g, "$1");
+  // Defensive input validation
+  if (!text || typeof text !== "string") {
+    return "";
+  }
+
+  // Prevent ReDoS: Cap input length
+  const MAX_LENGTH = 10000;
+  if (text.length > MAX_LENGTH) {
+    console.warn(`stripMarkdownFormatting: Input exceeds max length (${text.length}). Truncating.`);
+    text = text.slice(0, MAX_LENGTH);
+  }
+
+  let result = text;
+  let previousResult = "";
+  let iterations = 0;
+  const MAX_ITERATIONS = 10; // Prevent infinite loops with malformed input
+
+  // Iteratively strip markers to handle nested/malformed patterns
+  while (result !== previousResult && iterations < MAX_ITERATIONS) {
+    previousResult = result;
+    // Strip bold (**text**), capturing content and trimming whitespace
+    result = result.replace(/\*\*\s*(.+?)\s*\*\*/g, "$1");
+    // Strip italic (*text*), using negative lookahead to avoid ** matches
+    result = result.replace(/(?<!\*)\*\s*(.+?)\s*\*(?!\*)/g, "$1");
+    iterations++;
+  }
+
+  return result.trim();
 }
 
 export function parseSymptomConsultation(assistantContent: string): ParsedSymptomConsultation {
@@ -51,6 +89,8 @@ export function parseSymptomConsultation(assistantContent: string): ParsedSympto
 
     if (!listMatch) continue;
 
+    // Strip markdown at parse time to ensure new records are clean
+    // Also apply at render time for backward compatibility with existing records
     const item = stripMarkdownFormatting(listMatch[1].trim());
     if (!item) continue;
 

--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -23,6 +23,7 @@ import { showSuccess, showError } from "@/lib/toast-helpers";
 import { db, syncOfflineData, encryptSymptom, decryptSymptom } from "@/lib/offline-db";
 import { whenKeysReady, generateSearchTokens } from "@/lib/encryption";
 import { getCachedData, invalidateCache } from "@/lib/cached-queries";
+import { stripMarkdownFormatting } from "@/lib/symptom-consultation";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -634,7 +635,7 @@ const History = () => {
                           <p className="text-sm font-semibold mb-1">Possible Causes:</p>
                           <ul className="text-sm text-muted-foreground list-disc list-inside">
                             {entry.possible_causes.map((cause, idx) => (
-                              <li key={idx}>{cause}</li>
+                              <li key={idx}>{stripMarkdownFormatting(cause)}</li>
                             ))}
                           </ul>
                         </div>
@@ -644,7 +645,7 @@ const History = () => {
                           <p className="text-sm font-semibold mb-1">Recommendations:</p>
                           <ul className="text-sm text-muted-foreground list-disc list-inside">
                             {entry.recommendations.map((rec, idx) => (
-                              <li key={idx}>{rec}</li>
+                              <li key={idx}>{stripMarkdownFormatting(rec)}</li>
                             ))}
                           </ul>
                         </div>


### PR DESCRIPTION
## **Pull Request Description**
This PR implements a robust version of the `stripMarkdownFormatting()` helper and updates the symptom consultation parsing logic to resolve issues identified during code review. 

Specifically, it fixes edge cases regarding nested/overlapping markdown bold (`**`) and italic (`*`) patterns (e.g., `***nested***`, `****bold bold****`), whitespace stripping inside markers, type-safety checks for non-string inputs (`null`/`undefined`), and protects against Regular Expression Denial of Service (ReDoS) with input length limits.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [x] **Refactoring / Performance** (non-breaking code improvements for ReDoS safety)
- [x] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #986 

---

### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Ran the comprehensive Vitest suite for `symptom-consultation` to ensure formatting matches the expected outputs.
  2. Verified formatting strips nested bold/italic markers (`***Important***` -> `Important`) and handles invalid types safely without crashing.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
Screenshots are similar to previous raised pull request
---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.