### PR TITLE
fix: use local dates for check-in challenge and streaks (#1004)

### DIFF
--- a/src/hooks/useGamification.ts
+++ b/src/hooks/useGamification.ts
@@ -139,8 +139,16 @@ export function useCheckInChallenge() {
       if (fetchErr) throw fetchErr;
 
       const now = new Date();
-      const todayDateStr = now.toISOString().split("T")[0]; 
-      const todayStartISO = `${todayDateStr}T00:00:00.000Z`;
+      const toLocalDateStr = (date: Date): string =>
+        `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
+          date.getDate()
+        ).padStart(2, "0")}`;
+
+      // Compute the check-in day boundary from the user's local calendar day
+      // instead of the UTC date, so the check-in window matches the day the
+      // user sees on their device.
+      const todayDateStr = toLocalDateStr(now);
+      const todayStartISO = new Date(`${todayDateStr}T00:00:00`).toISOString();
 
       const lastCheckIn = current.last_check_in ? new Date(current.last_check_in) : null;
       const alreadyCheckedInToday =
@@ -150,11 +158,11 @@ export function useCheckInChallenge() {
         return { streak: current.current_streak, alreadyCheckedInToday: true };
       }
 
-      const lastCheckInDateStr = lastCheckIn ? lastCheckIn.toISOString().split("T")[0] : null;
+      const lastCheckInDateStr = lastCheckIn ? toLocalDateStr(lastCheckIn) : null;
       const daysSinceLastCheckIn = lastCheckInDateStr
         ? Math.round(
-            (Date.parse(`${todayDateStr}T00:00:00.000Z`) -
-              Date.parse(`${lastCheckInDateStr}T00:00:00.000Z`)) /
+            (Date.parse(`${todayDateStr}T00:00:00`) -
+              Date.parse(`${lastCheckInDateStr}T00:00:00`)) /
               (24 * 60 * 60 * 1000)
           )
         : null;


### PR DESCRIPTION
## Problem

The daily check-in challenge and streak logic compare dates in UTC. For users in timezones ahead of UTC this can mark a check-in as "tomorrow", break an existing streak, or allow two check-ins on the same local day — the check-in experience is wrong for most timezones.

## Fix

- Adds a `toLocalDateStr` helper that formats a timestamp into the user's local date.
- Computes `todayStartISO` from the start of the local day instead of UTC.
- Streak calculations now compare local dates, so a check-in always counts toward the correct local day.

## Files changed

- `src/hooks/useGamification.ts`

## Testing

- `npx tsc --noEmit -p tsconfig.app.json` on the merged fix branches shows no new type errors versus `main`.
- `npx eslint` on the changed file passes.
- Manual QA: set the device timezone ahead of UTC and confirm a check-in counts for today's local date and the streak is maintained correctly.

Closes #1004
