### PR TITLE
fix: resolve hidden date columns and stray asterisks in CSV export (#1157)

### DIFF
--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -350,30 +350,57 @@ const History = () => {
 
   const exportCSV = () => {
     const headers = [
-  "Date",
-  "Symptoms",
-  "Severity",
-  "Risk Score",
-  "Possible Causes",
-  "Recommendations",
-  "Resolved",
-];
-    const rows = history.map((entry) => [
-  new Date(entry.created_at).toLocaleDateString(),
-  `"${entry.symptoms.replace(/"/g, '""')}"`,
-  entry.severity_level,
-  entry.risk_score,
-  `"${entry.possible_causes.join("; ").replace(/"/g, '""')}"`,
-  `"${entry.recommendations.join("; ").replace(/"/g, '""')}"`,
-  entry.resolved ? "Yes" : "No",
-]);
+      "Date",
+      "Symptoms",
+      "Severity",
+      "Risk Score",
+      "Possible Causes",
+      "Recommendations",
+      "Resolved",
+    ];
+    const rows = history.map((entry) => {
+      const date = new Date(entry.created_at);
+      const formattedDate = isNaN(date.getTime())
+        ? ""
+        : date.toLocaleDateString("en-US"); // consistent short format to avoid long locale-specific strings showing as ######## in Excel
+
+      const cleanText = (text: string) => {
+        if (!text) return "";
+        return stripMarkdownFormatting(text).replace(/\*/g, "");
+      };
+
+      const symptomsClean = cleanText(entry.symptoms);
+      const severity = entry.severity_level || "";
+      const riskScore = entry.risk_score !== undefined && entry.risk_score !== null ? entry.risk_score : "";
+
+      const possibleCausesClean = entry.possible_causes
+        ? entry.possible_causes.map((cause) => cleanText(cause)).join("; ")
+        : "";
+
+      const recommendationsClean = entry.recommendations
+        ? entry.recommendations.map((rec) => cleanText(rec)).join("; ")
+        : "";
+
+      const resolved = entry.resolved ? "Yes" : "No";
+
+      return [
+        formattedDate,
+        `"${symptomsClean.replace(/"/g, '""')}"`,
+        severity,
+        riskScore,
+        `"${possibleCausesClean.replace(/"/g, '""')}"`,
+        `"${recommendationsClean.replace(/"/g, '""')}"`,
+        resolved,
+      ];
+    });
+
     const csv = [headers, ...rows].map((r) => r.join(",")).join("\n");
-    const blob = new Blob([csv], { type: "text/csv" });
+    const blob = new Blob(["\ufeff" + csv], { type: "text/csv;charset=utf-8;" }); // UTF-8 BOM for Excel compatibility
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
     const date = new Date().toISOString().split("T")[0];
-a.download = `symptom-history-${date}.csv`;
+    a.download = `symptom-history-${date}.csv`;
     a.click();
     URL.revokeObjectURL(url);
   };


### PR DESCRIPTION
This PR resolves the two bugs reported in #1157:

1. **Hidden date columns**: Excel often displays  when localized date formats exceed the column width. We standardise the formatting to use the short `en-US` locale (`M/D/YYYY` format) and prepend a UTF-8 Byte Order Mark (`\ufeff`) to the CSV blob, resolving decoding and display quirks in Excel.
2. **Stray asterisks**: We now strip any markdown bold/italic formatting tags (`**` or `*`) from symptoms, possible causes, and recommendations before exporting.