### PR TITLE
fix: stop spoofable X-Forwarded-For rate-limit bypass

### DIFF
--- a/supabase/functions/_shared/rateLimit.ts
+++ b/supabase/functions/_shared/rateLimit.ts
@@ -12,6 +12,32 @@ const WINDOW_SIZE_MS = 60 * 1000;
 const MAX_REQUESTS = 10;
 let warnedAboutFallback = false;
 
+/**
+ * Resolve a rate-limit identity from request headers.
+ * Prefer platform-trusted IPs; never trust the leftmost X-Forwarded-For hop
+ * (client-controlled). When XFF is the only signal, use the rightmost entry.
+ */
+export function getClientIp(req: Request): string {
+  const cfConnecting = req.headers.get("cf-connecting-ip")?.trim();
+  if (cfConnecting) return cfConnecting;
+
+  const realIp = req.headers.get("x-real-ip")?.trim();
+  if (realIp) return realIp;
+
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const hops = forwarded
+      .split(",")
+      .map((h) => h.trim())
+      .filter(Boolean);
+    if (hops.length > 0) {
+      return hops[hops.length - 1];
+    }
+  }
+
+  return "unknown";
+}
+
 // Fallback 1: Database-backed global rate limiter (handles multi-isolate environments)
 async function databaseRateLimit(ip: string): Promise<{ success: boolean }> {
   const supabaseUrl = Deno.env.get("SUPABASE_URL");

--- a/supabase/functions/broadcast-emergency/index.ts
+++ b/supabase/functions/broadcast-emergency/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.7.1";
-import { rateLimit } from "../_shared/rateLimit.ts";
+import { rateLimit, getClientIp } from "../_shared/rateLimit.ts";
 
 const ALLOWED_ORIGINS = [
   "http://localhost:3000",
@@ -46,10 +46,7 @@ serve(async (req) => {
 
   try {
     // Enforce rate limiting before processing the request
-    const ip =
-      req.headers.get("x-forwarded-for") ||
-      req.headers.get("cf-connecting-ip") ||
-      "unknown";
+    const ip = getClientIp(req);
 
     const rateLimitResult = await rateLimit(ip);
     if (!rateLimitResult.success) {

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { rateLimit } from "../_shared/rateLimit.ts";
+import { rateLimit, getClientIp } from "../_shared/rateLimit.ts";
 
 const ALLOWED_ORIGINS = [
   "http://localhost:3000",
@@ -42,10 +42,7 @@ serve(async (req) => {
   }
 
   try {
-    const ip =
-      req.headers.get("x-forwarded-for") ||
-      req.headers.get("cf-connecting-ip") ||
-      "unknown";
+    const ip = getClientIp(req);
 
     const rateLimitResult = await rateLimit(ip);
     if (!rateLimitResult.success) {

--- a/supabase/functions/delete-user-account/index.ts
+++ b/supabase/functions/delete-user-account/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.7.1";
-import { rateLimit } from "../_shared/rateLimit.ts";
+import { rateLimit, getClientIp } from "../_shared/rateLimit.ts";
 
 const ALLOWED_ORIGINS = [
   "http://localhost:3000",
@@ -43,10 +43,7 @@ serve(async (req) => {
   }
 
   try {
-    const ip =
-      req.headers.get("x-forwarded-for") ||
-      req.headers.get("cf-connecting-ip") ||
-      "unknown";
+    const ip = getClientIp(req);
 
     const rateLimitResult = await rateLimit(ip);
     if (!rateLimitResult.success) {

--- a/supabase/functions/get-cached-data/index.ts
+++ b/supabase/functions/get-cached-data/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { redis } from "../_shared/redis.ts";
-import { rateLimit } from "../_shared/rateLimit.ts";
+import { rateLimit, getClientIp } from "../_shared/rateLimit.ts";
 
 const ALLOWED_ORIGINS = [
   "http://localhost:3000",
@@ -41,10 +41,7 @@ serve(async (req) => {
 
   try {
     // Rate limit check
-    const ip =
-      req.headers.get("x-forwarded-for") ||
-      req.headers.get("cf-connecting-ip") ||
-      "unknown";
+    const ip = getClientIp(req);
 
     const rateLimitResult = await rateLimit(ip);
     if (!rateLimitResult.success) {

--- a/supabase/functions/invalidate-cache/index.ts
+++ b/supabase/functions/invalidate-cache/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { redis } from "../_shared/redis.ts";
-import { rateLimit } from "../_shared/rateLimit.ts";
+import { rateLimit, getClientIp } from "../_shared/rateLimit.ts";
 
 const ALLOWED_ORIGINS = [
   "http://localhost:3000",
@@ -41,10 +41,7 @@ serve(async (req) => {
 
   try {
     // Rate limit check
-    const ip =
-      req.headers.get("x-forwarded-for") ||
-      req.headers.get("cf-connecting-ip") ||
-      "unknown";
+    const ip = getClientIp(req);
 
     const rateLimitResult = await rateLimit(ip);
     if (!rateLimitResult.success) {

--- a/supabase/functions/symptom-analyzer/index.ts
+++ b/supabase/functions/symptom-analyzer/index.ts
@@ -3,7 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 import { RequestSchema } from "./validation.ts";
 import { detectEmergencySymptoms } from "./medicalSafety.ts";
-import { rateLimit } from "../_shared/rateLimit.ts";
+import { rateLimit, getClientIp } from "../_shared/rateLimit.ts";
 import { jsonResponse } from "./utils.ts";
 
 const ALLOWED_ORIGINS = [
@@ -65,8 +65,7 @@ serve(async (req: Request): Promise<Response> => {
   }
 
   try {
-    const ip =
-      req.headers.get("x-forwarded-for") || req.headers.get("cf-connecting-ip") || "unknown";
+    const ip = getClientIp(req);
 
     const rateLimitResult = await rateLimit(ip);
 


### PR DESCRIPTION
## **Pull Request Description**
Edge functions keyed rate limits on leftmost `X-Forwarded-For`, which clients can forge. Centralize `getClientIp()` to prefer trusted platform headers and use the rightmost XFF hop as a last resort.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
Fixes #1105

---

### **3. How Has This Been Tested?**
- [ ] **Local Build**: The application builds successfully locally (`npm run build`).
- [ ] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. All edge functions now call `getClientIp(req)`.
  2. Helper prefers `cf-connecting-ip`, then `x-real-ip`, then rightmost XFF.

---

### **4. Visual Verification (If applicable)**
N/A

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.

Made with [Cursor](https://cursor.com)