### PR TITLE
fix(999): re-encrypt existing records after password change/reset

### DIFF
--- a/src/lib/encryption.test.ts
+++ b/src/lib/encryption.test.ts
@@ -7,6 +7,8 @@ import {
   encryptText,
   decryptText,
   deriveKeyFromToken,
+  deriveSearchKeyFromToken,
+  rotateKeysToNewPassword,
 } from "./encryption";
 
 describe("Encryption Key Persistence", () => {
@@ -35,5 +37,32 @@ describe("Encryption Key Persistence", () => {
     expect(keys.searchKey).toBe(key);
     expect(getKey()).toBe(key);
     expect(getSearchKey()).toBe(key);
+  });
+
+  it("re-derives keys from a new password and reports a successful rotation", async () => {
+    const oldKey = await deriveKeyFromToken("old-seed", "user-123");
+    const oldSearchKey = await deriveSearchKeyFromToken("old-seed", "user-123");
+    setKeys(oldKey, oldSearchKey);
+
+    const rotated = await rotateKeysToNewPassword("new-password", "user@example.com", "user-123");
+
+    expect(rotated).toBe(true);
+    expect(getKey()).not.toBe(oldKey);
+    expect(getKey()).not.toBeNull();
+    expect(getSearchKey()).not.toBe(oldSearchKey);
+    // The new seed must be persisted so keys can be re-derived after a reload.
+    expect(localStorage.getItem("symptom_scribe_master_seed_user-123")).toBeTruthy();
+  });
+
+  it("activates new keys but reports no rotation when no old key was active", async () => {
+    setKeys(null, null);
+
+    const rotated = await rotateKeysToNewPassword("new-password", "user@example.com", "user-123");
+
+    expect(rotated).toBe(false);
+    // The new seed/keys are still set up so the session can encrypt new data.
+    expect(getKey()).not.toBeNull();
+    expect(getSearchKey()).not.toBeNull();
+    expect(localStorage.getItem("symptom_scribe_master_seed_user-123")).toBeTruthy();
   });
 });

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -373,6 +373,56 @@ export async function triggerKeyRotation(
   }
 }
 
+/**
+ * Re-derives the user's encryption keys from a *new* password and re-encrypts
+ * all existing data (local IndexedDB + server-side Supabase rows) under the
+ * new key.
+ *
+ * Must be called after `supabase.auth.updateUser({ password })` succeeds
+ * (Settings "Change Password" and ResetPassword). Without it, records that
+ * were encrypted under the old password-derived seed become undecryptable the
+ * moment the new key is activated (issue #999).
+ *
+ * If no old key is available on this device (e.g. a forgotten-password reset
+ * opened on a fresh browser where the old seed was never persisted), rotation
+ * is skipped: the old key is unrecoverable by design, and decrypting old
+ * ciphertext with the fallback key would corrupt it.
+ *
+ * @returns `true` when existing data was re-encrypted under the new key, and
+ *          `false` when no old key was available so old records cannot be
+ *          recovered (callers should inform the user in that case).
+ */
+export async function rotateKeysToNewPassword(
+  newPassword: string,
+  email: string,
+  userId: string
+): Promise<boolean> {
+  const oldKey = getKey();
+  const oldSearchKey = getSearchKey();
+
+  // Persist the new seed and activate the new keys before rotating data.
+  await setupKeysFromPassword(newPassword, email, userId);
+
+  if (!oldKey || !oldSearchKey) {
+    console.warn(
+      "No active encryption key before password change — existing encrypted " +
+        "records on this device cannot be re-encrypted."
+    );
+    return false;
+  }
+
+  const newKey = getKey();
+  const newSearchKey = getSearchKey();
+
+  if (!newKey || !newSearchKey) {
+    console.warn("New encryption keys could not be derived; existing records were not rotated.");
+    return false;
+  }
+
+  await triggerKeyRotation(oldKey, newKey, oldSearchKey, newSearchKey);
+  return true;
+}
+
 async function handleSessionChange(session: Session) {
   const userId = session.user?.id;
   if (!userId) return;

--- a/src/lib/offline-db.ts
+++ b/src/lib/offline-db.ts
@@ -1,6 +1,6 @@
 import Dexie, { type Table } from "dexie";
 import { supabase } from "@/integrations/supabase/client";
-import { type Json } from "@/integrations/supabase/types";
+import { type Json, type TablesInsert, type TablesUpdate } from "@/integrations/supabase/types";
 import {
   encryptText,
   decryptText,
@@ -178,6 +178,121 @@ export async function decryptMetric(record: OfflineMetric, key: CryptoKey): Prom
   return decrypted;
 }
 
+/**
+ * Re-encrypts the user's server-side rows after a key rotation so that data
+ * stored in Supabase (which only ever contains ciphertext) stays decryptable
+ * under the new key (issue #999).
+ *
+ * Each row is decrypted with the old key and re-encrypted with the new key;
+ * rows that cannot be decrypted (e.g. created under a key this device never
+ * had) are skipped and logged instead of aborting the whole rotation. After
+ * the pass, the Redis-backed read caches for both tables are invalidated so
+ * callers do not keep serving old-key ciphertext.
+ */
+async function reEncryptServerData(
+  oldKey: CryptoKey,
+  newKey: CryptoKey,
+  newSearchKey: CryptoKey
+): Promise<void> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return;
+
+  let reEncrypted = 0;
+  let skipped = 0;
+  let total = 0;
+
+  // 1. Re-encrypt health_metrics rows.
+  const { data: metricRows, error: metricError } = await supabase
+    .from("health_metrics")
+    .select("*")
+    .eq("user_id", user.id);
+
+  if (metricError) {
+    console.error("Failed to fetch server health_metrics for re-encryption:", metricError);
+  } else {
+    for (const row of metricRows ?? []) {
+      total++;
+      try {
+        const decrypted = await decryptMetric(row as unknown as OfflineMetric, oldKey);
+        const encrypted = await encryptMetric(decrypted, newKey, newSearchKey);
+        // `search_tokens` exists in the DB (migration 20260616143000) but is
+        // missing from the generated types; cast keeps the column writeable.
+        const payload = {
+          value: encrypted.value,
+          notes: encrypted.notes,
+          search_tokens: encrypted.search_tokens ?? null,
+        } as unknown as TablesUpdate<"health_metrics">;
+        const { error } = await supabase
+          .from("health_metrics")
+          .update(payload)
+          .eq("id", row.id);
+        if (error) {
+          skipped++;
+          console.warn(`Failed to re-encrypt health_metrics row ${row.id}:`, error.message);
+        } else {
+          reEncrypted++;
+        }
+      } catch (err) {
+        skipped++;
+        console.warn(`Skipping health_metrics row ${row.id} (cannot decrypt with old key):`, err);
+      }
+    }
+  }
+
+  // 2. Re-encrypt symptom_history rows.
+  const { data: symptomRows, error: symptomError } = await supabase
+    .from("symptom_history")
+    .select("*")
+    .eq("user_id", user.id);
+
+  if (symptomError) {
+    console.error("Failed to fetch server symptom_history for re-encryption:", symptomError);
+  } else {
+    for (const row of symptomRows ?? []) {
+      total++;
+      try {
+        const decrypted = await decryptSymptom(row as unknown as OfflineSymptom, oldKey);
+        const encrypted = await encryptSymptom(decrypted, newKey, newSearchKey);
+        const payload = {
+          symptoms: encrypted.symptoms,
+          ai_analysis: encrypted.ai_analysis,
+          possible_causes: encrypted.possible_causes,
+          recommendations: encrypted.recommendations,
+          search_tokens: encrypted.search_tokens ?? null,
+        } as unknown as TablesUpdate<"symptom_history">;
+        const { error } = await supabase
+          .from("symptom_history")
+          .update(payload)
+          .eq("id", row.id);
+        if (error) {
+          skipped++;
+          console.warn(`Failed to re-encrypt symptom_history row ${row.id}:`, error.message);
+        } else {
+          reEncrypted++;
+        }
+      } catch (err) {
+        skipped++;
+        console.warn(`Skipping symptom_history row ${row.id} (cannot decrypt with old key):`, err);
+      }
+    }
+  }
+
+  if (skipped > 0) {
+    console.warn(
+      `Server-side re-encryption finished: ${reEncrypted} re-encrypted, ${skipped} skipped of ${total} rows.`
+    );
+  }
+
+  // Cached copies of these tables still hold old-key ciphertext; drop them so
+  // callers re-fetch the re-encrypted rows.
+  await Promise.all([
+    invalidateCache("health_metrics").catch(() => {}),
+    invalidateCache("symptom_history").catch(() => {}),
+  ]);
+}
+
 // Register Encryption Hooks for Auth Lifecycles
 registerEncryptionHooks({
   onLogout: async () => {
@@ -211,6 +326,14 @@ registerEncryptionHooks({
       } catch (clearErr) {
         console.error("Failed to clear database after migration failure:", clearErr);
       }
+    }
+
+    // Also re-encrypt server-side rows so the Supabase copies stay decryptable
+    // under the new key (issue #999). Failures here must not clear local data.
+    try {
+      await reEncryptServerData(oldKey, newKey, newSearchKey);
+    } catch (err) {
+      console.error("Failed to re-encrypt server-side data after key rotation:", err);
     }
   },
 });
@@ -253,7 +376,7 @@ export const syncOfflineData = async (): Promise<boolean> => {
       const { pending_sync, pending_delete, ...supabaseData } = record;
       const { error } = await supabase
         .from("health_metrics")
-        .insert(supabaseData);
+        .insert(supabaseData as unknown as TablesInsert<"health_metrics">);
 
       if (!error) {
         await db.healthMetrics.update(record.id, { pending_sync: 0 });
@@ -289,7 +412,7 @@ export const syncOfflineData = async (): Promise<boolean> => {
       const { pending_sync, pending_delete, pending_update, ...supabaseData } = record;
       const { error } = await supabase
         .from("symptom_history")
-        .insert(supabaseData);
+        .insert(supabaseData as unknown as TablesInsert<"symptom_history">);
 
       if (!error) {
         await db.symptomHistory.update(record.id, { pending_sync: 0 });

--- a/src/pages/User/ResetPassword.tsx
+++ b/src/pages/User/ResetPassword.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
-import { showSuccess, showError } from "@/lib/toast-helpers";
+import { showSuccess, showError, showWarning } from "@/lib/toast-helpers";
 import { PasswordStrengthMeter } from "@/components/registration/shared/PasswordStrengthMeter";
 import { DEFAULT_PASSWORD_POLICY, evaluatePasswordStrength } from "@/lib/password-strength";
+import { rotateKeysToNewPassword } from "@/lib/encryption";
 
 const ResetPassword = () => {
   const [password, setPassword] = useState("");
@@ -29,14 +30,35 @@ const ResetPassword = () => {
       password,
     });
 
-    setLoading(false);
-
     if (error) {
+      setLoading(false);
       showError("Update Failed", error.message);
       return;
     }
 
+    // Re-derive the encryption keys from the new password and re-encrypt all
+    // existing records (local + server-side) so they stay decryptable (#999).
+    let keysRotated = false;
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (user?.email) {
+        keysRotated = await rotateKeysToNewPassword(password, user.email, user.id);
+      }
+    } catch (rotateErr) {
+      console.error("Failed to rotate encryption keys after password reset:", rotateErr);
+    }
+
+    setLoading(false);
+
     showSuccess("Password Updated!", "You can now sign in with your new password.");
+    if (!keysRotated) {
+      showWarning(
+        "Existing Records Not Re-encrypted",
+        "This device did not have your previous encryption key, so records saved before this reset cannot be decrypted."
+      );
+    }
     navigate("/auth");
   };
 

--- a/src/pages/User/Settings.tsx
+++ b/src/pages/User/Settings.tsx
@@ -16,12 +16,7 @@ import { PasswordStrengthMeter } from "@/components/registration/shared/Password
 import { DEFAULT_PASSWORD_POLICY, evaluatePasswordStrength } from "@/lib/password-strength";
 import { showSuccess, showError } from "@/lib/toast-helpers";
 import { clearSafeStorage } from "@/lib/storage";
-import {
-  getKey,
-  getSearchKey,
-  setupKeysFromPassword,
-  triggerKeyRotation,
-} from "@/lib/encryption";
+import { rotateKeysToNewPassword } from "@/lib/encryption";
 import TwoFactorAuth from "@/components/settings/TwoFactorAuth";
 
 const Settings = () => {
@@ -112,18 +107,8 @@ const Settings = () => {
         try {
           const userRes = await supabase.auth.getUser();
           const user = userRes.data.user;
-          if (user && user.email) {
-            const oldKey = getKey();
-            const oldSearchKey = getSearchKey();
-
-            await setupKeysFromPassword(newPassword, user.email, user.id);
-
-            const newKey = getKey();
-            const newSearchKey = getSearchKey();
-
-            if (oldKey && newKey && oldSearchKey && newSearchKey) {
-              await triggerKeyRotation(oldKey, newKey, oldSearchKey, newSearchKey);
-            }
+          if (user?.email) {
+            await rotateKeysToNewPassword(newPassword, user.email, user.id);
           }
         } catch (rotateErr) {
           console.error("Failed to rotate keys after password update:", rotateErr);


### PR DESCRIPTION
## **Pull Request Description**
Fixes a bug where changing or resetting the password never re-encrypted data already stored on the server, leaving existing records permanently undecryptable.
 
The encryption key is derived from a password-based seed (PBKDF2). On password change/reset, the new seed produces a new key, but the encrypted rows in `health_metrics` / `symptom_history` were still written under the old key. Previously:
- **Settings → Change Password** re-encrypted only the local IndexedDB copy; Supabase rows kept the old key's ciphertext.
- **Reset Password** never updated the seed or rotated keys at all, so after signing in with the new password the old seed was gone and all prior records became unrecoverable.
 
This PR makes both flows re-derive keys from the new password and re-encrypt **local and server-side** records, and it invalidates the read caches so stale ciphertext is not served.
---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [x] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #999 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
