### PR TITLE
fix: align CORS allowlist for cache edge functions (#997)

### DIFF
--- a/supabase/functions/get-cached-data/index.ts
+++ b/supabase/functions/get-cached-data/index.ts
@@ -7,11 +7,18 @@ const ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:8080",
   "https://symptom-scribe.vercel.app",
+  "https://symptom-scribe-clean.netlify.app",
 ];
+
+const NETLIFY_PREVIEW_ORIGIN = /^https:\/\/deploy-preview-\d+--symptom-scribe-clean\.netlify\.app$/;
+
+function isAllowedOrigin(origin: string): boolean {
+  return ALLOWED_ORIGINS.includes(origin) || NETLIFY_PREVIEW_ORIGIN.test(origin);
+}
 
 const getCorsHeaders = (origin: string | null) => ({
   "Access-Control-Allow-Origin":
-    origin && ALLOWED_ORIGINS.includes(origin) ? origin : "null",
+    origin && isAllowedOrigin(origin) ? origin : "null",
   "Access-Control-Allow-Headers":
     "authorization, x-client-info, apikey, content-type",
 });
@@ -19,7 +26,7 @@ const getCorsHeaders = (origin: string | null) => ({
 serve(async (req) => {
   const origin = req.headers.get("origin");
 
-  if (origin && !ALLOWED_ORIGINS.includes(origin)) {
+  if (origin && !isAllowedOrigin(origin)) {
     return new Response(JSON.stringify({ error: "Origin not allowed" }), {
       status: 403,
       headers: { ...getCorsHeaders(origin), "Content-Type": "application/json" },

--- a/supabase/functions/invalidate-cache/index.ts
+++ b/supabase/functions/invalidate-cache/index.ts
@@ -7,11 +7,18 @@ const ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:8080",
   "https://symptom-scribe.vercel.app",
+  "https://symptom-scribe-clean.netlify.app",
 ];
+
+const NETLIFY_PREVIEW_ORIGIN = /^https:\/\/deploy-preview-\d+--symptom-scribe-clean\.netlify\.app$/;
+
+function isAllowedOrigin(origin: string): boolean {
+  return ALLOWED_ORIGINS.includes(origin) || NETLIFY_PREVIEW_ORIGIN.test(origin);
+}
 
 const getCorsHeaders = (origin: string | null) => ({
   "Access-Control-Allow-Origin":
-    origin && ALLOWED_ORIGINS.includes(origin) ? origin : "null",
+    origin && isAllowedOrigin(origin) ? origin : "null",
   "Access-Control-Allow-Headers":
     "authorization, x-client-info, apikey, content-type, x-webhook-secret",
 });
@@ -19,7 +26,7 @@ const getCorsHeaders = (origin: string | null) => ({
 serve(async (req) => {
   const origin = req.headers.get("origin");
 
-  if (origin && !ALLOWED_ORIGINS.includes(origin)) {
+  if (origin && !isAllowedOrigin(origin)) {
     return new Response(JSON.stringify({ error: "Origin not allowed" }), {
       status: 403,
       headers: { ...getCorsHeaders(origin), "Content-Type": "application/json" },


### PR DESCRIPTION
## **Pull Request Description**
The cache edge functions (`get-cached-data`, `invalidate-cache`) returned `Access-Control-Allow-Origin` errors from the Netlify domain because their CORS allowlist was stale and diverged from `symptom-analyzer`.

Both functions now share the same `ALLOWED_ORIGINS` list (including `https://symptom-scribe-clean.netlify.app`), the `NETLIFY_PREVIEW_ORIGIN` regex, and the `isAllowedOrigin()` helper. `invalidate-cache` keeps `x-webhook-secret` in `Access-Control-Allow-Headers` so webhook calls still authenticate.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #997

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Verified the shared origin helper accepts the production Netlify origin and rejects unknown origins; confirmed `x-webhook-secret` remains in allowed headers.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| N/A (no UI change) | N/A (no UI change) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
