### PR TITLE
feat(triage): implement stateful multi-turn AI health assistant triage flow (#1051)

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -35,6 +35,8 @@ import { compressImage, uploadSymptomImage } from "@/lib/image-utils";
 import ChatLoading from "./ChatLoading";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { type Json } from "@/integrations/supabase/types";
+import { type TriagePhase, type CollectedInfo } from "@/types/triage";
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -67,6 +69,9 @@ interface ChatSession {
   messages: Json;
   created_at: string | null;
   updated_at: string | null;
+  phase: TriagePhase;
+  collected_info: CollectedInfo;
+  questions_asked: number;
 }
 
 const ChatInterface = () => {
@@ -78,6 +83,11 @@ const ChatInterface = () => {
   const [sessionsLoading, setSessionsLoading] = useState(false);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+
+  const [phase, setPhase] = useState<TriagePhase>("gathering");
+  const [collectedInfo, setCollectedInfo] = useState<CollectedInfo>({});
+  const [questionsAsked, setQuestionsAsked] = useState<number>(0);
+  const [parseFailures, setParseFailures] = useState<number>(0);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -136,8 +146,16 @@ const ChatInterface = () => {
     const loadedMessages = (session.messages as unknown as Message[]) || [];
     if (loadedMessages.length === 0) {
       setMessages([INITIAL_GREETING]);
+      setPhase("gathering");
+      setCollectedInfo({});
+      setQuestionsAsked(0);
+      setParseFailures(0);
     } else {
       setMessages(loadedMessages);
+      setPhase((session.phase as TriagePhase) || "gathering");
+      setCollectedInfo((session.collected_info as CollectedInfo) || {});
+      setQuestionsAsked(session.questions_asked || 0);
+      setParseFailures(0);
     }
     setIsMobileOpen(false);
   };
@@ -165,6 +183,10 @@ const ChatInterface = () => {
   const handleNewChat = () => {
     setActiveSessionId(null);
     setMessages([INITIAL_GREETING]);
+    setPhase("gathering");
+    setCollectedInfo({});
+    setQuestionsAsked(0);
+    setParseFailures(0);
     setIsMobileOpen(false);
   };
 
@@ -215,6 +237,9 @@ const ChatInterface = () => {
             user_id: user.id,
             title,
             messages: newMessages as unknown as Json,
+            phase,
+            collected_info: collectedInfo as unknown as Json,
+            questions_asked: questionsAsked,
           })
           .select()
           .single();
@@ -228,6 +253,9 @@ const ChatInterface = () => {
           .from("chat_sessions")
           .update({
             messages: newMessages as unknown as Json,
+            phase,
+            collected_info: collectedInfo as unknown as Json,
+            questions_asked: questionsAsked,
             updated_at: new Date().toISOString(),
           })
           .eq("id", currentSessionId);
@@ -249,7 +277,13 @@ const ChatInterface = () => {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ messages: [...recentContext, userMessage] }),
+        body: JSON.stringify({
+          messages: [...recentContext, userMessage],
+          phase,
+          collectedInfo,
+          questionsAsked,
+          parseFailures,
+        }),
       });
 
       if (!response.ok || !response.body) {
@@ -260,6 +294,11 @@ const ChatInterface = () => {
       const decoder = new TextDecoder();
       let textBuffer = "";
       let streamDone = false;
+
+      let latestPhase = phase;
+      let latestCollectedInfo = collectedInfo;
+      let latestQuestionsAsked = questionsAsked;
+      let latestParseFailures = parseFailures;
 
       while (!streamDone) {
         const { done, value } = await reader.read();
@@ -285,6 +324,19 @@ const ChatInterface = () => {
             const parsed = JSON.parse(jsonStr);
             const content = parsed.choices?.[0]?.delta?.content as string | undefined;
             if (content) upsertAssistant(content);
+
+            if (parsed.triageState) {
+              const state = parsed.triageState;
+              latestPhase = state.phase;
+              latestCollectedInfo = state.collectedInfo;
+              latestQuestionsAsked = state.questionsAsked;
+              latestParseFailures = state.parseFailures || 0;
+
+              setPhase(latestPhase);
+              setCollectedInfo(latestCollectedInfo);
+              setQuestionsAsked(latestQuestionsAsked);
+              setParseFailures(latestParseFailures);
+            }
           } catch {
             textBuffer = line + "\n" + textBuffer;
             break;
@@ -305,6 +357,9 @@ const ChatInterface = () => {
           .from("chat_sessions")
           .update({
             messages: finalMessages as unknown as Json,
+            phase: latestPhase,
+            collected_info: latestCollectedInfo as unknown as Json,
+            questions_asked: latestQuestionsAsked,
             updated_at: new Date().toISOString(),
           })
           .eq("id", currentSessionId);
@@ -319,99 +374,104 @@ const ChatInterface = () => {
               ? {
                   ...s,
                   messages: finalMessages as unknown as Json,
+                  phase: latestPhase,
+                  collected_info: latestCollectedInfo as unknown as Json,
+                  questions_asked: latestQuestionsAsked,
                   updated_at: new Date().toISOString(),
                 }
               : s
           )
         );
 
-        const { possibleCauses, recommendations, severityLevel } =
-          parseSymptomConsultation(assistantContent);
+        if (latestPhase === "complete" || latestPhase === "ready") {
+          const { possibleCauses, recommendations, severityLevel } =
+            parseSymptomConsultation(assistantContent);
 
-        if (assistantContent.match(/severity(\s+level)?/i)) {
-          showInfo("Severity Assessment", `AI rates this as ${severityLevel} severity`);
-        }
-
-        const riskScore = computeRiskScore(
-          severityLevel,
-          possibleCauses.length,
-          recommendations.length
-        );
-
-        if (shouldPersistConsultation(assistantContent)) {
-          let uploadedImages: string[] | null = null;
-          if (selectedFiles.length > 0) {
-            try {
-              uploadedImages = [];
-              for (const file of selectedFiles) {
-                const compressed = await compressImage(file);
-                const url = await uploadSymptomImage(compressed, user.id);
-                uploadedImages.push(url);
-              }
-            } catch (err) {
-              console.error("Image upload failed:", err);
-              showWarning("Upload Failed", "Failed to upload attached images, saving without them.");
-              uploadedImages = null;
-            }
+          if (assistantContent.match(/severity(\s+level)?/i)) {
+            showInfo("Severity Assessment", `AI rates this as ${severityLevel} severity`);
           }
 
-          const recordId = crypto.randomUUID();
-          const record = {
-            id: recordId,
-            user_id: user.id,
-            symptoms: userMessage.content,
-            ai_analysis: assistantContent,
-            severity_level: severityLevel,
-            possible_causes: possibleCauses.length > 0 ? possibleCauses : null,
-            recommendations: recommendations.length > 0 ? recommendations : null,
-            risk_score: riskScore,
-            resolved: false,
-            created_at: new Date().toISOString(),
-            images: uploadedImages,
-          };
-
-          const keys = await whenKeysReady();
-          const encryptedRecord = await encryptSymptom(
-            record as unknown as OfflineSymptom,
-            keys.encryptionKey,
-            keys.searchKey
+          const riskScore = computeRiskScore(
+            severityLevel,
+            possibleCauses.length,
+            recommendations.length
           );
 
-          // Strip offline-only fields so we match the Supabase table schema
-          const { pending_sync, pending_update, pending_delete, ...supabaseRecord } =
-            encryptedRecord;
+          if (shouldPersistConsultation(assistantContent)) {
+            let uploadedImages: string[] | null = null;
+            if (selectedFiles.length > 0) {
+              try {
+                uploadedImages = [];
+                for (const file of selectedFiles) {
+                  const compressed = await compressImage(file);
+                  const url = await uploadSymptomImage(compressed, user.id);
+                  uploadedImages.push(url);
+                }
+              } catch (err) {
+                console.error("Image upload failed:", err);
+                showWarning("Upload Failed", "Failed to upload attached images, saving without them.");
+                uploadedImages = null;
+              }
+            }
 
-          const { error: insertError } = await supabase
-            .from("symptom_history")
-            .insert(supabaseRecord);
+            const recordId = crypto.randomUUID();
+            const record = {
+              id: recordId,
+              user_id: user.id,
+              symptoms: userMessage.content,
+              ai_analysis: assistantContent,
+              severity_level: severityLevel,
+              possible_causes: possibleCauses.length > 0 ? possibleCauses : null,
+              recommendations: recommendations.length > 0 ? recommendations : null,
+              risk_score: riskScore,
+              resolved: false,
+              created_at: new Date().toISOString(),
+              images: uploadedImages,
+            };
 
-          if (insertError) {
-            console.warn("Supabase save failed, falling back to local saving:", insertError);
-
-            // Save locally to Dexie immediately with pending_sync: 1
-            await db.symptomHistory.put({
-              ...encryptedRecord,
-              pending_sync: 1,
-              pending_update: 0,
-              pending_delete: 0,
-            });
-
-            showWarning(
-              "Saved Offline",
-              "Could not connect to server. Saved locally and will sync once connection is restored."
+            const keys = await whenKeysReady();
+            const encryptedRecord = await encryptSymptom(
+              record as unknown as OfflineSymptom,
+              keys.encryptionKey,
+              keys.searchKey
             );
-          } else {
-            await invalidateCache("symptom_history");
 
-            // Save locally to Dexie immediately
-            await db.symptomHistory.put({
-              ...encryptedRecord,
-              pending_sync: 0,
-              pending_update: 0,
-              pending_delete: 0,
-            });
+            // Strip offline-only fields so we match the Supabase table schema
+            const { pending_sync, pending_update, pending_delete, ...supabaseRecord } =
+              encryptedRecord;
 
-            showSuccess("Saved to history", "This analysis has been added to your health records");
+            const { error: insertError } = await supabase
+              .from("symptom_history")
+              .insert(supabaseRecord);
+
+            if (insertError) {
+              console.warn("Supabase save failed, falling back to local saving:", insertError);
+
+              // Save locally to Dexie immediately with pending_sync: 1
+              await db.symptomHistory.put({
+                ...encryptedRecord,
+                pending_sync: 1,
+                pending_update: 0,
+                pending_delete: 0,
+              });
+
+              showWarning(
+                "Saved Offline",
+                "Could not connect to server. Saved locally and will sync once connection is restored."
+              );
+            } else {
+              await invalidateCache("symptom_history");
+
+              // Save locally to Dexie immediately
+              await db.symptomHistory.put({
+                ...encryptedRecord,
+                pending_sync: 0,
+                pending_update: 0,
+                pending_delete: 0,
+              });
+
+              showSuccess("Saved to history", "This analysis has been added to your health records");
+            }
           }
         }
       }
@@ -650,9 +710,20 @@ const ChatInterface = () => {
             </div>
           )}
 
-          {messages.map((message, index) => (
-            <ChatMessage key={index} role={message.role} content={message.content} />
-          ))}
+          {messages.map((message, index) => {
+            const isLastMessage = index === messages.length - 1;
+            const showProgress = isLastMessage && message.role === "assistant" && phase === "gathering" && questionsAsked > 0;
+            const progressText = showProgress ? `Clarifying Question ${questionsAsked} of ~4` : undefined;
+
+            return (
+              <ChatMessage
+                key={index}
+                role={message.role}
+                content={message.content}
+                progressText={progressText}
+              />
+            );
+          })}
 
           {isLoading && messages[messages.length - 1]?.role !== "assistant" && <ChatLoading />}
           <div ref={messagesEndRef} />

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -4,9 +4,10 @@ import ReactMarkdown from "react-markdown";
 interface ChatMessageProps {
   role: "user" | "assistant";
   content: string;
+  progressText?: string;
 }
 
-const ChatMessage = ({ role, content }: ChatMessageProps) => {
+const ChatMessage = ({ role, content, progressText }: ChatMessageProps) => {
   const isUser = role === "user";
 
   return (
@@ -47,6 +48,11 @@ const ChatMessage = ({ role, content }: ChatMessageProps) => {
           >
             {content.replace(/•/g, "-")}
           </ReactMarkdown>
+          {progressText && (
+            <div className="text-[10px] text-muted-foreground mt-2 border-t border-border/40 pt-1.5 font-medium select-none">
+              {progressText}
+            </div>
+          )}
         </div>
       </div>
 
@@ -61,3 +67,4 @@ const ChatMessage = ({ role, content }: ChatMessageProps) => {
 };
 
 export default ChatMessage;
+

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -22,6 +22,9 @@ export type Database = {
           title: string | null
           updated_at: string | null
           user_id: string
+          phase: "gathering" | "ready" | "complete"
+          collected_info: Json
+          questions_asked: number
         }
         Insert: {
           created_at?: string | null
@@ -30,6 +33,9 @@ export type Database = {
           title?: string | null
           updated_at?: string | null
           user_id: string
+          phase?: "gathering" | "ready" | "complete"
+          collected_info?: Json
+          questions_asked?: number
         }
         Update: {
           created_at?: string | null
@@ -38,6 +44,9 @@ export type Database = {
           title?: string | null
           updated_at?: string | null
           user_id?: string
+          phase?: "gathering" | "ready" | "complete"
+          collected_info?: Json
+          questions_asked?: number
         }
         Relationships: []
       }

--- a/src/lib/mesh-network.ts
+++ b/src/lib/mesh-network.ts
@@ -36,7 +36,7 @@ class MeshNetworkManager {
   constructor() {
     // Generate a unique node ID for this tab session
     this.nodeId = crypto.randomUUID();
-    this.isOfflineSimulated = localStorage.getItem("symptom_scribe_offline_sim") === "true";
+    this.isOfflineSimulated = typeof localStorage !== "undefined" && localStorage.getItem("symptom_scribe_offline_sim") === "true";
 
     if (typeof window !== "undefined") {
       this.channel = new BroadcastChannel("symptom_scribe_mesh_channel");
@@ -77,7 +77,9 @@ class MeshNetworkManager {
 
   public setOfflineSimulation(simulated: boolean) {
     this.isOfflineSimulated = simulated;
-    localStorage.setItem("symptom_scribe_offline_sim", simulated ? "true" : "false");
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("symptom_scribe_offline_sim", simulated ? "true" : "false");
+    }
     this.notifyListeners();
 
     if (!simulated && navigator.onLine) {

--- a/src/lib/triageEngine.test.ts
+++ b/src/lib/triageEngine.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { evaluateTriageState, type TriageState } from "../../supabase/functions/symptom-analyzer/triageEngine";
+import { detectEmergencySymptoms } from "../../supabase/functions/symptom-analyzer/medicalSafety";
+
+describe("Triage Engine - State Transitions", () => {
+  it("normal 3-question flow (Scenario 1)", () => {
+    // 1. Initial State
+    let state: TriageState = {
+      phase: "gathering",
+      collectedInfo: {},
+      questionsAsked: 0,
+      parseFailures: 0,
+    };
+
+    // User responds, AI asks question 1
+    let responseText = "How long have you had this fever?";
+    let result = evaluateTriageState(state, responseText, false);
+    expect(result.nextPhase).toBe("gathering");
+    expect(result.nextQuestionsAsked).toBe(1);
+    expect(result.shouldRunAnalysis).toBe(false);
+
+    // Update state for next turn
+    state = {
+      phase: result.nextPhase,
+      collectedInfo: result.nextCollectedInfo,
+      questionsAsked: result.nextQuestionsAsked,
+      parseFailures: result.nextParseFailures,
+    };
+
+    // User responds, AI asks question 2
+    responseText = "Is the fever accompanied by chills or body aches?";
+    result = evaluateTriageState(state, responseText, false);
+    expect(result.nextPhase).toBe("gathering");
+    expect(result.nextQuestionsAsked).toBe(2);
+
+    state = {
+      phase: result.nextPhase,
+      collectedInfo: result.nextCollectedInfo,
+      questionsAsked: result.nextQuestionsAsked,
+      parseFailures: result.nextParseFailures,
+    };
+
+    // User responds, AI concludes triage and outputs READY_FOR_ANALYSIS
+    responseText = `Thank you. I am ready to generate the analysis now.
+    READY_FOR_ANALYSIS
+    {
+      "symptom": "headache",
+      "duration": "3 days",
+      "severity": "moderate",
+      "associatedSymptoms": ["chills"],
+      "triggers": "stress"
+    }`;
+    result = evaluateTriageState(state, responseText, false);
+    expect(result.nextPhase).toBe("ready");
+    expect(result.shouldRunAnalysis).toBe(true);
+    expect(result.nextCollectedInfo.symptom).toBe("headache");
+    expect(result.nextCollectedInfo.duration).toBe("3 days");
+    expect(result.nextCollectedInfo.severity).toBe("moderate");
+    expect(result.nextCollectedInfo.associatedSymptoms).toContain("chills");
+  });
+
+  it("emergency flow check (Scenario 2)", () => {
+    const state: TriageState = {
+      phase: "gathering",
+      collectedInfo: {},
+      questionsAsked: 0,
+      parseFailures: 0,
+    };
+
+    const messages = [{ content: "I am having the worst headache of my life" }];
+    const emergencyCheck = detectEmergencySymptoms(messages);
+    expect(emergencyCheck.isEmergency).toBe(true);
+    expect(emergencyCheck.matchedKeywords).toContain("worst headache of my life");
+
+    const result = evaluateTriageState(state, null, emergencyCheck.isEmergency);
+    expect(result.nextPhase).toBe("ready");
+    expect(result.shouldRunAnalysis).toBe(true);
+  });
+
+  it("malformed marker fallback (Scenario 4)", () => {
+    let state: TriageState = {
+      phase: "gathering",
+      collectedInfo: {},
+      questionsAsked: 2,
+      parseFailures: 0,
+    };
+
+    // First malformed JSON output from LLM
+    let responseText = "READY_FOR_ANALYSIS { malformed json }";
+    let result = evaluateTriageState(state, responseText, false);
+    
+    // Should fallback: ask one more question and stay in gathering phase
+    expect(result.nextPhase).toBe("gathering");
+    expect(result.nextQuestionsAsked).toBe(3);
+    expect(result.nextParseFailures).toBe(1);
+    expect(result.shouldRunAnalysis).toBe(false);
+    expect(result.fallbackText).toBeDefined();
+
+    // Update state for next turn
+    state = {
+      phase: result.nextPhase,
+      collectedInfo: result.nextCollectedInfo,
+      questionsAsked: result.nextQuestionsAsked,
+      parseFailures: result.nextParseFailures,
+    };
+
+    // Second malformed JSON output from LLM
+    responseText = "READY_FOR_ANALYSIS { still bad }";
+    result = evaluateTriageState(state, responseText, false);
+
+    // Should transition to ready after 2 failures
+    expect(result.nextPhase).toBe("ready");
+    expect(result.shouldRunAnalysis).toBe(true);
+    expect(result.nextParseFailures).toBe(2);
+  });
+
+  it("hitting the question cap (Scenario 3)", () => {
+    // 4 questions already asked
+    const state: TriageState = {
+      phase: "gathering",
+      collectedInfo: {},
+      questionsAsked: 4,
+      parseFailures: 0,
+    };
+
+    // Should force transition to ready immediately
+    const result = evaluateTriageState(state, "Another question...", false);
+    expect(result.nextPhase).toBe("ready");
+    expect(result.shouldRunAnalysis).toBe(true);
+  });
+});

--- a/src/pages/Health/AIHealthAssistant.tsx
+++ b/src/pages/Health/AIHealthAssistant.tsx
@@ -7,6 +7,8 @@ import { invalidateCache } from "@/lib/cached-queries";
 import { whenKeysReady } from "@/lib/encryption";
 import { encryptSymptom, db, type OfflineSymptom } from "@/lib/offline-db";
 import ReactMarkdown from "react-markdown";
+import { type TriagePhase, type CollectedInfo } from "@/types/triage";
+
 
 import { parseSymptomConsultation, shouldPersistConsultation } from "@/lib/symptom-consultation";
 import {
@@ -75,6 +77,11 @@ const AIHealthAssistant = () => {
     { role: "user" | "assistant"; text: string; time: string }[]
   >([]);
   const [loading, setLoading] = useState(false);
+
+  const [phase, setPhase] = useState<TriagePhase>("gathering");
+  const [collectedInfo, setCollectedInfo] = useState<CollectedInfo>({});
+  const [questionsAsked, setQuestionsAsked] = useState<number>(0);
+  const [parseFailures, setParseFailures] = useState<number>(0);
   const [isListening, setIsListening] = useState(false);
   const [currentlyReadingText, setCurrentlyReadingText] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -227,6 +234,10 @@ const AIHealthAssistant = () => {
         },
         body: JSON.stringify({
           messages: [...recentContext, { role: "user", content: userMessage }],
+          phase,
+          collectedInfo,
+          questionsAsked,
+          parseFailures,
         }),
       });
 
@@ -244,6 +255,11 @@ const AIHealthAssistant = () => {
       const decoder = new TextDecoder();
       let textBuffer = "";
       let streamDone = false;
+
+      let latestPhase = phase;
+      let latestCollectedInfo = collectedInfo;
+      let latestQuestionsAsked = questionsAsked;
+      let latestParseFailures = parseFailures;
 
       while (!streamDone) {
         const { done, value } = await reader.read();
@@ -269,6 +285,19 @@ const AIHealthAssistant = () => {
             const parsed = JSON.parse(jsonStr);
             const content = parsed.choices?.[0]?.delta?.content as string | undefined;
             if (content) upsertAssistant(content);
+
+            if (parsed.triageState) {
+              const state = parsed.triageState;
+              latestPhase = state.phase;
+              latestCollectedInfo = state.collectedInfo;
+              latestQuestionsAsked = state.questionsAsked;
+              latestParseFailures = state.parseFailures || 0;
+
+              setPhase(latestPhase);
+              setCollectedInfo(latestCollectedInfo);
+              setQuestionsAsked(latestQuestionsAsked);
+              setParseFailures(latestParseFailures);
+            }
           } catch {
             textBuffer = line + "\n" + textBuffer;
             break;
@@ -283,7 +312,7 @@ const AIHealthAssistant = () => {
         const {
           data: { user },
         } = await supabase.auth.getUser();
-        if (user) {
+        if (user && (latestPhase === "complete" || latestPhase === "ready")) {
           const { possibleCauses, recommendations, severityLevel } =
             parseSymptomConsultation(assistantContent);
 
@@ -553,6 +582,11 @@ const AIHealthAssistant = () => {
                       >
                         {msg.text.replace(/•/g, "-")}
                       </ReactMarkdown>
+                      {msg.role === "assistant" && i === messages.length - 1 && phase === "gathering" && questionsAsked > 0 && (
+                        <div className="text-[10px] text-muted-foreground mt-2 border-t border-border/40 pt-1.5 font-medium select-none">
+                          Clarifying Question {questionsAsked} of ~4
+                        </div>
+                      )}
                     </div>
                   </div>
                   <span

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -22,3 +22,17 @@ class ResizeObserverMock {
 }
 
 global.ResizeObserver = ResizeObserverMock;
+
+if (typeof global.localStorage === "undefined" || global.localStorage === null) {
+  const store = new Map<string, string>();
+  global.localStorage = {
+    getItem: (key: string) => store.get(key) || null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+    key: (index: number) => Array.from(store.keys())[index] || null,
+    get length() {
+      return store.size;
+    },
+  } as any;
+}

--- a/src/types/triage.ts
+++ b/src/types/triage.ts
@@ -1,0 +1,9 @@
+export type TriagePhase = "gathering" | "ready" | "complete";
+
+export interface CollectedInfo {
+  symptom?: string | null;
+  duration?: string | null;
+  severity?: string | null;
+  associatedSymptoms?: string[] | null;
+  triggers?: string | null;
+}

--- a/supabase/functions/symptom-analyzer/index.ts
+++ b/supabase/functions/symptom-analyzer/index.ts
@@ -5,6 +5,8 @@ import { RequestSchema } from "./validation.ts";
 import { detectEmergencySymptoms } from "./medicalSafety.ts";
 import { rateLimit } from "../_shared/rateLimit.ts";
 import { jsonResponse } from "./utils.ts";
+import { evaluateTriageState } from "./triageEngine.ts";
+
 
 const ALLOWED_ORIGINS = [
   "http://localhost:3000",
@@ -218,173 +220,365 @@ ${symptoms.map((s, idx) => `${idx + 1}. ${s}`).join("\n")}
 
     const safetyCheck = detectEmergencySymptoms(messages);
 
-    const systemPrompt = `
-You are a professional medical assistant helping users understand their symptoms.
-
-Provide a clear, detailed, and helpful response in standard Markdown format. You MUST structure your response with the following sections and exact headers so the frontend can parse them properly:
-
-### Severity Level
-Severity Level: ${
-      safetyCheck.isEmergency
-        ? "High"
-        : "[Low | Moderate | High] (choose the appropriate one based on symptoms)"
-    }
+    // Hard-coded, non-LLM emergency response logic
+    if (safetyCheck.isEmergency) {
+      const encoder = new TextEncoder();
+      const emergencyResponse = `### Severity Level
+Severity Level: High
 
 ### Possible Causes
-Provide a bulleted list of possible causes:
-- [Cause 1]
-- [Cause 2]
+- Emergency condition (identified by warning keywords)
+
+### Recommendations
+- **IMMEDIATE ACTION REQUIRED**: Your description contains symptoms that may represent a life-threatening medical emergency.
+- **DO NOT WAIT**: Call your local emergency services (e.g., 911 or local emergency number) or go to the nearest emergency room immediately.
+- Remain as calm as possible and notify someone nearby of your situation.
+
+⚠️ Important: This is general health information only. Consult a qualified healthcare provider for diagnosis and treatment.`;
+
+      const stream = new ReadableStream({
+        start(controller) {
+          // Stream the predefined emergency message
+          const words = emergencyResponse.split(" ");
+          let i = 0;
+          
+          const intervalId = setInterval(() => {
+            if (i < words.length) {
+              const chunk = (i > 0 ? " " : "") + words[i];
+              const payload = `data: ${JSON.stringify({
+                choices: [{ delta: { content: chunk } }],
+              })}\n\n`;
+              controller.enqueue(encoder.encode(payload));
+              i++;
+            } else {
+              clearInterval(intervalId);
+              controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+              controller.close();
+            }
+          }, 20); // Simulate smooth streaming
+        },
+      });
+
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          ...getCorsHeaders(origin),
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    }
+
+    let phase = "phase" in requestData ? requestData.phase : "gathering";
+    let collectedInfo = "collectedInfo" in requestData ? requestData.collectedInfo : {};
+    let questionsAsked = "questionsAsked" in requestData ? requestData.questionsAsked : 0;
+    let parseFailures = "parseFailures" in requestData ? requestData.parseFailures : 0;
+
+    // Force transition to 'ready' if questionsAsked hits 4
+    if (phase === "gathering" && questionsAsked >= 4) {
+      phase = "ready";
+    }
+
+    const conversationText = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
+
+    const getCorsHeaders = (origin: string | null) => ({
+      "Access-Control-Allow-Origin": origin && isAllowedOrigin(origin) ? origin : "null",
+      "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+    });
+
+    const corsHeaders = getCorsHeaders(origin);
+
+    async function getGeminiResponseText(
+      systemPrompt: string,
+      conversationText: string
+    ): Promise<string> {
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${GEMINI_API_KEY}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            contents: [
+              {
+                parts: [
+                  {
+                    text: `${systemPrompt}\n\nConversation:\n${conversationText}`,
+                  },
+                ],
+              },
+            ],
+            generationConfig: {
+              temperature: 0.4,
+              maxOutputTokens: 2048,
+            },
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Gemini API error: ${response.status}`);
+      }
+
+      const json = await response.json();
+      return json?.candidates?.[0]?.content?.parts?.[0]?.text || "";
+    }
+
+    function streamStaticResponse(
+      text: string,
+      triageStateToSend: any
+    ): Response {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          const payload = `data: ${JSON.stringify({
+            choices: [{ delta: { content: text } }],
+          })}\n\n`;
+          controller.enqueue(encoder.encode(payload));
+
+          const statePayload = `data: ${JSON.stringify({
+            triageState: triageStateToSend,
+          })}\n\n`;
+          controller.enqueue(encoder.encode(statePayload));
+
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        },
+      });
+
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    }
+
+    async function streamGeminiResponse(
+      systemPrompt: string,
+      conversationText: string,
+      triageStateToSend: any
+    ): Promise<Response> {
+      const geminiResponse = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent?alt=sse&key=${GEMINI_API_KEY}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            contents: [
+              {
+                parts: [
+                  {
+                    text: `${systemPrompt}\n\nConversation:\n${conversationText}`,
+                  },
+                ],
+              },
+            ],
+            generationConfig: {
+              temperature: 0.4,
+              maxOutputTokens: 2048,
+            },
+          }),
+        }
+      );
+
+      if (!geminiResponse.ok || !geminiResponse.body) {
+        return jsonResponse(
+          { error: "Gemini API error during analysis streaming" },
+          geminiResponse.status,
+          corsHeaders
+        );
+      }
+
+      const encoder = new TextEncoder();
+      const decoder = new TextDecoder();
+      const reader = geminiResponse.body.getReader();
+
+      const stream = new ReadableStream({
+        async start(controller) {
+          let buffer = "";
+          let closed = false;
+
+          const safeClose = () => {
+            if (closed) return;
+            closed = true;
+            controller.close();
+          };
+
+          const processLine = (line: string) => {
+            const trimmed = line.trim();
+            if (!trimmed.startsWith("data:")) return;
+
+            const jsonStr = trimmed.slice(5).trim();
+            if (!jsonStr || jsonStr === "[DONE]") return;
+
+            try {
+              const parsed = JSON.parse(jsonStr);
+              const candidate = parsed?.candidates?.[0];
+              const parts = candidate?.content?.parts ?? [];
+              for (const part of parts) {
+                if (part?.text) {
+                  const payload = `data: ${JSON.stringify({
+                    choices: [{ delta: { content: part.text } }],
+                  })}\n\n`;
+                  controller.enqueue(encoder.encode(payload));
+                }
+              }
+            } catch (parseErr) {
+              console.error("Failed to parse Gemini SSE chunk:", parseErr, jsonStr);
+            }
+          };
+
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+
+              buffer += decoder.decode(value, { stream: true });
+              const lines = buffer.split("\n");
+              buffer = lines.pop() ?? "";
+
+              for (const line of lines) processLine(line);
+            }
+
+            buffer += decoder.decode();
+            if (buffer.trim()) processLine(buffer);
+
+            // Send the updated triageState before the DONE marker
+            const statePayload = `data: ${JSON.stringify({
+              triageState: triageStateToSend,
+            })}\n\n`;
+            controller.enqueue(encoder.encode(statePayload));
+            
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          } catch (streamErr) {
+            console.error("Error while relaying Gemini stream:", streamErr);
+            const errorPayload = `data: ${JSON.stringify({
+              error: "Stream interrupted while generating the response.",
+            })}\n\n`;
+            controller.enqueue(encoder.encode(errorPayload));
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          } finally {
+            safeClose();
+          }
+        },
+        cancel(reason) {
+          try {
+            reader.cancel(reason);
+          } catch {}
+        },
+      });
+
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    }
+
+    let result;
+
+    if (phase === "gathering") {
+      const triagePrompt = `
+You are an AI medical triage assistant. Your goal is to gather symptom information from the user before rendering a final health analysis.
+You MUST follow these rules:
+1. Ask exactly ONE clarifying question at a time.
+2. Ask in the following priority order, check if each is already known from context:
+   - Duration (e.g., "How long has this been occurring?")
+   - Severity (e.g., "On a scale of 1-10, how severe is the pain/symptom?")
+   - Associated symptoms or triggers (e.g., "Are you experiencing any other symptoms, or does anything specific seem to trigger it?")
+3. NEVER provide possible causes, recommendations, severity levels, or advice yet.
+4. Keep your tone empathetic, clear, and professional.
+5. Once you have gathered sufficient information on these areas OR when questionsAsked reaches 4 (current questionsAsked count: ${questionsAsked}), you MUST conclude your reply by appending the exact token "READY_FOR_ANALYSIS" followed by a JSON summary of the collected info.
+
+Format for concluding when ready (ensure JSON is valid and on a new line after the READY_FOR_ANALYSIS token):
+READY_FOR_ANALYSIS
+{
+  "symptom": "[symptom name]",
+  "duration": "[duration description]",
+  "severity": "[severity description]",
+  "associatedSymptoms": ["list", "of", "symptoms"],
+  "triggers": "[trigger description]"
+}
+`;
+
+      const responseText = await getGeminiResponseText(triagePrompt, conversationText);
+      result = evaluateTriageState(
+        { phase, collectedInfo, questionsAsked, parseFailures },
+        responseText,
+        false
+      );
+
+      if (result.nextPhase === "gathering") {
+        const textToSend = result.fallbackText || responseText;
+        const triageStateToSend = {
+          phase: "gathering",
+          collectedInfo: result.nextCollectedInfo,
+          questionsAsked: result.nextQuestionsAsked,
+          parseFailures: result.nextParseFailures,
+        };
+        return streamStaticResponse(textToSend, triageStateToSend);
+      }
+    } else {
+      result = evaluateTriageState(
+        { phase, collectedInfo, questionsAsked, parseFailures },
+        null,
+        false
+      );
+    }
+
+    // If phase is 'ready' (either originally or transitioned above)
+    if (result.nextPhase === "ready" || result.shouldRunAnalysis) {
+      const analysisPrompt = `
+You are a professional medical assistant helping users understand their symptoms.
+You are provided with structured symptom details collected during a triage phase:
+- Symptom: ${result.nextCollectedInfo?.symptom || "Unknown"}
+- Duration: ${result.nextCollectedInfo?.duration || "Unknown"}
+- Severity: ${result.nextCollectedInfo?.severity || "Unknown"}
+- Associated Symptoms: ${(result.nextCollectedInfo?.associatedSymptoms || []).join(", ") || "None"}
+- Triggers: ${result.nextCollectedInfo?.triggers || "Unknown"}
+
+Provide a clear, detailed, and helpful response in standard Markdown format. You MUST structure your response with the following sections and exact headers so the frontend can parse them properly.
+Rank potential causes by relevance to the collected triage context instead of using a generic static list.
+
+### Severity Level
+Severity Level: [Low | Moderate | High] (choose the appropriate one based on symptoms and severity)
+
+### Possible Causes
+Provide a bulleted list of possible causes ranked by relevance to the details above:
+- [Ranked Cause 1]
+- [Ranked Cause 2]
 
 ### Recommendations
 Provide self-care steps or action items:
 - [Recommendation 1]
 - [Recommendation 2]
 
-${
-  safetyCheck.isEmergency
-    ? `
-IMPORTANT:
-The user's symptoms indicate a potential medical emergency.
-You MUST set the Severity Level to High, and strongly advise immediate professional medical attention or visiting the nearest emergency room.
-`
-    : ""
-}
-
 ⚠️ Important: This is general health information only. Consult a qualified healthcare provider for diagnosis and treatment.
 `;
 
-    const conversationText = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
+      const triageStateToSend = {
+        phase: "complete",
+        collectedInfo: result.nextCollectedInfo,
+        questionsAsked: result.nextQuestionsAsked,
+        parseFailures: result.nextParseFailures,
+      };
 
-    const geminiResponse = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent?alt=sse&key=${GEMINI_API_KEY}`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          contents: [
-            {
-              parts: [
-                {
-                  text: `${systemPrompt}\n\nConversation:\n${conversationText}`,
-                },
-              ],
-            },
-          ],
-          generationConfig: {
-            temperature: 0.4,
-            maxOutputTokens: 2048,
-          },
-        }),
-      }
-    );
-
-    if (!geminiResponse.ok || !geminiResponse.body) {
-      const errorText = await geminiResponse.text().catch(() => "");
-
-      console.error("Gemini API error:", geminiResponse.status, errorText);
-
-      return jsonResponse(
-        {
-          error: "Gemini API error",
-          status: geminiResponse.status,
-        },
-        geminiResponse.status,
-        getCorsHeaders(origin)
-      );
+      return streamGeminiResponse(analysisPrompt, conversationText, triageStateToSend);
     }
 
-    const encoder = new TextEncoder();
-    const decoder = new TextDecoder();
-
-    function extractTextChunks(parsed: unknown): string[] {
-      const candidate = (parsed as { candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> })
-        ?.candidates?.[0];
-      const parts = candidate?.content?.parts ?? [];
-      return parts.map((p) => p?.text).filter((t): t is string => Boolean(t));
-    }
-
-    let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
-
-    const stream = new ReadableStream({
-      async start(controller) {
-        const localReader = geminiResponse.body!.getReader();
-        reader = localReader;
-        let buffer = "";
-        let closed = false;
-
-        const safeClose = () => {
-          if (closed) return;
-          closed = true;
-          controller.close();
-        };
-
-        const processLine = (line: string) => {
-          const trimmed = line.trim();
-          if (!trimmed.startsWith("data:")) return;
-
-          const jsonStr = trimmed.slice(5).trim();
-          if (!jsonStr || jsonStr === "[DONE]") return;
-
-          try {
-            const parsed = JSON.parse(jsonStr);
-            for (const chunkText of extractTextChunks(parsed)) {
-              const payload = `data: ${JSON.stringify({
-                choices: [{ delta: { content: chunkText } }],
-              })}\n\n`;
-              controller.enqueue(encoder.encode(payload));
-            }
-          } catch (parseErr) {
-            console.error("Failed to parse Gemini SSE chunk:", parseErr, jsonStr);
-          }
-        };
-
-        try {
-          while (true) {
-            const { done, value } = await localReader.read();
-            if (done) break;
-
-            buffer += decoder.decode(value, { stream: true });
-            const lines = buffer.split("\n");
-            buffer = lines.pop() ?? "";
-
-            for (const line of lines) processLine(line);
-          }
-
-          buffer += decoder.decode(); // flush any pending multi-byte sequence
-          if (buffer.trim()) processLine(buffer);
-
-          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-        } catch (streamErr) {
-          console.error("Error while relaying Gemini stream:", streamErr);
-          const errorPayload = `data: ${JSON.stringify({
-            error: "Stream interrupted while generating the response.",
-          })}\n\n`;
-          controller.enqueue(encoder.encode(errorPayload));
-          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-        } finally {
-          safeClose();
-        }
-      },
-      cancel(reason) {
-        try {
-          reader?.cancel(reason);
-        } catch {
-          // reader may already be closed/released — safe to ignore.
-        }
-      },
-    });
-
-    return new Response(stream, {
-      status: 200,
-      headers: {
-        ...getCorsHeaders(origin),
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-      },
-    });
+    return jsonResponse({ error: "Invalid phase state reached" }, 500, corsHeaders);
   } catch (error) {
     console.error("Error in symptom-analyzer:", error);
 
@@ -393,7 +587,11 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
         error: error instanceof Error ? error.message : "Unknown server error",
       },
       500,
-      getCorsHeaders(origin)
+      {
+        "Access-Control-Allow-Origin": origin && isAllowedOrigin(origin) ? origin : "null",
+        "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+      }
     );
   }
 });
+

--- a/supabase/functions/symptom-analyzer/medicalSafety.ts
+++ b/supabase/functions/symptom-analyzer/medicalSafety.ts
@@ -8,6 +8,9 @@ const emergencyKeywords = [
     "suicidal",
     "heart attack",
     "severe bleeding",
+    "worst headache of my life",
+    "can't breathe",
+    "slurred speech",
 ];
 
 type Message = {

--- a/supabase/functions/symptom-analyzer/triageEngine.ts
+++ b/supabase/functions/symptom-analyzer/triageEngine.ts
@@ -1,0 +1,128 @@
+export type TriagePhase = "gathering" | "ready" | "complete";
+
+export interface CollectedInfo {
+  symptom?: string | null;
+  duration?: string | null;
+  severity?: string | null;
+  associatedSymptoms?: string[] | null;
+  triggers?: string | null;
+}
+
+export interface TriageState {
+  phase: TriagePhase;
+  collectedInfo: CollectedInfo;
+  questionsAsked: number;
+  parseFailures: number;
+}
+
+export interface TriageResult {
+  nextPhase: TriagePhase;
+  nextCollectedInfo: CollectedInfo;
+  nextQuestionsAsked: number;
+  nextParseFailures: number;
+  shouldRunAnalysis: boolean;
+  fallbackText?: string | null;
+}
+
+export function evaluateTriageState(
+  state: TriageState,
+  responseText: string | null,
+  isEmergency: boolean
+): TriageResult {
+  if (isEmergency) {
+    return {
+      nextPhase: "ready",
+      nextCollectedInfo: state.collectedInfo,
+      nextQuestionsAsked: state.questionsAsked,
+      nextParseFailures: state.parseFailures,
+      shouldRunAnalysis: true,
+    };
+  }
+
+  let { phase, collectedInfo, questionsAsked, parseFailures } = state;
+
+  // Force transition if questionsAsked >= 4
+  if (phase === "gathering" && questionsAsked >= 4) {
+    return {
+      nextPhase: "ready",
+      nextCollectedInfo: collectedInfo,
+      nextQuestionsAsked: questionsAsked,
+      nextParseFailures: parseFailures,
+      shouldRunAnalysis: true,
+    };
+  }
+
+  if (phase === "gathering") {
+    if (!responseText) {
+      return {
+        nextPhase: "gathering",
+        nextCollectedInfo: collectedInfo,
+        nextQuestionsAsked: questionsAsked,
+        nextParseFailures: parseFailures,
+        shouldRunAnalysis: false,
+      };
+    }
+
+    if (responseText.includes("READY_FOR_ANALYSIS")) {
+      const markerIndex = responseText.indexOf("READY_FOR_ANALYSIS");
+      const jsonPart = responseText.substring(markerIndex + "READY_FOR_ANALYSIS".length).trim();
+      try {
+        const parsed = JSON.parse(jsonPart);
+        const nextCollectedInfo: CollectedInfo = {
+          symptom: parsed.symptom || collectedInfo.symptom || null,
+          duration: parsed.duration || collectedInfo.duration || null,
+          severity: parsed.severity || collectedInfo.severity || null,
+          associatedSymptoms: parsed.associatedSymptoms || collectedInfo.associatedSymptoms || [],
+          triggers: parsed.triggers || collectedInfo.triggers || null,
+        };
+
+        return {
+          nextPhase: "ready",
+          nextCollectedInfo,
+          nextQuestionsAsked: questionsAsked,
+          nextParseFailures: parseFailures,
+          shouldRunAnalysis: true,
+        };
+      } catch (err) {
+        console.error("Failed to parse triage JSON:", err);
+        const nextParseFailures = parseFailures + 1;
+        if (nextParseFailures >= 2) {
+          return {
+            nextPhase: "ready",
+            nextCollectedInfo: collectedInfo,
+            nextQuestionsAsked: questionsAsked,
+            nextParseFailures: nextParseFailures,
+            shouldRunAnalysis: true,
+          };
+        } else {
+          return {
+            nextPhase: "gathering",
+            nextCollectedInfo: collectedInfo,
+            nextQuestionsAsked: questionsAsked + 1,
+            nextParseFailures: nextParseFailures,
+            shouldRunAnalysis: false,
+            fallbackText: "I want to make sure I have all the details. Could you please specify how long you've had these symptoms, their severity (e.g., on a 1-10 scale), and any triggers?",
+          };
+        }
+      }
+    } else {
+      // Normal question
+      return {
+        nextPhase: "gathering",
+        nextCollectedInfo: collectedInfo,
+        nextQuestionsAsked: questionsAsked + 1,
+        nextParseFailures: parseFailures,
+        shouldRunAnalysis: false,
+      };
+    }
+  }
+
+  // If we are already in ready or complete phase
+  return {
+    nextPhase: "complete",
+    nextCollectedInfo: collectedInfo,
+    nextQuestionsAsked: questionsAsked,
+    nextParseFailures: parseFailures,
+    shouldRunAnalysis: true,
+  };
+}

--- a/supabase/functions/symptom-analyzer/validation.ts
+++ b/supabase/functions/symptom-analyzer/validation.ts
@@ -8,6 +8,14 @@ export const MessageSchema = z.object({
         .max(2000, "Message content exceeds limit"),
 });
 
+export const CollectedInfoSchema = z.object({
+    symptom: z.string().nullable().optional(),
+    duration: z.string().nullable().optional(),
+    severity: z.string().nullable().optional(),
+    associatedSymptoms: z.array(z.string()).nullable().optional(),
+    triggers: z.string().nullable().optional(),
+});
+
 export const RequestSchema = z.union([
   z.object({
     mode: z.literal("chat").optional(),
@@ -15,6 +23,10 @@ export const RequestSchema = z.union([
       .array(MessageSchema)
       .min(1, "At least one message is required")
       .max(20, "Too many messages provided"),
+    phase: z.enum(["gathering", "ready", "complete"]).optional(),
+    collectedInfo: CollectedInfoSchema.optional(),
+    questionsAsked: z.number().min(0).max(4).optional(),
+    parseFailures: z.number().min(0).optional(),
   }),
   z.object({
     mode: z.literal("predict"),
@@ -25,3 +37,4 @@ export const RequestSchema = z.union([
 ]);
 
 export type RequestBody = z.infer<typeof RequestSchema>;
+


### PR DESCRIPTION
Resolves #1051

This pull request implements the requested stateful multi-turn triage flow for the AI Health Assistant prior to providing the final medical symptom analysis.

### Changes Implemented:

1. **Stateful Database Schema**:
   - Registered `phase` (`TriagePhase`), `collected_info` (`CollectedInfo`), and `questions_asked` variables into the Supabase project mappings in `src/integrations/supabase/types.ts`.

2. **Deno Edge Function Engine**:
   - Created the triage evaluation engine in `supabase/functions/symptom-analyzer/triageEngine.ts` to handle phase transitions, state validation, and error recovery.
   - Decoupled the single triage prompt into:
     - `TRIAGE_PROMPT`: Directs Gemini to ask one question at a time (Duration -> Severity -> Associated Symptoms/Triggers order of priority) and emit a JSON summary block when ready.
     - `ANALYSIS_PROMPT`: Evaluates context, self-care guides, and generates the final structured assessment card.
   - Built a hard-coded emergency short-circuit bypass for critical symptoms (e.g. chest pain, slurred speech).
   - Gracefully handles malformed JSON parsing failures with a fallback recovery flow.

3. **Multi-Turn Chat UI & Session Integration**:
   - Modified `src/components/chat/ChatInterface.tsx` and `src/pages/Health/AIHealthAssistant.tsx` to track state hooks, stream intermediate state adjustments, and delay saving history/severity toasts until `phase === "complete"`.
   - Updated the Chat UI to render a clean progress badge (e.g., `Clarifying Question 2 of ~4`) on active questions, and display the assessment card only when the flow transitions to `ready`/`complete`.

4. **Testing & Stability**:
   - Added `src/lib/triageEngine.test.ts` covering standard flow transitions, emergency bypass, question cap (4), and malformed parsing recovery. All tests pass successfully.
   - Patched `localStorage` test environment issues in `src/test/setup.ts` to ensure compatibility.