### PR TITLE
fix: reject system role in symptom-analyzer messages

### DIFF
--- a/supabase/functions/symptom-analyzer/index.ts
+++ b/supabase/functions/symptom-analyzer/index.ts
@@ -253,7 +253,10 @@ You MUST set the Severity Level to High, and strongly advise immediate professio
 ⚠️ Important: This is general health information only. Consult a qualified healthcare provider for diagnosis and treatment.
 `;
 
-    const conversationText = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
+    const conversationText = messages
+      .filter((m) => m.role === "user" || m.role === "assistant")
+      .map((m) => `${m.role}: ${m.content}`)
+      .join("\n");
 
     const geminiResponse = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent?alt=sse&key=${GEMINI_API_KEY}`,

--- a/supabase/functions/symptom-analyzer/validation.ts
+++ b/supabase/functions/symptom-analyzer/validation.ts
@@ -1,7 +1,7 @@
 import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
 
 export const MessageSchema = z.object({
-    role: z.enum(["user", "assistant", "system"]),
+    role: z.enum(["user", "assistant"]),
     content: z
         .string()
         .min(1, "Message content cannot be empty")
@@ -19,7 +19,12 @@ export const RequestSchema = z.union([
   z.object({
     mode: z.literal("predict"),
     symptoms: z
-      .array(z.string())
+      .array(
+        z
+          .string()
+          .min(1, "Symptom entry cannot be empty")
+          .max(500, "Symptom entry exceeds limit")
+      )
       .max(50, "Too many symptoms provided"),
   }),
 ]);


### PR DESCRIPTION
## **Pull Request Description**
`MessageSchema` accepted `role: "system"`, which clients could inject into the Gemini prompt. Restrict roles to `user`/`assistant`, filter again before prompt build, and add a per-string max for predict-mode symptoms.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
Fixes #1102

---

### **3. How Has This Been Tested?**
- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Zod schema no longer allows `system`.
  2. Prompt builder filters to user/assistant only.

---

### **4. Visual Verification (If applicable)**
N/A

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.

Made with [Cursor](https://cursor.com)