### PR TITLE
fix: delete-all-history uses authenticated user id and handles zero rows (#1005)

### DIFF
--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -19,7 +19,7 @@ import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 import { useNavigate } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
-import { showSuccess, showError } from "@/lib/toast-helpers";
+import { showSuccess, showError, showInfo } from "@/lib/toast-helpers";
 import { db, syncOfflineData, encryptSymptom, decryptSymptom } from "@/lib/offline-db";
 import { whenKeysReady, generateSearchTokens } from "@/lib/encryption";
 import { getCachedData, invalidateCache } from "@/lib/cached-queries";
@@ -323,15 +323,33 @@ const History = () => {
 
   const deleteAllEntries = async () => {
     try {
+      // Use the authenticated user id instead of the first visible record:
+      // when the visible (filtered/search) list is empty, history[0] is
+      // undefined and the server delete used to match zero rows while the
+      // local cache was still cleared and a success toast shown.
+      const { data: { user } } = await supabase.auth.getUser();
+      const userId = user?.id;
+      if (!userId) {
+        showError("Delete failed", "Could not identify your account.");
+        return;
+      }
+
       if (navigator.onLine) {
-        const { error } = await supabase
+        const { data, error } = await supabase
           .from("symptom_history")
           .delete()
-          .eq("user_id", history[0]?.user_id || "");
+          .eq("user_id", userId)
+          .select("id");
 
         if (error) throw error;
         await invalidateCache("symptom_history");
         await db.symptomHistory.clear();
+
+        const deletedCount = Array.isArray(data) ? data.length : 0;
+        if (deletedCount === 0) {
+          showInfo("No records to delete", "There were no records to remove.");
+          return;
+        }
       } else {
         const allRecords = await db.symptomHistory.toArray();
         for (const record of allRecords) {


### PR DESCRIPTION
## Problem

`deleteAllEntries` deletes by `history[0]?.user_id || ""`. After the user clears their history locally (empty list), `user_id` resolves to `""`, so the server delete targets `user_id = ""`, affects zero rows, does not raise an error, and the UI shows a false-success toast and wipes state that was never actually deleted.

## Fix

- Resolves the authenticated user via `supabase.auth.getUser()` and deletes by that real `user_id`.
- Checks the deleted-row count from `.select("id")`; a zero-row delete shows an informational toast (instead of a success toast) and returns early, while a successful multi-row delete keeps the existing success behavior.

## Files changed

- `src/pages/History/index.tsx`

## Testing

- `npx tsc --noEmit -p tsconfig.app.json` on the merged fix branches shows no new type errors versus `main`.
- `npx eslint` on the changed file passes.
- Manual QA: with history present, delete all and confirm rows are removed and the success toast shows; with an empty history, confirm the info toast appears instead of a false success.

Closes #1005
