### PR TITLE
fix: re-encrypt server-side data after password change/reset (#999)

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -48,6 +48,7 @@ export type Database = {
           metric_type: string
           notes: string | null
           recorded_at: string | null
+          search_tokens: string[] | null
           user_id: string
           value: Json
         }
@@ -57,6 +58,7 @@ export type Database = {
           metric_type: string
           notes?: string | null
           recorded_at?: string | null
+          search_tokens?: string[] | null
           user_id: string
           value: Json
         }
@@ -66,6 +68,7 @@ export type Database = {
           metric_type?: string
           notes?: string | null
           recorded_at?: string | null
+          search_tokens?: string[] | null
           user_id?: string
           value?: Json
         }
@@ -135,6 +138,7 @@ export type Database = {
           recommendations: string[] | null
           resolved: boolean | null
           risk_score: number | null
+          search_tokens: string[] | null
           severity_level: string
           symptoms: string
           updated_at: string | null
@@ -149,6 +153,7 @@ export type Database = {
           recommendations?: string[] | null
           resolved?: boolean | null
           risk_score?: number | null
+          search_tokens?: string[] | null
           severity_level: string
           symptoms: string
           updated_at?: string | null
@@ -163,6 +168,7 @@ export type Database = {
           recommendations?: string[] | null
           resolved?: boolean | null
           risk_score?: number | null
+          search_tokens?: string[] | null
           severity_level?: string
           symptoms?: string
           updated_at?: string | null

--- a/src/lib/offline-db.ts
+++ b/src/lib/offline-db.ts
@@ -1,6 +1,6 @@
 import Dexie, { type Table } from "dexie";
 import { supabase } from "@/integrations/supabase/client";
-import { type Json } from "@/integrations/supabase/types";
+import { type Database, type Json } from "@/integrations/supabase/types";
 import {
   encryptText,
   decryptText,
@@ -8,6 +8,10 @@ import {
   registerEncryptionHooks,
   getSearchKey,
   generateSearchTokens,
+  encryptProfileField,
+  decryptProfileField,
+  encryptProfileArray,
+  decryptProfileArray,
 } from "./encryption";
 import { invalidateCache } from "@/lib/cached-queries";
 
@@ -327,4 +331,140 @@ export const syncOfflineData = async (): Promise<boolean> => {
     console.error("Error during offline synchronization:", error);
     return false;
   }
+};
+
+/**
+ * Re-encrypts the authenticated user's server-side rows after a password
+ * change/reset so existing records remain decryptable under the new key.
+ *
+ * Without this, only the local Dexie cache is re-encrypted (see the
+ * onTokenRefresh hook above) and every server row stays encrypted under the
+ * old key, becoming undecryptable after a reload.
+ */
+export const reencryptServerData = async (
+  oldKey: CryptoKey,
+  newKey: CryptoKey,
+  oldSearchKey?: CryptoKey | null,
+  newSearchKey?: CryptoKey | null
+): Promise<void> => {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+
+  // symptom_history
+  const { data: symptoms, error: symptomsError } = await supabase
+    .from("symptom_history")
+    .select("*")
+    .eq("user_id", user.id);
+
+  if (symptomsError) {
+    console.error("Failed to fetch symptom_history for re-encryption:", symptomsError);
+  } else if (symptoms && symptoms.length > 0) {
+    for (const record of symptoms) {
+      try {
+        const decrypted = await decryptSymptom(record as unknown as OfflineSymptom, oldKey);
+        const reencrypted = await encryptSymptom(decrypted, newKey, newSearchKey);
+        const { error: updateError } = await supabase
+          .from("symptom_history")
+          .update({
+            symptoms: reencrypted.symptoms,
+            ai_analysis: reencrypted.ai_analysis,
+            possible_causes: reencrypted.possible_causes,
+            recommendations: reencrypted.recommendations,
+            search_tokens: reencrypted.search_tokens,
+          })
+          .eq("id", record.id);
+        if (updateError) {
+          console.error(`Failed to re-encrypt symptom_history row ${record.id}:`, updateError);
+        }
+      } catch (err) {
+        console.error(`Failed to re-encrypt symptom_history row ${record.id}:`, err);
+      }
+    }
+  }
+
+  // health_metrics
+  const { data: metrics, error: metricsError } = await supabase
+    .from("health_metrics")
+    .select("*")
+    .eq("user_id", user.id);
+
+  if (metricsError) {
+    console.error("Failed to fetch health_metrics for re-encryption:", metricsError);
+  } else if (metrics && metrics.length > 0) {
+    for (const record of metrics) {
+      try {
+        const decrypted = await decryptMetric(record as unknown as OfflineMetric, oldKey);
+        const reencrypted = await encryptMetric(decrypted, newKey, newSearchKey);
+        const { error: updateError } = await supabase
+          .from("health_metrics")
+          .update({
+            value: reencrypted.value,
+            notes: reencrypted.notes,
+            search_tokens: reencrypted.search_tokens,
+          })
+          .eq("id", record.id);
+        if (updateError) {
+          console.error(`Failed to re-encrypt health_metrics row ${record.id}:`, updateError);
+        }
+      } catch (err) {
+        console.error(`Failed to re-encrypt health_metrics row ${record.id}:`, err);
+      }
+    }
+  }
+
+  // profiles (encrypted fields)
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    console.error("Failed to fetch profile for re-encryption:", profileError);
+  } else if (profile) {
+    const profileUpdate: Database["public"]["Tables"]["profiles"]["Update"] = {};
+
+    const textFields = [
+      "full_name",
+      "date_of_birth",
+      "emergency_contact_name",
+      "emergency_contact_phone",
+    ] as const;
+    const arrayFields = ["allergies", "chronic_conditions"] as const;
+
+    for (const field of textFields) {
+      try {
+        const decrypted = await decryptProfileField(profile[field], oldKey);
+        profileUpdate[field] = await encryptProfileField(decrypted, newKey);
+      } catch (err) {
+        console.error(`Failed to re-encrypt profile field ${field}:`, err);
+      }
+    }
+
+    for (const field of arrayFields) {
+      try {
+        const decrypted = await decryptProfileArray(profile[field] as unknown as string, oldKey);
+        profileUpdate[field] = (await encryptProfileArray(decrypted, newKey)) as unknown as string[] | null;
+      } catch (err) {
+        console.error(`Failed to re-encrypt profile field ${field}:`, err);
+      }
+    }
+
+    const { error: profileUpdateError } = await supabase
+      .from("profiles")
+      .update(profileUpdate)
+      .eq("user_id", user.id);
+
+    if (profileUpdateError) {
+      console.error("Failed to update re-encrypted profile fields:", profileUpdateError);
+    }
+  }
+
+  await Promise.all([
+    invalidateCache("health_metrics").catch(() => {}),
+    invalidateCache("symptom_history").catch(() => {}),
+    invalidateCache("profiles").catch(() => {}),
+  ]);
 };

--- a/src/pages/User/ResetPassword.tsx
+++ b/src/pages/User/ResetPassword.tsx
@@ -4,6 +4,13 @@ import { supabase } from "@/integrations/supabase/client";
 import { showSuccess, showError } from "@/lib/toast-helpers";
 import { PasswordStrengthMeter } from "@/components/registration/shared/PasswordStrengthMeter";
 import { DEFAULT_PASSWORD_POLICY, evaluatePasswordStrength } from "@/lib/password-strength";
+import {
+  getKey,
+  getSearchKey,
+  setupKeysFromPassword,
+  triggerKeyRotation,
+} from "@/lib/encryption";
+import { reencryptServerData } from "@/lib/offline-db";
 
 const ResetPassword = () => {
   const [password, setPassword] = useState("");
@@ -25,16 +32,38 @@ const ResetPassword = () => {
 
     setLoading(true);
 
+    const oldKey = getKey();
+    const oldSearchKey = getSearchKey();
+
     const { error } = await supabase.auth.updateUser({
       password,
     });
 
-    setLoading(false);
-
     if (error) {
+      setLoading(false);
       showError("Update Failed", error.message);
       return;
     }
+
+    try {
+      const userRes = await supabase.auth.getUser();
+      const user = userRes.data.user;
+      if (user && user.email) {
+        await setupKeysFromPassword(password, user.email, user.id);
+
+        const newKey = getKey();
+        const newSearchKey = getSearchKey();
+
+        if (oldKey && newKey && oldSearchKey && newSearchKey) {
+          await triggerKeyRotation(oldKey, newKey, oldSearchKey, newSearchKey);
+          await reencryptServerData(oldKey, newKey, oldSearchKey, newSearchKey);
+        }
+      }
+    } catch (rotateErr) {
+      console.error("Failed to rotate encryption keys after password reset:", rotateErr);
+    }
+
+    setLoading(false);
 
     showSuccess("Password Updated!", "You can now sign in with your new password.");
     navigate("/auth");

--- a/src/pages/User/Settings.tsx
+++ b/src/pages/User/Settings.tsx
@@ -22,6 +22,7 @@ import {
   setupKeysFromPassword,
   triggerKeyRotation,
 } from "@/lib/encryption";
+import { reencryptServerData } from "@/lib/offline-db";
 import TwoFactorAuth from "@/components/settings/TwoFactorAuth";
 
 const Settings = () => {
@@ -123,6 +124,7 @@ const Settings = () => {
 
             if (oldKey && newKey && oldSearchKey && newSearchKey) {
               await triggerKeyRotation(oldKey, newKey, oldSearchKey, newSearchKey);
+              await reencryptServerData(oldKey, newKey, oldSearchKey, newSearchKey);
             }
           }
         } catch (rotateErr) {


### PR DESCRIPTION
## Problem

After a password change or reset, only the local Dexie cache is re-encrypted (via the `onTokenRefresh` hook). The server-side rows — `symptom_history`, `health_metrics`, and the encrypted `profiles` fields — stay encrypted under the old key. After a reload the old key no longer exists, so previously saved records become undecryptable (broken profile, history, metrics, and server-side search).

## Fix

- Adds `reencryptServerData(oldKey, newKey, oldSearchKey, newSearchKey)` in `src/lib/offline-db.ts` which decrypts and re-encrypts all of the authenticated user's `symptom_history`, `health_metrics`, and encrypted `profiles` fields (text + array fields) with the new key and new search tokens, then invalidates the related caches.
- Calls `reencryptServerData` after `triggerKeyRotation` in the password change flow (`src/pages/User/Settings.tsx`).
- Calls `reencryptServerData` in the reset-password flow (`src/pages/User/ResetPassword.tsx`) after `setupKeysFromPassword` derives the new key, so records created under the old password are migrated too.
- Adds the missing `search_tokens` column to the generated types for `symptom_history` and `health_metrics` (the column already exists in the database per `20260616143000_add_search_tokens_blind_indexes.sql`), which the re-encryption writes.

## Files changed

- `src/integrations/supabase/types.ts`
- `src/lib/offline-db.ts`
- `src/pages/User/Settings.tsx`
- `src/pages/User/ResetPassword.tsx`

## Testing

- `npx tsc --noEmit -p tsconfig.app.json` on the merged fix branches shows no new type errors versus `main`.
- `npx eslint` on the changed files passes.
- Manual QA: change the password, reload the app, and verify history/metrics/profile still decrypt correctly and search still returns rows; repeat for the reset-password flow.

Closes #999
