### PR TITLE
fix: use dynamic origin for password reset redirect (#998)

### DIFF
--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -200,7 +200,7 @@ const handleForgotPassword= async () => {
   const { error } = await supabase.auth.resetPasswordForEmail(
     signInEmail,
     {
-    redirectTo: "https://symptom-scribe-15.lovable.app/reset-password",
+    redirectTo: `${window.location.origin}/reset-password`,
     });
 
   if (error) {


### PR DESCRIPTION
## **Pull Request Description**
Fixes the password reset flow so the confirmation email's redirect link points to the current deployment origin instead of a hardcoded domain.

`resetPasswordForEmail` now passes `redirectTo: ${window.location.origin}/reset-password`, so the reset link works regardless of which environment the user signed up in (local, preview, or production).

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #998

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Requested a password reset from a deployed origin and confirmed the email link resolves to `<origin>/reset-password` instead of the stale hardcoded domain.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| N/A (no UI change) | N/A (no UI change) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
