### PR TITLE
fix: compute challenge check-in day from the user's local timezone (#1004)

### DIFF
--- a/src/hooks/useGamification.ts
+++ b/src/hooks/useGamification.ts
@@ -5,6 +5,20 @@ import { useEffect, useState } from "react";
 import type { User } from "@supabase/supabase-js";
 import { toast } from "sonner";
 
+// Local-calendar helpers used by the challenge check-in logic. These convert
+// to/from the user's LOCAL date so that "today" matches the user's calendar
+// day rather than the UTC day.
+function toLocalDateStr(d: Date): string {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function localMidnightToISO(d: Date): string {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).toISOString();
+}
+
 // ─── Lightweight current-user helper (no custom useAuth hook needed) ─────────
 // Mirrors the pattern already used in Auth.tsx (supabase.auth.* calls directly)
 
@@ -139,8 +153,13 @@ export function useCheckInChallenge() {
       if (fetchErr) throw fetchErr;
 
       const now = new Date();
-      const todayDateStr = now.toISOString().split("T")[0]; 
-      const todayStartISO = `${todayDateStr}T00:00:00.000Z`;
+      // Use the user's LOCAL calendar day, not UTC. For a UTC+5:30 user the
+      // local day starts at 18:30 UTC the previous day — computing the
+      // boundary from `toISOString()` would treat the first ~5.5 local hours
+      // as "yesterday" and wrongly block the new day's check-in (and streak
+      // day-count would be timezone-shifted for everyone).
+      const todayDateStr = toLocalDateStr(now);
+      const todayStartISO = localMidnightToISO(now);
 
       const lastCheckIn = current.last_check_in ? new Date(current.last_check_in) : null;
       const alreadyCheckedInToday =
@@ -150,7 +169,7 @@ export function useCheckInChallenge() {
         return { streak: current.current_streak, alreadyCheckedInToday: true };
       }
 
-      const lastCheckInDateStr = lastCheckIn ? lastCheckIn.toISOString().split("T")[0] : null;
+      const lastCheckInDateStr = lastCheckIn ? toLocalDateStr(lastCheckIn) : null;
       const daysSinceLastCheckIn = lastCheckInDateStr
         ? Math.round(
             (Date.parse(`${todayDateStr}T00:00:00.000Z`) -


### PR DESCRIPTION
## **Pull Request Description**
The daily check-in challenge used UTC dates, so users near midnight could double-check-in or miss a day depending on their timezone.

`src/hooks/useGamification.ts` now computes the check-in day from the user's local timezone (`toLocalDateStr`/`localMidnightToISO` helpers) for `todayDateStr`, `todayStartISO`, `alreadyCheckedInToday`, `lastCheckInDateStr`, and streak day counting ? including the corrected boundary in the `.lt` filter.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #1004

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Set system timezone to one far from UTC and confirmed check-in day/streak advance on local midnight.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| N/A (no UI change) | N/A (no UI change) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
