### PR TITLE
fix: stop silently overwriting local salt on session change (#1000)

### DIFF
--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -398,7 +398,22 @@ async function handleSessionChange(session: Session) {
     const localSalt = localStorage.getItem(SALT_KEY_PREFIX + userId);
 
     if (dbSalt) {
-      if (dbSalt !== localSalt) {
+      if (localSalt && dbSalt !== localSalt) {
+        // A diverged salt must not be silently swapped in: the salt is a
+        // direct input to key derivation, so overwriting it would silently
+        // produce a different key and make all previously encrypted fields
+        // and blind-index search tokens unreadable (see the "Per-user PBKDF2
+        // Salt" note above). Treat the mismatch as an error that requires an
+        // explicit re-encryption instead of rotating the key under the user.
+        console.error(
+          "Encryption salt mismatch: local salt differs from the database salt for this user. " +
+            "Refusing to overwrite the local salt because it would change the derived key and " +
+            "make existing encrypted data undecryptable. An explicit re-encryption is required " +
+            "to migrate to the database salt."
+        );
+      } else if (!localSalt) {
+        // Fresh device with no local data yet: safely adopt the database salt
+        // so all devices converge on one salt.
         localStorage.setItem(SALT_KEY_PREFIX + userId, dbSalt);
       }
     } else {


### PR DESCRIPTION
## Problem

`handleSessionChange` blindly overwrites the local salt with the database salt whenever the two differ. Because the salt is mixed into PBKDF2 key derivation, overwriting the local salt silently changes the derived key: data encrypted with the old (local) salt can no longer be decrypted after a reload, and existing offline data becomes unrecoverable.

## Fix

- Refuses to overwrite the local salt when `dbSalt !== localSalt`; instead it logs a clear error explaining that the salts differ and that re-encryption is required, so the user's existing data stays decryptable.
- Only adopts the database salt when no local salt exists (fresh device/first session), preserving the intended cross-device salt convergence for new users.

## Files changed

- `src/lib/encryption.ts`

## Testing

- `npx tsc --noEmit -p tsconfig.app.json` on the merged fix branches shows no new type errors versus `main`.
- `npx eslint` on the changed file passes.
- Manual QA: on an existing device with local salt, trigger a session refresh and confirm the local salt is not replaced; on a brand-new device, confirm the database salt is adopted.

Closes #1000
