### PR TITLE
fix: use current origin for reset-password redirect (#998)

### DIFF
--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -200,7 +200,7 @@ const handleForgotPassword= async () => {
   const { error } = await supabase.auth.resetPasswordForEmail(
     signInEmail,
     {
-    redirectTo: "https://symptom-scribe-15.lovable.app/reset-password",
+    redirectTo: `${window.location.origin}/reset-password`,
     });
 
   if (error) {


### PR DESCRIPTION
## Problem

The reset-password email `redirectTo` is hardcoded to `https://symptom-scribe-15.lovable.app/reset-password`. When the app is deployed on the Netlify domain, clicking the reset link in the email lands on the old Lovable URL and the reset flow never reaches the deployed app.

## Fix

- Builds the `redirectTo` from `window.location.origin` so the email always links back to the domain the user actually opened the app on (Netlify production, preview, or local dev).

## Files changed

- `src/pages/Auth/index.tsx`

## Testing

- `npx eslint` on the changed file passes.
- Manual QA: trigger "forgot password" from the deployed app, open the emailed link, and confirm it opens `/reset-password` on the same domain and the reset succeeds.

Closes #998
