### PR TITLE
fix: enforce MFA/AAL2 in ProtectedRoute (#1001)

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -12,24 +12,46 @@ interface ProtectedRouteProps {
 const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
+  const [mfaPending, setMfaPending] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
 
   useEffect(() => {
     let isMounted = true;
 
+    const applyAssuranceLevel = async (nextSession: Session | null) => {
+      if (!nextSession) {
+        if (!isMounted) return;
+        setSession(null);
+        setMfaPending(false);
+        setLoading(false);
+        return;
+      }
+
+      // Enforce AAL2 whenever the account has a verified MFA factor. A session
+      // restored from a refresh token or a new tab is only AAL1 — without this
+      // check a 2FA user could reach protected pages without a second factor.
+      const { data: aalData } =
+        (await supabase.auth.mfa?.getAuthenticatorAssuranceLevel()) ?? { data: null };
+      const pendingMfa =
+        aalData?.nextLevel === "aal2" && aalData.currentLevel !== aalData.nextLevel;
+
+      if (!isMounted) return;
+      setSession(nextSession);
+      setMfaPending(pendingMfa);
+      setLoading(false);
+    };
+
     const initializeSession = async () => {
       const { data, error } = await supabase.auth.getSession();
 
-      if (!isMounted) return;
-
       if (error) {
+        if (!isMounted) return;
         setAuthError(error.message);
         setLoading(false);
         return;
       }
 
-      setSession(data.session);
-      setLoading(false);
+      await applyAssuranceLevel(data.session);
     };
 
     initializeSession();
@@ -38,10 +60,8 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, nextSession) => {
       if (!isMounted) return;
-
-      setSession(nextSession);
       setAuthError(null);
-      setLoading(false);
+      applyAssuranceLevel(nextSession);
     });
 
     return () => {
@@ -72,6 +92,10 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
 
   if (!session) {
     return <Navigate to="/auth" replace />;
+  }
+
+  if (mfaPending) {
+    return <Navigate to="/auth?mfa=1" replace />;
   }
 
   return <>{children}</>;

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -91,6 +91,39 @@ const Auth = () => {
     setShowPassword(false);
   }, [authTab]);
 
+  // Resume an interrupted MFA challenge after a reload/new tab. When
+  // ProtectedRoute detects an AAL1 session that requires AAL2 it redirects
+  // here with ?mfa=1; this effect surfaces the second-factor OTP UI instead
+  // of leaving the user stuck at the sign-in form with an existing session.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("mfa") !== "1") return;
+
+    const resumeMfaChallenge = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) return;
+
+      const { data: aalData } =
+        (await supabase.auth.mfa?.getAuthenticatorAssuranceLevel()) ?? { data: null };
+      if (
+        !aalData ||
+        aalData.nextLevel !== "aal2" ||
+        aalData.currentLevel === aalData.nextLevel
+      ) {
+        return;
+      }
+
+      const { data: factorsData } = await supabase.auth.mfa.listFactors();
+      const totpFactor = factorsData?.totp?.[0];
+      if (totpFactor) {
+        setMfaFactorId(totpFactor.id);
+        setMfaRequired(true);
+      }
+    };
+
+    resumeMfaChallenge();
+  }, []);
+
 
   const validateSignIn = () => {
     try {


### PR DESCRIPTION
## **Pull Request Description**
Protected routes only checked for an authenticated session, so users with MFA enabled but an unverified second factor were not forced to complete AAL2 verification.

`ProtectedRoute` now queries `supabase.auth.mfa.getAuthenticatorAssuranceLevel()` after session fetch and on auth state changes; when `nextLevel === "aal2"` and the user isn't there yet, it redirects to `/auth?mfa=1`. The Auth page reads that flag, verifies the pending level + first TOTP factor, and prompts for the MFA code.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #1001

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Enabled MFA, visited a protected route with an unverified factor, and confirmed redirect to the MFA prompt at `/auth?mfa=1`.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| N/A (no UI change) | N/A (no UI change) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
