### PR TITLE
docs: fix incorrect TROUBLESHOOTING.md reference to match actual TROU…

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ Play brain-training games.
 For detailed troubleshooting instructions, see:
 
 ```text
-TROUBLESHOOTING.md
+TROUBLESHOOT.md
 ```
 
 Common issues include:


### PR DESCRIPTION
## **Pull Request Description**
Fixed an incorrect file reference in README.md — the Troubleshooting section pointed to `TROUBLESHOOTING.md`, but the actual file listed in the Project Structure is `TROUBLESHOOT.md`.

---
### **1. Type of Change**
- [x] **Documentation Update** (changes to README, guides, or comments)

---
### **2. Related Issue**
- Fixes #None (just a documentation quick fix )

---
### **3. How Has This Been Tested?**
- [x] **Manual Verification**: Cross-checked the filename against the Project Structure section in the same README.
  1. Confirmed `TROUBLESHOOT.md` is the actual file listed in Project Structure
  2. Updated the Troubleshooting section reference to match

---
### **4. Visual Verification (If applicable)**
N/A — documentation-only fix.

---
### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.