### PR TITLE
fix: enforce AAL2 on protected routes after reload (#1001)

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -13,6 +13,7 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
   const [authError, setAuthError] = useState<string | null>(null);
+  const [needsMfaChallenge, setNeedsMfaChallenge] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -26,6 +27,22 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
         setAuthError(error.message);
         setLoading(false);
         return;
+      }
+
+      if (data.session) {
+        const { data: aalData } =
+          (await supabase.auth.mfa?.getAuthenticatorAssuranceLevel()) ?? { data: null };
+
+        if (!isMounted) return;
+
+        // The account has MFA (2FA) enabled but the current session is only
+        // AAL1, so a second-factor challenge is still required before the
+        // protected content can be shown. Redirect to the MFA challenge flow.
+        if (aalData && aalData.currentLevel !== "aal2" && aalData.nextLevel === "aal2") {
+          setNeedsMfaChallenge(true);
+          setLoading(false);
+          return;
+        }
       }
 
       setSession(data.session);
@@ -68,6 +85,10 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
         </div>
       </div>
     );
+  }
+
+  if (needsMfaChallenge) {
+    return <Navigate to="/auth?mfa=challenge" replace />;
   }
 
   if (!session) {

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -88,6 +88,27 @@ const Auth = () => {
   }, [navigate]);
 
   useEffect(() => {
+    // When redirected here from ProtectedRoute with a pending second-factor
+    // challenge (?mfa=challenge), present the MFA verification UI for the
+    // existing AAL1 session so reloading the app cannot bypass 2FA.
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("mfa") === "challenge") {
+      (async () => {
+        const { data: aalData } =
+          (await supabase.auth.mfa?.getAuthenticatorAssuranceLevel()) ?? { data: null };
+        if (aalData && aalData.currentLevel !== "aal2" && aalData.nextLevel === "aal2") {
+          const { data: factorsData } = await supabase.auth.mfa.listFactors();
+          const totpFactor = factorsData?.totp?.[0];
+          if (totpFactor) {
+            setMfaFactorId(totpFactor.id);
+            setMfaRequired(true);
+          }
+        }
+      })();
+    }
+  }, []);
+
+  useEffect(() => {
     setShowPassword(false);
   }, [authTab]);
 
@@ -181,7 +202,7 @@ const Auth = () => {
 
     try {
       const { data: userRes } = await supabase.auth.getUser();
-      if (userRes?.user) {
+      if (userRes?.user && signInPassword) {
         await setupKeysFromPassword(signInPassword, signInEmail, userRes.user.id);
       }
     } catch (deriveErr) {


### PR DESCRIPTION
## Problem

`ProtectedRoute` only checks that a session exists. After signing in with password only (AAL1), or right after the MFA challenge on the Auth page, a page reload passes `ProtectedRoute` with an AAL1 session, so protected routes can be reached without completing the 2FA (AAL2) step.

## Fix

- `ProtectedRoute` now calls `supabase.auth.mfa.getAuthenticatorAssuranceLevel()` and, when `nextLevel` is `aal2` but the current level is `aal1`, redirects to `/auth?mfa=challenge` instead of rendering the protected route.
- `src/pages/Auth/index.tsx` handles the `mfa=challenge` query parameter: it lists the user's TOTP factors and shows the MFA verification UI, and only derives encryption keys in `handleMfaVerify` when a password is available (so challenge-only sessions don't break key setup).

## Files changed

- `src/components/auth/ProtectedRoute.tsx`
- `src/pages/Auth/index.tsx`

## Testing

- `npx tsc --noEmit -p tsconfig.app.json` on the merged fix branches shows no new type errors versus `main`.
- `npx eslint` on the changed files passes.
- Manual QA: sign in with password only, reload a protected page, and confirm redirection to `/auth?mfa=challenge`; complete the TOTP code and confirm access is granted.

Closes #1001
