### PR TITLE
fix: change date format to DD/MM/YYYY

### DIFF
--- a/src/components/history/SymptomCalendarView.tsx
+++ b/src/components/history/SymptomCalendarView.tsx
@@ -606,7 +606,7 @@ export const SymptomCalendarView = ({
                               <AlertDialogTitle>Delete Symptom Entry?</AlertDialogTitle>
                               <AlertDialogDescription>
                                 Are you sure you want to delete this entry logged on{" "}
-                                {new Date(entry.created_at).toLocaleDateString()}?
+                                {new Date(entry.created_at).toLocaleDateString("en-GB")}?
                               </AlertDialogDescription>
                             </AlertDialogHeader>
                             <AlertDialogFooter>

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -522,7 +522,7 @@ const Dashboard = () => {
                   <div className="flex-1">
                     <p className="font-medium text-sm">{item.symptoms.substring(0, 60)}...</p>
                     <p className="text-xs text-muted-foreground mt-1">
-                      {new Date(item.created_at).toLocaleDateString()}
+                      {new Date(item.created_at).toLocaleDateString("en-GB")}
                     </p>
                   </div>
                   <div className="flex items-center gap-2">

--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -413,7 +413,7 @@ const History = () => {
 
     doc.setFontSize(10);
     doc.setTextColor(100);
-    const generatedOn = new Date().toLocaleString();
+    const generatedOn = new Date().toLocaleString("en-GB");
     doc.text(`Generated on: ${generatedOn}`, 14, 25);
 
     if (history.length > 0) {
@@ -660,7 +660,7 @@ const History = () => {
                       <div className="flex-1 min-w-0">
                         <CardTitle className="text-lg break-words">{entry.symptoms}</CardTitle>
                         <p className="text-sm text-muted-foreground">
-                          {new Date(entry.created_at).toLocaleString()}
+                          {new Date(entry.created_at).toLocaleString("en-GB")}
                         </p>
                       </div>
                       <div className="flex flex-wrap items-center gap-2 shrink-0">

--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -362,7 +362,7 @@ const History = () => {
       const date = new Date(entry.created_at);
       const formattedDate = isNaN(date.getTime())
         ? ""
-        : date.toLocaleDateString("en-US"); // consistent short format to avoid long locale-specific strings showing as ######## in Excel
+        : date.toLocaleDateString("en-GB"); // consistent short format to avoid long locale-specific strings showing as ######## in Excel
 
       const cleanText = (text: string) => {
         if (!text) return "";
@@ -419,10 +419,10 @@ const History = () => {
     if (history.length > 0) {
       const oldestDate = new Date(
         Math.min(...history.map((e) => new Date(e.created_at).getTime()))
-      ).toLocaleDateString();
+      ).toLocaleDateString("en-GB");
       const newestDate = new Date(
         Math.max(...history.map((e) => new Date(e.created_at).getTime()))
-      ).toLocaleDateString();
+      ).toLocaleDateString("en-GB");
       doc.text(`Date range: ${oldestDate} - ${newestDate}`, 14, 31);
       doc.text(`Total entries: ${history.length}`, 14, 37);
     }
@@ -431,7 +431,7 @@ const History = () => {
       startY: 44,
       head: [["Date", "Symptoms", "Severity", "Risk Score", "Status"]],
       body: history.map((entry) => [
-        new Date(entry.created_at).toLocaleDateString(),
+        new Date(entry.created_at).toLocaleDateString("en-GB"),
         entry.symptoms,
         entry.severity_level,
         `${entry.risk_score}/100`,


### PR DESCRIPTION
## **Pull Request Description**
This PR fixes the bug where dates were incorrectly formatted as `MM/DD/YYYY` across the application. The logic has been updated to use the `"en-GB"` locale in `toLocaleDateString` configs to ensure all dates are uniformly displayed in the expected `DD/MM/YYYY` format natively, without the need for additional third-party dependencies.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #1162

---

### **3. How Has This Been Tested?**
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: 
  1. Navigated to the **Dashboard** and verified the recent symptom entries' dates are rendered as DD/MM/YYYY.
  2. Verified the **History** table page and CSV/PDF export formats are successfully applying the new DD/MM/YYYY format globally.

---

### **4. Visual Verification (If applicable)**
<img width="1634" height="537" alt="image" src="https://github.com/user-attachments/assets/a055be75-3af4-4ca1-9de3-9bc4f350b68e" />


---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
