### PR TITLE
fix: add images column to symptom_history so chat images save (#996)

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -131,6 +131,7 @@ export type Database = {
           created_at: string | null
           follow_up_date: string | null
           id: string
+          images: string[] | null
           possible_causes: string[] | null
           recommendations: string[] | null
           resolved: boolean | null
@@ -145,6 +146,7 @@ export type Database = {
           created_at?: string | null
           follow_up_date?: string | null
           id?: string
+          images?: string[] | null
           possible_causes?: string[] | null
           recommendations?: string[] | null
           resolved?: boolean | null
@@ -159,6 +161,7 @@ export type Database = {
           created_at?: string | null
           follow_up_date?: string | null
           id?: string
+          images?: string[] | null
           possible_causes?: string[] | null
           recommendations?: string[] | null
           resolved?: boolean | null

--- a/src/lib/offline-db.ts
+++ b/src/lib/offline-db.ts
@@ -37,6 +37,7 @@ export interface OfflineSymptom {
   pending_update: number;
   pending_delete: number;
   ai_analysis?: string;
+  images?: string[] | null;
   search_tokens?: string[] | null;
 }
 

--- a/supabase/migrations/20260806100000_add_images_to_symptom_history.sql
+++ b/supabase/migrations/20260806100000_add_images_to_symptom_history.sql
@@ -1,0 +1,3 @@
+-- Add nullable images column to symptom_history for attached consultation images
+ALTER TABLE public.symptom_history
+  ADD COLUMN IF NOT EXISTS images text[];


### PR DESCRIPTION
## **Pull Request Description**
Symptom history rows are missing an `images` column, so chat images were silently dropped when a consultation was saved.

Adds a `supabase/migrations/20260806100000_add_images_to_symptom_history.sql` migration (`ALTER TABLE public.symptom_history ADD COLUMN IF NOT EXISTS images text[];`), updates the generated Supabase types (`images: string[] | null`) for Row/Insert/Update, and adds `images?: string[] | null` to the offline `OfflineSymptom` type so images round-trip correctly in local-first mode too.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #996

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Ran the migration against a local Supabase instance; verified the column is added idempotently and types compile.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| N/A (no UI change) | N/A (no UI change) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
