### PR TITLE
fix: decrypt errors with DecryptionError class

### DIFF
--- a/src/lib/encryption.test.ts
+++ b/src/lib/encryption.test.ts
@@ -6,6 +6,7 @@ import {
   whenKeysReady,
   encryptText,
   decryptText,
+  DecryptionError,
   deriveKeyFromToken,
   deriveSearchKeyFromToken,
   rotateKeysToNewPassword,
@@ -26,6 +27,37 @@ describe("Encryption Key Persistence", () => {
 
     const decrypted = await decryptText(ciphertext, key);
     expect(decrypted).toBe(plaintext);
+  });
+
+  it("throws DecryptionError with name DecryptionError on invalid format", async () => {
+    const key = await deriveKeyFromToken("stable-master-seed", "user-123");
+
+    let thrownErr: unknown;
+    try {
+      await decryptText("invalid-format-no-colon", key);
+    } catch (err) {
+      thrownErr = err;
+    }
+
+    expect(thrownErr).toBeInstanceOf(DecryptionError);
+    expect((thrownErr as DecryptionError).name).toBe("DecryptionError");
+    expect((thrownErr as DecryptionError).message).toBe("Invalid encrypted text format");
+  });
+
+  it("throws DecryptionError on decryption failure (e.g. wrong key or tampered ciphertext)", async () => {
+    const key1 = await deriveKeyFromToken("seed-1", "user-123");
+    const key2 = await deriveKeyFromToken("seed-2", "user-123");
+    const ciphertext = await encryptText("secret data", key1);
+
+    let thrownErr: unknown;
+    try {
+      await decryptText(ciphertext, key2);
+    } catch (err) {
+      thrownErr = err;
+    }
+
+    expect(thrownErr).toBeInstanceOf(DecryptionError);
+    expect((thrownErr as DecryptionError).name).toBe("DecryptionError");
   });
 
   it("resolves whenKeysReady when active keys are set", async () => {

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -242,27 +242,44 @@ export async function encryptText(text: string, key: CryptoKey): Promise<string>
   return `${ivHex}:${ciphertextHex}`;
 }
 
+export class DecryptionError extends Error {
+  constructor(message: string = "Decryption failed", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "DecryptionError";
+  }
+}
+
 export async function decryptText(encryptedText: string, key: CryptoKey): Promise<string> {
   const parts = encryptedText.split(":");
   if (parts.length !== 2) {
-    throw new Error("Invalid encrypted text format");
+    throw new DecryptionError("Invalid encrypted text format");
   }
 
   const [ivHex, ciphertextHex] = parts;
   const iv = hexToUint8Array(ivHex);
   const ciphertext = hexToUint8Array(ciphertextHex);
 
-  const decryptedBuffer = await crypto.subtle.decrypt(
-    {
-      name: "AES-GCM",
-      iv: iv,
-    },
-    key,
-    ciphertext
-  );
+  try {
+    const decryptedBuffer = await crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: iv,
+      },
+      key,
+      ciphertext
+    );
 
-  const decoder = new TextDecoder();
-  return decoder.decode(decryptedBuffer);
+    const decoder = new TextDecoder();
+    return decoder.decode(decryptedBuffer);
+  } catch (err) {
+    if (err instanceof DecryptionError) {
+      throw err;
+    }
+    throw new DecryptionError(
+      err instanceof Error ? err.message : "Decryption failed",
+      { cause: err }
+    );
+  }
 }
 
 // Callbacks registered by offline-db


### PR DESCRIPTION
Summary of Changes
Created & Exported DecryptionError: Added DecryptionError extending Error with name = "DecryptionError".
Normalized decryptText Errors: Wrapped the crypto.subtle.decrypt call in a try/catch block to catch underlying Web Crypto failures (DOMException, TypeError, etc.) and throw a normalized DecryptionError with cause set to the underlying error.
Format Check: Updated the invalid format check (parts.length !== 2) in decryptText to throw DecryptionError("Invalid encrypted text format").
Unit Tests: Added test cases in src/lib/encryption.test.ts
 verifying that format errors and decryption failures (e.g. wrong key) throw an instanceof DecryptionError with name === "DecryptionError".


closes #910