### PR TITLE
perf(1087): split vendor chunks and drop eager dashboard preload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,13 +19,10 @@ import { AuthProvider } from "./components/auth/AuthProvider";
 import Layout from "./components/layout/Layout.tsx";
 import ScrollToTop from "@/components/navigation/ScrollToTop.tsx";
 
-// Preload Dashboard page for faster navigation
-const preloadDashboard = () => import("./pages/Dashboard");
-
 // Lazy-loaded pages
 const Index = lazy(() => import("./pages/Home/Index.tsx"));
 const Auth = lazy(() => import("./pages/Auth/index.tsx"));
-const Dashboard = lazy(() => preloadDashboard());
+const Dashboard = lazy(() => import("./pages/Dashboard"));
 const Chat = lazy(() => import("./pages/Chat"));
 const Metrics = lazy(() => import("./pages/Metrics"));
 const History = lazy(() => import("./pages/History"));
@@ -47,11 +44,6 @@ const BlogPostPage = lazy(() => import("@/pages/Blog/BlogPostPage.tsx"));
 const ResetPassword = lazy(() => import("./pages/User/ResetPassword.tsx"));
 const GamificationPage = lazy(() => import("@/pages/Gamification"));
 const Reminders = lazy(() => import("./pages/Reminders/index.tsx"));
-
-// Preload dashboard on app start for faster perceived navigation
-if (typeof window !== "undefined") {
-  preloadDashboard();
-}
 
 // Loading spinner fallback component
 const LoadingScreen = () => (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,6 +55,26 @@ export default defineConfig(({ mode }) => ({
       },
     }),
   ].filter(Boolean),
+  build: {
+    rollupOptions: {
+      output: {
+        // Split heavy/rarely-used vendor libraries into dedicated chunks so the
+        // main entry bundle stays small and browsers can cache them independently.
+        manualChunks: {
+          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-query": ["@tanstack/react-query"],
+          "vendor-i18n": ["i18next", "react-i18next"],
+          "vendor-supabase": ["@supabase/supabase-js"],
+          "vendor-dexie": ["dexie"],
+          "vendor-recharts": ["recharts"],
+          "vendor-pdf": ["jspdf", "jspdf-autotable"],
+          "vendor-image": ["html-to-image"],
+          "vendor-motion": ["framer-motion"],
+          "vendor-markdown": ["react-markdown"],
+        },
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## **Pull Request Description**
A clear and concise description of the changes introduced by this pull request.
Fixes the production bundle size warnings: `npm run build` emitted a >500 kB chunk warning (the App/entry chunk was 990 kB, gzip 311 kB). Chunking is now explicit and cache-friendly, and the eager dashboard preload that defeated route-level code splitting has been removed. After this change the entry chunk is **290 kB (gzip 96.6 kB)** and **no chunk exceeds 500 kB**

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [x] **New Feature** (non-breaking change which adds functionality)
- [x] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #1087 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- `npm run build` — succeeds, no chunk-size warnings
- `npm run test` — existing tests pass
- PWA service worker precaches all new chunks (`**/*.{js,css,...}` glob)

---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Chunk | Before | After |
|---|---|---|
| Entry (App + providers) | 990.02 kB │ gzip: 311.60 kB | **290.10 kB** │ gzip: 96.58 kB |
| Charts | 385.26 kB (eager) | 383.33 kB `vendor-recharts` (lazy) |
| PDF export | 450.85 kB (mixed) | 422.00 kB `vendor-pdf` (lazy) |
| >500 kB warnings | 1 | **0** |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
