### PR TITLE
fix: Delete All history targets the authenticated user instead of the first visible record (#1005)

### DIFF
--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -19,7 +19,7 @@ import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 import { useNavigate } from "react-router-dom";
 import { useToast } from "@/hooks/use-toast";
-import { showSuccess, showError } from "@/lib/toast-helpers";
+import { showSuccess, showError, showInfo } from "@/lib/toast-helpers";
 import { db, syncOfflineData, encryptSymptom, decryptSymptom } from "@/lib/offline-db";
 import { whenKeysReady, generateSearchTokens } from "@/lib/encryption";
 import { getCachedData, invalidateCache } from "@/lib/cached-queries";
@@ -324,12 +324,32 @@ const History = () => {
   const deleteAllEntries = async () => {
     try {
       if (navigator.onLine) {
-        const { error } = await supabase
+        // Use the authenticated user's id rather than the first visible
+        // record. `history[0]?.user_id` is "" when the filtered/search list
+        // is empty, which made the server delete match zero rows while the
+        // local cache was still wiped and a success toast shown — the records
+        // reappeared on the next fetch.
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+          showError("Authentication Error", "You must be signed in to delete your history.");
+          return;
+        }
+
+        const { data: deletedRows, error } = await supabase
           .from("symptom_history")
           .delete()
-          .eq("user_id", history[0]?.user_id || "");
+          .eq("user_id", user.id)
+          .select("id");
 
         if (error) throw error;
+
+        if (!deletedRows || deletedRows.length === 0) {
+          showInfo("Nothing to delete", "No symptom history found to delete.");
+          return;
+        }
+
         await invalidateCache("symptom_history");
         await db.symptomHistory.clear();
       } else {


### PR DESCRIPTION
## **Pull Request Description**
Delete All History could target the wrong rows because it didn't scope the delete to the authenticated user.

`src/pages/History/index.tsx` now fetches the authenticated user via `supabase.auth.getUser()` and deletes `.eq("user_id", user.id)`. If no rows match it shows an info toast and returns without wiping the local Dexie cache, so the user's own data is never lost.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #1005

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Clicked Delete All with records and without; confirmed only the authenticated user's rows are removed.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| N/A (no UI change) | N/A (no UI change) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
