### PR TITLE
fix: retry emergency mesh relay after failure

### DIFF
--- a/src/lib/mesh-network.ts
+++ b/src/lib/mesh-network.ts
@@ -223,12 +223,12 @@ class MeshNetworkManager {
       return; // Already processed, avoid infinite loop
     }
 
-    // Save to local IndexedDB
+    // Save to local IndexedDB — always queue until relay succeeds
     const localAlert: MeshAlert = {
       ...alert,
       publicKeyJwk,
       signature,
-      pending_sync: this.isOnline() ? 0 : 1, // Need to sync if currently offline
+      pending_sync: 1,
     };
 
     await db.pendingEmergencyMesh.put(localAlert);
@@ -243,7 +243,7 @@ class MeshNetworkManager {
 
     // If we are online, act as a gateway and immediately relay it!
     if (this.isOnline()) {
-      this.relayAlert(localAlert);
+      await this.relayAlert(localAlert);
     }
   }
 
@@ -299,7 +299,8 @@ class MeshNetworkManager {
     const fullAlert: MeshAlert = {
       ...alert,
       signature,
-      pending_sync: this.isOnline() ? 0 : 1,
+      // Stay queued until relayAlert confirms success
+      pending_sync: 1,
     };
 
     // Store in our own local Dexie table
@@ -327,7 +328,7 @@ class MeshNetworkManager {
 
     // If online, send directly to Edge Function
     if (this.isOnline()) {
-      this.relayAlert(fullAlert);
+      await this.relayAlert(fullAlert);
     }
 
     return fullAlert;
@@ -369,6 +370,8 @@ class MeshNetworkManager {
       window.dispatchEvent(event);
     } catch (err) {
       console.error(`Mesh Gateway: Failed to relay alert ${alert.id}:`, err);
+      // Keep pending_sync === 1 so syncMeshAlerts can retry
+      await db.pendingEmergencyMesh.update(alert.id, { pending_sync: 1 });
     }
   }
 


### PR DESCRIPTION
## **Pull Request Description**
Online mesh alerts were written with `pending_sync: 0` before `relayAlert` finished (and relay was fire-and-forget). Failures never re-entered `syncMeshAlerts`. Always queue with `pending_sync: 1`, await relay, and only clear on success.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
Fixes #1099

---

### **3. How Has This Been Tested?**
- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Confirmed insert paths always use `pending_sync: 1`.
  2. Confirmed `relayAlert` awaits and re-queues on failure.

---

### **4. Visual Verification (If applicable)**
N/A

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.

Made with [Cursor](https://cursor.com)