### PR TITLE
fix: add missing images column to symptom_history (#996)

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -131,6 +131,7 @@ export type Database = {
           created_at: string | null
           follow_up_date: string | null
           id: string
+          images: string[] | null
           possible_causes: string[] | null
           recommendations: string[] | null
           resolved: boolean | null
@@ -145,6 +146,7 @@ export type Database = {
           created_at?: string | null
           follow_up_date?: string | null
           id?: string
+          images?: string[] | null
           possible_causes?: string[] | null
           recommendations?: string[] | null
           resolved?: boolean | null
@@ -159,6 +161,7 @@ export type Database = {
           created_at?: string | null
           follow_up_date?: string | null
           id?: string
+          images?: string[] | null
           possible_causes?: string[] | null
           recommendations?: string[] | null
           resolved?: boolean | null

--- a/src/lib/offline-db.ts
+++ b/src/lib/offline-db.ts
@@ -38,6 +38,7 @@ export interface OfflineSymptom {
   pending_delete: number;
   ai_analysis?: string;
   search_tokens?: string[] | null;
+  images?: string[] | null;
 }
 
 export interface MeshAlert {

--- a/supabase/migrations/20260806000000_add_images_to_symptom_history.sql
+++ b/supabase/migrations/20260806000000_add_images_to_symptom_history.sql
@@ -1,0 +1,2 @@
+-- Add nullable images column to symptom_history so attached chat images can be persisted
+ALTER TABLE public.symptom_history ADD COLUMN IF NOT EXISTS images TEXT[];


### PR DESCRIPTION
## Problem

The symptom submission flow builds a `symptom_history` record that includes an `images` array, but the `symptom_history` table has no `images` column and the generated Supabase types (`src/integrations/supabase/types.ts`) do not include it. Inserts therefore fail because the payload references a column that does not exist in the schema or the types.

## Fix

- Adds a migration `supabase/migrations/20260806000000_add_images_to_symptom_history.sql` that adds a nullable `images TEXT[]` column to `symptom_history`.
- Adds `images` to the generated `symptom_history` types (`Row`, `Insert`, `Update`) in `src/integrations/supabase/types.ts`.
- Adds `images?: string[] | null` to the `OfflineSymptom` type in `src/lib/offline-db.ts` so offline records that carry images are typed correctly.

## Files changed

- `src/integrations/supabase/types.ts`
- `src/lib/offline-db.ts`
- `supabase/migrations/20260806000000_add_images_to_symptom_history.sql`

## Testing

- Applied the migration (nullable column, backward compatible).
- `npx tsc --noEmit -p tsconfig.app.json` on the merged fix branches shows no new type errors versus `main`.
- `npx eslint` on the changed files passes.
- Manual QA: submit a symptom entry with images attached and verify the row is written to `symptom_history` including the `images` array; verify entries without images still insert correctly.

Closes #996
