### PR TITLE
fix: clear emergency mesh queue on logout

### DIFF
--- a/src/lib/offline-db.ts
+++ b/src/lib/offline-db.ts
@@ -299,6 +299,7 @@ registerEncryptionHooks({
     try {
       await db.healthMetrics.clear();
       await db.symptomHistory.clear();
+      await db.pendingEmergencyMesh.clear();
     } catch (err) {
       console.error("Error clearing database on logout:", err);
     }


### PR DESCRIPTION
## **Pull Request Description**
`onLogout` already cleared metrics/symptoms from Dexie but left `pendingEmergencyMesh` (contact name/phone, lat/lon). Clear that table too.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
Fixes #1098

---

### **3. How Has This Been Tested?**
- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Confirmed `onLogout` now clears `pendingEmergencyMesh` alongside other Dexie tables.

---

### **4. Visual Verification (If applicable)**
N/A

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.

Made with [Cursor](https://cursor.com)