### PR TITLE
style: add modern gradient text boost to login hero headline

### DIFF
--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -235,8 +235,12 @@ const handleForgotPassword= async () => {
 
           <div className="space-y-5">
             <h1 className="text-5xl font-bold leading-tight tracking-normal text-white">
-              {t("auth.headline")}
-            </h1>
+              <span className="bg-gradient-to-r from-teal-400 to-emerald-400 bg-clip-text text-transparent font-extrabold">
+                Care insights
+              </span>
+              {t("auth.headline").replace("Care insights", "")}
+          </h1>
+
             <p className="max-w-lg text-lg leading-8 text-slate-300">{t("auth.subheadline")}</p>
           </div>
 


### PR DESCRIPTION
## **Pull Request Description**
Enhanced the visual hierarchy of the Sign-In page by styling the primary phrase "Care insights" with a modern text gradient boost (`from-teal-400` to `to-emerald-400`). This matches contemporary SaaS aesthetics and immediate value recall.


---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [x] **Other** (please specify): _UI Enhancement________

---

### **2. Related Issue**
- Fixes #1047

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Ran `npm run setup` and `npm run dev` locally.
  2. Verified the login page hero text hierarchy looks correct in the browser.

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :---: | :---: |
| 
<img width="1907" height="1197" alt="image" src="https://github.com/user-attachments/assets/cc9aff9a-fbcb-4236-a611-a740b0ffa092" /> | <img width="1892" height="1186" alt="image" src="https://github.com/user-attachments/assets/8c21c439-5827-47f9-b975-7b4c3db022c8" /> |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
