### PR TITLE
fix: clear master seed and salt on logout

### DIFF
--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -4,6 +4,8 @@ import type { Session } from "@supabase/supabase-js";
 let activeKey: CryptoKey | null = null;
 let activeSearchKey: CryptoKey | null = null;
 let lastToken: string | null = null;
+/** Last authenticated user id — needed on logout because getUser() is empty after sign-out. */
+let lastKnownUserId: string | null = null;
 
 let readyPromise: Promise<{ encryptionKey: CryptoKey; searchKey: CryptoKey }> | null = null;
 let readyResolver: ((keys: { encryptionKey: CryptoKey; searchKey: CryptoKey }) => void) | null = null;
@@ -427,6 +429,8 @@ async function handleSessionChange(session: Session) {
   const userId = session.user?.id;
   if (!userId) return;
 
+  lastKnownUserId = userId;
+
   const token = session.access_token;
   if (!token) return;
 
@@ -522,21 +526,36 @@ async function handleSessionChange(session: Session) {
   }
 }
 
+function clearPersistedKeyMaterial(userId: string) {
+  clearUserSalt(userId);
+  localStorage.removeItem(SEED_KEY_PREFIX + userId);
+}
+
 async function handleSessionClear() {
   // Clear user-specific data on logout.
   //
-  // This removes the locally cached salt and master seed so that no key
-  // material can be re-derived from this browser/device without the user
-  // authenticating again. Note the salt is recoverable on next login (it's
-  // also stored in the user's Supabase profile, see the sync logic in
-  // `handleSessionChange` above); the seed is not persisted anywhere except
-  // the current device, so it is re-derived from the password on next login.
+  // Prefer lastKnownUserId: by the time onAuthStateChange fires with
+  // session === null, supabase.auth.getUser() no longer returns the user,
+  // so gating the wipe on getUser() left seed/salt in localStorage.
   const { data: { user } } = await supabase.auth.getUser();
-  if (user?.id) {
-    clearUserSalt(user.id);
-    localStorage.removeItem(SEED_KEY_PREFIX + user.id);
+  const userId = lastKnownUserId || user?.id || null;
+
+  if (userId) {
+    clearPersistedKeyMaterial(userId);
+  } else {
+    // Belt-and-suspenders: wipe any leftover seed/salt keys if we lost the id.
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const key = localStorage.key(i);
+      if (
+        key &&
+        (key.startsWith(SEED_KEY_PREFIX) || key.startsWith(SALT_KEY_PREFIX))
+      ) {
+        localStorage.removeItem(key);
+      }
+    }
   }
 
+  lastKnownUserId = null;
   setKeys(null, null);
   lastToken = null;
   if (onLogoutCallback) {


### PR DESCRIPTION
## **Pull Request Description**
Logout left `master_seed_*` / PBKDF2 salt in localStorage because `handleSessionClear` called `getUser()` after the session was already null. Track `lastKnownUserId` and wipe by that id (with a prefix-scan fallback).

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
Fixes #1097

---

### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Reviewed auth clear path: `lastKnownUserId` set in `handleSessionChange`, used in `handleSessionClear`.
  2. Confirmed prefix-scan fallback when user id is unavailable.

---

### **4. Visual Verification (If applicable)**
N/A

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.

Made with [Cursor](https://cursor.com)