### PR TITLE
fix: restore AAL2 session when delete-account verification fails (#1003)

### DIFF
--- a/src/pages/User/Settings.tsx
+++ b/src/pages/User/Settings.tsx
@@ -162,14 +162,26 @@ const Settings = () => {
         return;
       }
 
-      // Verify password
+      // Verify password. signInWithPassword replaces the active session with a
+      // fresh password-only AAL1 session, so capture the current (AAL2)
+      // session first and restore it whenever the deletion does not go through
+      // — otherwise MFA users would be left signed in under the weaker session.
       const user = (await supabase.auth.getUser()).data.user;
+      const { data: sessionData } = await supabase.auth.getSession();
+      const currentSession = sessionData.session;
+
       const { error: signInError } = await supabase.auth.signInWithPassword({
         email: user?.email || "",
         password: deletePassword,
       });
 
       if (signInError) {
+        if (currentSession) {
+          await supabase.auth.setSession({
+            access_token: currentSession.access_token,
+            refresh_token: currentSession.refresh_token,
+          });
+        }
         showError(
           t("settings.toasts.invalidPasswordTitle"),
           t("settings.toasts.passwordIncorrect")
@@ -182,6 +194,14 @@ const Settings = () => {
       const { error: deleteFuncError } = await supabase.functions.invoke("delete-user-account");
 
       if (deleteFuncError) {
+        // Restore the original session so the failed attempt does not
+        // downgrade the user to a password-only (AAL1) session.
+        if (currentSession) {
+          await supabase.auth.setSession({
+            access_token: currentSession.access_token,
+            refresh_token: currentSession.refresh_token,
+          });
+        }
         showError(t("settings.toasts.deletionFailedTitle"), deleteFuncError.message);
       } else {
         // Log out locally (clear session)


### PR DESCRIPTION
## Problem

The delete-account flow calls `signInWithPassword` to re-verify the user's password. If the verification fails or the `delete-user-account` edge function returns an error, the user is left on an AAL1 session — the original AAL2 (2FA-verified) session is lost, so the user silently loses MFA protection on the current device.

## Fix

- Captures the current session (including its AAL2 assurance level) before re-verifying the password.
- If password verification fails or the `delete-user-account` call fails, restores the captured session via `supabase.auth.setSession` so the user keeps their 2FA-verified session.

## Files changed

- `src/pages/User/Settings.tsx`

## Testing

- `npx tsc --noEmit -p tsconfig.app.json` on the merged fix branches shows no new type errors versus `main`.
- `npx eslint` on the changed file passes.
- Manual QA: with MFA enabled, attempt to delete the account and enter a wrong password; confirm the current session remains AAL2 and the user is not logged out or downgraded.

Closes #1003
