### PR TITLE
fix: abort chat streams and revoke preview blob URLs

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -81,7 +81,25 @@ const ChatInterface = () => {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const streamAbortRef = useRef<AbortController | null>(null);
   const { toast } = useToast();
+
+  const previewUrls = useMemo(
+    () => selectedFiles.map((file) => URL.createObjectURL(file)),
+    [selectedFiles]
+  );
+
+  useEffect(() => {
+    return () => {
+      previewUrls.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, [previewUrls]);
+
+  useEffect(() => {
+    return () => {
+      streamAbortRef.current?.abort();
+    };
+  }, []);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
@@ -177,6 +195,10 @@ const ChatInterface = () => {
     setInput("");
     setIsLoading(true);
 
+    streamAbortRef.current?.abort();
+    const abortController = new AbortController();
+    streamAbortRef.current = abortController;
+
     let assistantContent = "";
 
     const upsertAssistant = (chunk: string) => {
@@ -250,6 +272,7 @@ const ChatInterface = () => {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({ messages: [...recentContext, userMessage] }),
+        signal: abortController.signal,
       });
 
       if (!response.ok || !response.body) {
@@ -416,6 +439,10 @@ const ChatInterface = () => {
         }
       }
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        dismissLoading();
+        return;
+      }
       console.error("Chat error:", error);
       dismissLoading();
       const errorMsg =
@@ -423,6 +450,9 @@ const ChatInterface = () => {
       showError("Analysis failed", errorMsg);
       setMessages((prev) => prev.filter((m) => m !== userMessage));
     } finally {
+      if (streamAbortRef.current === abortController) {
+        streamAbortRef.current = null;
+      }
       setIsLoading(false);
       setSelectedFiles([]);
       if (fileInputRef.current) fileInputRef.current.value = "";
@@ -663,9 +693,9 @@ const ChatInterface = () => {
           {selectedFiles.length > 0 && (
             <div className="flex gap-2 mb-3 overflow-x-auto p-2 border border-border/50 rounded-xl bg-background/50">
               {selectedFiles.map((file, idx) => (
-                <div key={idx} className="relative shrink-0">
+                <div key={`${file.name}-${file.lastModified}-${idx}`} className="relative shrink-0">
                   <img
-                    src={URL.createObjectURL(file)}
+                    src={previewUrls[idx]}
                     alt={`Preview ${idx + 1}`}
                     className="w-16 h-16 object-cover rounded-md border border-border"
                   />

--- a/src/pages/Health/AIHealthAssistant.tsx
+++ b/src/pages/Health/AIHealthAssistant.tsx
@@ -80,17 +80,19 @@ const AIHealthAssistant = () => {
   const bottomRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const recognitionRef = useRef<ISpeechRecognition | null>(null);
+  const streamAbortRef = useRef<AbortController | null>(null);
   const { toast } = useToast();
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, loading]);
 
-  // Cleanup recognition and speech synthesis on unmount
+  // Cleanup recognition, speech synthesis, and in-flight chat stream on unmount
   useEffect(() => {
     return () => {
       recognitionRef.current?.abort();
       window.speechSynthesis?.cancel();
+      streamAbortRef.current?.abort();
     };
   }, []);
 
@@ -190,6 +192,10 @@ const AIHealthAssistant = () => {
     setMessages((prev) => [...prev, { role: "user", text: userMessage, time }]);
     setLoading(true);
 
+    streamAbortRef.current?.abort();
+    const abortController = new AbortController();
+    streamAbortRef.current = abortController;
+
     let assistantContent = "";
 
     const upsertAssistant = (chunk: string) => {
@@ -228,6 +234,7 @@ const AIHealthAssistant = () => {
         body: JSON.stringify({
           messages: [...recentContext, { role: "user", content: userMessage }],
         }),
+        signal: abortController.signal,
       });
 
       if (!response.ok || !response.body) {
@@ -366,6 +373,10 @@ const AIHealthAssistant = () => {
         }
       }
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        dismissLoading();
+        return;
+      }
       console.error("Chat error:", error);
       dismissLoading();
 
@@ -384,6 +395,9 @@ const AIHealthAssistant = () => {
       showError("Analysis failed", errorMessage);
       setMessages((prev) => prev.filter((m) => !(m.role === "user" && m.text === userMessage)));
     } finally {
+      if (streamAbortRef.current === abortController) {
+        streamAbortRef.current = null;
+      }
       setLoading(false);
     }
   };


### PR DESCRIPTION
## **Pull Request Description**
Chat streaming fetch had no AbortController, so navigating away left readers running. Image previews also called `createObjectURL` in render without revoke. Abort on unmount/new send and revoke preview URLs via memo + cleanup.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
Fixes #1104

---

### **3. How Has This Been Tested?**
- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. ChatInterface + AIHealthAssistant pass `signal` and abort on unmount.
  2. Preview URLs memoized and revoked in effect cleanup.

---

### **4. Visual Verification (If applicable)**
N/A

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.

Made with [Cursor](https://cursor.com)