### PR TITLE
test(#942): extend score-calculator coverage with edge cases

### DIFF
--- a/src/lib/score-calculator.test.ts
+++ b/src/lib/score-calculator.test.ts
@@ -139,6 +139,27 @@ describe("calculateWeeklyHealthScore", () => {
 
       expect(result.streakDays).toBe(1);
     });
+
+    it("continues counting consecutive days beyond the seven-day window", () => {
+      const symptoms = Array.from({ length: 10 }, (_, i) =>
+        makeSymptom({ id: `symptom-${i}`, created_at: daysAgo(i) })
+      );
+
+      const result = calculateWeeklyHealthScore(symptoms);
+
+      // The streak is unbounded, while the consistency window is capped at 7 days.
+      expect(result.streakDays).toBe(10);
+      expect(result.loggingDaysLastWeek).toBe(7);
+    });
+
+    it("does not count days logged only by pending-delete metrics", () => {
+      const result = calculateWeeklyHealthScore(
+        [],
+        [makeMetric({ recorded_at: daysAgo(0), pending_delete: 1 })]
+      );
+
+      expect(result.streakDays).toBe(0);
+    });
   });
 
   describe("logging consistency", () => {
@@ -165,6 +186,20 @@ describe("calculateWeeklyHealthScore", () => {
       expect(result.loggingDaysLastWeek).toBe(4);
       // (4 / 7) * 40 = 22.857… → 23
       expect(pointsFor(result, "consistency")).toBe(23);
+    });
+
+    it.each([
+      { days: 1, expected: 6 }, // (1 / 7) * 40 = 5.71… → 6
+      { days: 3, expected: 17 }, // (3 / 7) * 40 = 17.14… → 17
+      { days: 6, expected: 34 }, // (6 / 7) * 40 = 34.28… → 34
+    ])("rounds $days logged days to $expected consistency points", ({ days, expected }) => {
+      const symptoms = Array.from({ length: days }, (_, i) =>
+        makeSymptom({ id: `symptom-${i}`, created_at: daysAgo(i) })
+      );
+
+      const result = calculateWeeklyHealthScore(symptoms);
+
+      expect(pointsFor(result, "consistency")).toBe(expected);
     });
 
     it("marks the category complete only from five logged days", () => {
@@ -232,6 +267,36 @@ describe("calculateWeeklyHealthScore", () => {
       expect(pointsFor(result, "symptom_resolution")).toBe(0);
       expect(result.breakdown[1].completed).toBe(false);
     });
+
+    it("rounds the resolved ratio and flips the completion flag at 20 points", () => {
+      const oneOfThree = calculateWeeklyHealthScore([
+        makeSymptom({ id: "a", resolved: true }),
+        makeSymptom({ id: "b", resolved: false }),
+        makeSymptom({ id: "c", resolved: false }),
+      ]);
+      const twoOfThree = calculateWeeklyHealthScore([
+        makeSymptom({ id: "a", resolved: true }),
+        makeSymptom({ id: "b", resolved: true }),
+        makeSymptom({ id: "c", resolved: false }),
+      ]);
+
+      // (1 / 3) * 30 = 10 → not complete
+      expect(pointsFor(oneOfThree, "symptom_resolution")).toBe(10);
+      expect(oneOfThree.breakdown[1].completed).toBe(false);
+      // (2 / 3) * 30 = 20 → exactly at the completion threshold
+      expect(pointsFor(twoOfThree, "symptom_resolution")).toBe(20);
+      expect(twoOfThree.breakdown[1].completed).toBe(true);
+    });
+
+    it("still applies the resolved ratio to entries older than the week window", () => {
+      const result = calculateWeeklyHealthScore([
+        makeSymptom({ created_at: daysAgo(10), resolved: false }),
+      ]);
+
+      // Symptom scoring is not windowed: the old unresolved entry still drops the
+      // score from the 30-point no-symptom baseline down to 0.
+      expect(pointsFor(result, "symptom_resolution")).toBe(0);
+    });
   });
 
   describe("biometric stability", () => {
@@ -274,6 +339,44 @@ describe("calculateWeeklyHealthScore", () => {
       }
     );
 
+    it.each([
+      // heart rate: optimal when 60–100 inclusive
+      { metric_type: "heart_rate", value: { value: 60 }, optimal: true },
+      { metric_type: "heart_rate", value: { value: 100 }, optimal: true },
+      { metric_type: "heart_rate", value: { value: 59 }, optimal: false },
+      { metric_type: "heart_rate", value: { value: 101 }, optimal: false },
+      // temperature: optimal when 97–99.5 inclusive
+      { metric_type: "temperature", value: { value: 97 }, optimal: true },
+      { metric_type: "temperature", value: { value: 99.5 }, optimal: true },
+      { metric_type: "temperature", value: { value: 96.9 }, optimal: false },
+      { metric_type: "temperature", value: { value: 99.6 }, optimal: false },
+      // oxygen saturation: optimal when >= 95
+      { metric_type: "oxygen_saturation", value: { value: 95 }, optimal: true },
+      { metric_type: "oxygen_saturation", value: { value: 94 }, optimal: false },
+      // blood sugar: optimal when 70–140 inclusive
+      { metric_type: "blood_sugar", value: { value: 70 }, optimal: true },
+      { metric_type: "blood_sugar", value: { value: 140 }, optimal: true },
+      { metric_type: "blood_sugar", value: { value: 69 }, optimal: false },
+      { metric_type: "blood_sugar", value: { value: 141 }, optimal: false },
+      // blood pressure: optimal only when both components are below threshold
+      { metric_type: "blood_pressure", value: { systolic: 129, diastolic: 84 }, optimal: true },
+      { metric_type: "blood_pressure", value: { systolic: 130, diastolic: 84 }, optimal: false },
+      { metric_type: "blood_pressure", value: { systolic: 129, diastolic: 85 }, optimal: false },
+      // sleep: optimal when >= 6
+      { metric_type: "sleep", value: { value: 6 }, optimal: true },
+      { metric_type: "sleep", value: { value: 5.9 }, optimal: false },
+      // steps: optimal when >= 5000
+      { metric_type: "steps", value: { value: 5000 }, optimal: true },
+      { metric_type: "steps", value: { value: 4999 }, optimal: false },
+    ])(
+      "treats a $metric_type reading at the exact threshold boundary as $optimal",
+      ({ metric_type, value, optimal }) => {
+        const result = calculateWeeklyHealthScore([], [makeMetric({ metric_type, value })]);
+
+        expect(pointsFor(result, "biometric_stability")).toBe(optimal ? 30 : 0);
+      }
+    );
+
     it("treats an unrecognised metric type as optimal", () => {
       const result = calculateWeeklyHealthScore(
         [],
@@ -294,6 +397,18 @@ describe("calculateWeeklyHealthScore", () => {
       expect(result.breakdown[2].description).toBe("1 of 2 vital readings in optimal range");
     });
 
+    it("treats a zero value as sub-optimal without crashing", () => {
+      const result = calculateWeeklyHealthScore([], [makeMetric({ value: { value: 0 } })]);
+
+      expect(pointsFor(result, "biometric_stability")).toBe(0);
+    });
+
+    it("treats a metric with an empty value object as sub-optimal without crashing", () => {
+      const result = calculateWeeklyHealthScore([], [makeMetric({ value: {} })]);
+
+      expect(pointsFor(result, "biometric_stability")).toBe(0);
+    });
+
     it("requires both blood pressure components to be present", () => {
       const result = calculateWeeklyHealthScore(
         [],
@@ -301,6 +416,31 @@ describe("calculateWeeklyHealthScore", () => {
       );
 
       expect(pointsFor(result, "biometric_stability")).toBe(0);
+    });
+
+    it("excludes pending-delete metrics from the optimal ratio", () => {
+      const result = calculateWeeklyHealthScore(
+        [],
+        [
+          makeMetric({ id: "a", value: { value: 72 } }),
+          makeMetric({ id: "b", value: { value: 45 } }),
+          makeMetric({ id: "c", value: { value: 55 }, pending_delete: 1 }),
+        ]
+      );
+
+      // Only the two valid readings count: 1 of 2 in range → 15 points.
+      expect(pointsFor(result, "biometric_stability")).toBe(15);
+      expect(result.breakdown[2].description).toBe("1 of 2 vital readings in optimal range");
+    });
+
+    it("still scores entries older than the week window", () => {
+      const result = calculateWeeklyHealthScore(
+        [],
+        [makeMetric({ recorded_at: daysAgo(10), value: { value: 72 } })]
+      );
+
+      // Biometric scoring is not windowed: a 10-day-old optimal reading still scores.
+      expect(pointsFor(result, "biometric_stability")).toBe(30);
     });
 
     it("scales with the ratio of optimal readings", () => {


### PR DESCRIPTION
## **Pull Request Description**
A clear and concise description of the changes introduced by this pull request.

Extends the `calculateWeeklyHealthScore` test suite (`src/lib/score-calculator.test.ts`) with edge-case coverage: streak boundaries beyond the 7-day window, consistency-point rounding, symptom-completion threshold, exact biometric threshold boundaries for all metric types, mixed pending-delete ratios, zero/empty metric values, and TTL (date-window) behavior. A base suite already covered the primary branches (empty input, resolved/unresolved symptoms, per-metric optimal thresholds, clamping); this PR locks down the boundary and edge cases. 32 new assertions/tests, 71 total passing.
 
---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [x] **Other** (please specify): testing, security

---

### **2. Related Issue**
- Fixes #908 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`). — *note: not run; change is test-file-only*
- [x] **Lint/Format Checks**: Local checks passed (`npx prettier --check src/lib/score-calculator.test.ts` / `npx eslint src/lib/score-calculator.test.ts`)
- [x] **Automated Tests**: `npx vitest run src/lib/score-calculator.test.ts` → 71 tests passed (1 file)
 

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
