### PR TITLE
fix(theme): map unique Lucide icons to all themes and resolve swapped…

### DIFF
--- a/src/components/theme/components/AnimatedThemeToggler.tsx
+++ b/src/components/theme/components/AnimatedThemeToggler.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
-import { flushSync } from 'react-dom';
-import { useTheme } from 'next-themes';
-import { Sun, Moon } from 'lucide-react';
-import '../styles/animated-theme-toggler.css';
+import { useEffect, useState } from "react";
+import { flushSync } from "react-dom";
+import { useTheme } from "next-themes";
+import { Sun, Moon, Sparkles, Droplet, TreePine, Sunset, Flower } from "lucide-react";
+import "../styles/animated-theme-toggler.css";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -13,7 +13,7 @@ import {
   DropdownMenuRadioItem,
 } from "@/components/ui/dropdown-menu";
 
-export function AnimatedThemeToggler({ className = '' }) {
+export function AnimatedThemeToggler({ className = "" }) {
   // next-themes is the single source of truth for theme state/persistence.
   // `resolvedTheme` is what's actually applied (system -> light/dark).
   const { resolvedTheme, setTheme } = useTheme();
@@ -22,28 +22,32 @@ export function AnimatedThemeToggler({ className = '' }) {
   // React mounts (preventing a page-wide flash). Seed local mount state
   // from that class so the icon itself doesn't flash to the wrong state
   // during the brief window before `resolvedTheme` is available.
+  const themes = [
+    { value: "light", label: "☀️ Light" },
+    { value: "dark", label: "🌙 Dark" },
+    { value: "cosmic", label: "🌌 Cosmic" },
+    { value: "deep-blue", label: "🔵 Deep Blue" },
+    { value: "forest", label: "🌲 Forest Green" },
+    { value: "orange", label: "🌅 Orange Sunset" },
+    { value: "pastel-pink", label: "🌸 Pastel Pink" },
+  ];
+
   const [mounted, setMounted] = useState(false);
-  const [preMountIsDark, setPreMountIsDark] = useState(false);
+  const [preMountTheme, setPreMountTheme] = useState("light");
   useEffect(() => {
-    setPreMountIsDark(document.documentElement.classList.contains('dark'));
+    const root = document.documentElement;
+    const activeClass = themes.map((t) => t.value).find((cls) => root.classList.contains(cls));
+    setPreMountTheme(activeClass ?? "light");
     setMounted(true);
   }, []);
 
-  const isDark = mounted ? resolvedTheme === 'dark' : preMountIsDark;
+  const currentTheme = mounted ? (resolvedTheme ?? "light") : preMountTheme;
+  const isDark = ["dark", "cosmic", "deep-blue"].includes(currentTheme);
   const duration = 400;
-  const themes = [
-  { value: "light", label: "☀️ Light" },
-  { value: "dark", label: "🌙 Dark" },
-  { value: "cosmic", label: "🌌 Cosmic" },
-  { value: "deep-blue", label: "🔵 Deep Blue" },
-  { value: "forest", label: "🌲 Forest Green" },
-  { value: "orange", label: "🌅 Orange Sunset" },
-  { value: "pastel-pink", label: "🌸 Pastel Pink" },
-];
 
   const handleToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
     const button = e.currentTarget;
-    const nextTheme = isDark ? 'light' : 'dark';
+    const nextTheme = isDark ? "light" : "dark";
 
     const applyTheme = () => {
       // Delegate entirely to next-themes: it updates the `class`
@@ -61,13 +65,10 @@ export function AnimatedThemeToggler({ className = '' }) {
     const y = top + height / 2;
     const viewportWidth = window.visualViewport?.width ?? window.innerWidth;
     const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
-    const maxRadius = Math.hypot(
-      Math.max(x, viewportWidth - x),
-      Math.max(y, viewportHeight - y)
-    );
+    const maxRadius = Math.hypot(Math.max(x, viewportWidth - x), Math.max(y, viewportHeight - y));
 
     // Fallback for browsers that don't support View Transitions API
-    if (typeof document.startViewTransition !== 'function') {
+    if (typeof document.startViewTransition !== "function") {
       applyTheme();
       return;
     }
@@ -79,54 +80,80 @@ export function AnimatedThemeToggler({ className = '' }) {
     transition?.ready?.then(() => {
       document.documentElement.animate(
         {
-          clipPath: [
-            `circle(0px at ${x}px ${y}px)`,
-            `circle(${maxRadius}px at ${x}px ${y}px)`,
-          ],
+          clipPath: [`circle(0px at ${x}px ${y}px)`, `circle(${maxRadius}px at ${x}px ${y}px)`],
         },
         {
           duration,
-          easing: 'ease-in-out',
-          pseudoElement: '::view-transition-new(root)',
+          easing: "ease-in-out",
+          pseudoElement: "::view-transition-new(root)",
         }
       );
     });
   };
 
   return (
-  <DropdownMenu>
-    <DropdownMenuTrigger asChild>
-      <button
-        type="button"
-        className={`animated-theme-toggler ${className}`.trim()}
-        aria-label="Select theme"
-      >
-        <span className="att-icons" aria-hidden="true">
-          <span className={`att-icon att-sun ${isDark ? "att-show" : ""}`.trim()}>
-            <Sun className="h-5 w-5" />
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={`animated-theme-toggler ${className}`.trim()}
+          aria-label="Select theme"
+        >
+          <span className="att-icons" aria-hidden="true">
+            <span
+              className={`att-icon att-sun ${currentTheme === "light" ? "att-show" : ""}`.trim()}
+            >
+              <Sun className="h-5 w-5" />
+            </span>
+            <span
+              className={`att-icon att-moon ${currentTheme === "dark" ? "att-show" : ""}`.trim()}
+            >
+              <Moon className="h-5 w-5" />
+            </span>
+            <span
+              className={`att-icon att-cosmic ${currentTheme === "cosmic" ? "att-show" : ""}`.trim()}
+            >
+              <Sparkles className="h-5 w-5" />
+            </span>
+            <span
+              className={`att-icon att-deep-blue ${currentTheme === "deep-blue" ? "att-show" : ""}`.trim()}
+            >
+              <Droplet className="h-5 w-5" />
+            </span>
+            <span
+              className={`att-icon att-forest ${currentTheme === "forest" ? "att-show" : ""}`.trim()}
+            >
+              <TreePine className="h-5 w-5" />
+            </span>
+            <span
+              className={`att-icon att-orange ${currentTheme === "orange" ? "att-show" : ""}`.trim()}
+            >
+              <Sunset className="h-5 w-5" />
+            </span>
+            <span
+              className={`att-icon att-pastel-pink ${currentTheme === "pastel-pink" ? "att-show" : ""}`.trim()}
+            >
+              <Flower className="h-5 w-5" />
+            </span>
           </span>
-          <span className={`att-icon att-moon ${!isDark ? "att-show" : ""}`.trim()}>
-            <Moon className="h-5 w-5" />
-          </span>
-        </span>
-      </button>
-    </DropdownMenuTrigger>
+        </button>
+      </DropdownMenuTrigger>
 
-    <DropdownMenuContent align="end" className="w-50">
-      <DropdownMenuLabel>Choose Theme</DropdownMenuLabel>
-      <DropdownMenuSeparator />
+      <DropdownMenuContent align="end" className="w-50">
+        <DropdownMenuLabel>Choose Theme</DropdownMenuLabel>
+        <DropdownMenuSeparator />
 
-      <DropdownMenuRadioGroup
-        value={resolvedTheme ?? "light"}
-        onValueChange={(value) => setTheme(value)}
-      >
-        {themes.map((theme) => (
-          <DropdownMenuRadioItem key={theme.value} value={theme.value}>
-            {theme.label}
-          </DropdownMenuRadioItem>
-        ))}
-      </DropdownMenuRadioGroup>
-    </DropdownMenuContent>
-  </DropdownMenu>
-);
+        <DropdownMenuRadioGroup
+          value={resolvedTheme ?? "light"}
+          onValueChange={(value) => setTheme(value)}
+        >
+          {themes.map((theme) => (
+            <DropdownMenuRadioItem key={theme.value} value={theme.value}>
+              {theme.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 }


### PR DESCRIPTION
### 1. Type of Change
- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] UI/UX Enhancement

### 2. Related Issue
Fixes #1017

### 3. Description of Issue & Fix
**Issue**: 
The theme selector trigger button showed the incorrect theme icon (showing the Moon on Light mode and the Sun on Dark mode). Furthermore, it did not dynamically change icons for other custom themes (like Cosmic or Deep Blue) because the code only checked for a binary `resolvedTheme === 'dark'` state.

**Resolution**:
1. **Dynamic Icon Mapping**: Imported and mapped unique Lucide icons matching each theme's identity:
   - Light ➔ `Sun` (☀️)
   - Dark ➔ `Moon` (🌙)
   - Cosmic ➔ `Sparkles` (🌌)
   - Deep Blue ➔ `Droplet` (🔵)
   - Forest Green ➔ `TreePine` (🌲)
   - Orange Sunset ➔ `Sunset` (🌅)
   - Pastel Pink ➔ `Flower` (🌸)
2. **Corrected Icon Rendering Logic**: Swapped the rendering conditions so the Sun displays on light backgrounds, and the Moon/other icons render on their respective themes.
3. **Smooth View Transitions**: Rendered all mapped icons inside the `.att-icons` absolute transition container, dynamically appending the `.att-show` class to preserve fade transition animations.
4. **Hydration Flickering Fix**: Improved the pre-mount theme check to parse the exact theme class on `document.documentElement` to prevent wrong-icon flash states on initial page load.

---

### 4. Visual Verification (Screenshots)

<img width="1470" height="956" alt="Screenshot 2026-08-06 at 2 18 58 PM" src="https://github.com/user-attachments/assets/868cf3d4-15ac-4c3e-b0e6-6eb5f51e50fd" />
<img width="1470" height="956" alt="Screenshot 2026-08-06 at 2 19 08 PM" src="https://github.com/user-attachments/assets/ea0ebbdc-9abf-4f06-b805-8a38aa7c403d" />
<img width="1470" height="956" alt="Screenshot 2026-08-06 at 2 19 14 PM" src="https://github.com/user-attachments/assets/69573716-160f-4212-9e34-251889751344" />
<img width="1470" height="956" alt="Screenshot 2026-08-06 at 2 19 22 PM" src="https://github.com/user-attachments/assets/2b06ebf1-ab79-4fc1-84ad-eb645e65a2d5" />
<img width="1470" height="956" alt="Screenshot 2026-08-06 at 2 19 31 PM" src="https://github.com/user-attachments/assets/e8f6ffe3-222e-4383-928c-50aa43a4e9be" />
<img width="1470" height="956" alt="Screenshot 2026-08-06 at 2 19 38 PM" src="https://github.com/user-attachments/assets/ca5f1725-9471-4aca-8713-9a7622f77e4d" />
<img width="1470" height="956" alt="Screenshot 2026-08-06 at 2 19 45 PM" src="https://github.com/user-attachments/assets/d4f41da2-1c03-4004-9d73-11a05a2adad9" />
