### PR TITLE
fix(games): improve Brain Games responsiveness for mobile and tablet

### DIFF
--- a/src/pages/Games/BrainGames.tsx
+++ b/src/pages/Games/BrainGames.tsx
@@ -325,7 +325,7 @@ const SimonSaysGame = ({ onExit, onXp, onCelebrate }: MiniGameProps) => {
         <p aria-live="polite" className="text-center text-muted-foreground min-h-[1.5rem]">
           {message}
         </p>
-        <div className="grid grid-cols-2 gap-4 w-full max-w-xs">
+        <div className="grid grid-cols-2 gap-4 w-full max-w-sm">
           {SIMON_PADS.map((pad, i) => (
             <button
               key={pad.name}
@@ -579,7 +579,7 @@ const MentalMathGame = ({ onExit, onXp, onCelebrate }: MiniGameProps) => {
             >
               {problem.text}
             </div>
-            <div className="grid grid-cols-2 gap-3 w-full max-w-xs">
+            <div className="grid grid-cols-2 gap-3 w-full max-w-sm">
               {options.map((opt) => (
                 <Button
                   key={opt}
@@ -802,7 +802,7 @@ const ColorSequenceGame = ({ onExit, onXp, onCelebrate }: MiniGameProps) => {
         <p aria-live="polite" className="text-center text-muted-foreground min-h-[1.5rem]">
           {message}
         </p>
-        <div className="grid grid-cols-3 gap-3 sm:gap-4 w-full max-w-sm">
+        <div className="grid grid-cols-3 gap-3 sm:gap-4 w-full max-w-sm sm:max-w-md">
           {COLOR_TILES.map((tile, i) => (
             <button
               key={tile.name}
@@ -1897,7 +1897,7 @@ const BrainGames = () => {
         )}
 
         <div
-          className="grid grid-cols-4 gap-2 sm:gap-3 max-w-sm mx-auto"
+          className="grid grid-cols-4 gap-2 sm:gap-3 md:gap-4 w-full max-w-sm sm:max-w-md mx-auto"
           onTouchStart={handle2048TouchStart}
           onTouchEnd={handle2048TouchEnd}
           role="group"
@@ -2639,7 +2639,7 @@ const BrainGames = () => {
                     </div>
                   </CardHeader>
                   <CardContent className="p-4 sm:p-8 md:p-12">
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-6 max-w-4xl mx-auto">
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-5 lg:gap-6 w-full max-w-3xl lg:max-w-4xl mx-auto">
                       {memoryCards.map((card, index) => {
                         const isFlipped = flippedCards.includes(index) || matchedCards.includes(index);
                         return (


### PR DESCRIPTION
## **Pull Request Description**
Improves Brain Games responsiveness on mobile/tablet by removing fixed max-width bottlenecks and making grids/gaps scale with the viewport.

- **Simon Says**: pad grid `max-w-xs` ? `max-w-sm`
- **Mental Math**: answer grid `max-w-xs` ? `max-w-sm`
- **Color Sequence**: tile grid `max-w-sm sm:max-w-md`
- **2048**: board `w-full` + `max-w-sm sm:max-w-md` + responsive gaps
- **Memory Game**: responsive `gap-3 sm:gap-5 lg:gap-6`, `w-full max-w-3xl lg:max-w-4xl`

All grids use `aspect-square` cells so tiles scale proportionally; no gameplay logic changed.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #941

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Resized the page across mobile/tablet/desktop widths and confirmed each game board scales without overflow.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| N/A (no screenshots captured) | N/A (no screenshots captured) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
