### PR TITLE
security(1085): store P2P emergency signing key non-extractable in In…

### DIFF
--- a/src/lib/encryption.test.ts
+++ b/src/lib/encryption.test.ts
@@ -9,6 +9,8 @@ import {
   deriveKeyFromToken,
   deriveSearchKeyFromToken,
   rotateKeysToNewPassword,
+  getP2PSigningKeys,
+  registerP2PKeyStorage,
 } from "./encryption";
 
 describe("Encryption Key Persistence", () => {
@@ -64,5 +66,52 @@ describe("Encryption Key Persistence", () => {
     expect(getKey()).not.toBeNull();
     expect(getSearchKey()).not.toBeNull();
     expect(localStorage.getItem("symptom_scribe_master_seed_user-123")).toBeTruthy();
+  });
+});
+
+describe("P2P Emergency Signing Keys", () => {
+  beforeEach(() => {
+    localStorage.removeItem("symptom_scribe_p2p_private_key");
+    localStorage.removeItem("symptom_scribe_p2p_public_key");
+  });
+
+  it("generates a non-extractable signing keypair, persists it, and removes legacy localStorage JWKs (issue #1085)", async () => {
+    // Seed the plaintext JWKs the pre-#1085 implementation left in localStorage.
+    localStorage.setItem("symptom_scribe_p2p_private_key", "legacy-private-jwk");
+    localStorage.setItem("symptom_scribe_p2p_public_key", "legacy-public-jwk");
+
+    // Simulate the IndexedDB-backed store that offline-db.ts registers.
+    let stored: { privateKey: CryptoKey; publicKey: CryptoKey } | null = null;
+    registerP2PKeyStorage({
+      load: async () => stored,
+      save: async (privateKey, publicKey) => {
+        stored = { privateKey, publicKey };
+      },
+    });
+
+    const keys = await getP2PSigningKeys();
+
+    // Private half must never be exportable; public half stays shareable.
+    expect(keys.privateKey.extractable).toBe(false);
+    expect(keys.publicKey.extractable).toBe(true);
+    expect(keys.privateKey.usages).toContain("sign");
+    expect(keys.publicKey.usages).toContain("verify");
+
+    // The pair must be handed to the store for IndexedDB persistence.
+    expect(stored).not.toBeNull();
+    expect(stored!.privateKey).toBe(keys.privateKey);
+    expect(stored!.publicKey).toBe(keys.publicKey);
+
+    // Legacy plaintext JWKs must be scrubbed from localStorage.
+    expect(localStorage.getItem("symptom_scribe_p2p_private_key")).toBeNull();
+    expect(localStorage.getItem("symptom_scribe_p2p_public_key")).toBeNull();
+
+    // A second call loads the persisted pair instead of regenerating.
+    const reloaded = await getP2PSigningKeys();
+    expect(reloaded.privateKey).toBe(keys.privateKey);
+    expect(reloaded.publicKey).toBe(keys.publicKey);
+
+    // Sanity check: exporting the non-extractable private key must fail.
+    await expect(crypto.subtle.exportKey("jwk", keys.privateKey)).rejects.toThrow();
   });
 });

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -667,38 +667,48 @@ function looksEncrypted(value: string): boolean {
 }
 
 // ─── P2P Emergency Mesh Signatures ──────────────────────────────────────────
-export async function getP2PSigningKeys(): Promise<{ privateKey: CryptoKey; publicKey: CryptoKey }> {
-  const storedPrivate = localStorage.getItem("symptom_scribe_p2p_private_key");
-  const storedPublic = localStorage.getItem("symptom_scribe_p2p_public_key");
+//
+// The ECDSA P-256 private key used to sign emergency mesh alerts is generated
+// as *non-extractable* (`extractable: false`), so it can never be exported
+// (e.g. as a JWK) by a compromised script, extension, or injected library.
+// Persistence is delegated to IndexedDB via `registerP2PKeyStorage` (see
+// offline-db.ts): IndexedDB's structured-clone algorithm can store
+// non-extractable CryptoKey objects, so the key survives reloads without ever
+// existing as portable key material outside the browser. Only the public key
+// remains extractable, and only its JWK is ever shared (broadcast with
+// alerts so peers can verify the signature).
+//
+// This replaces the previous implementation (issue #1085) which stored the
+// private key as a plaintext, extractable JWK in localStorage under
+// `symptom_scribe_p2p_private_key` — any XSS/extension with localStorage
+// access could exfiltrate it and forge emergency alerts.
 
-  if (storedPrivate && storedPublic) {
-    try {
-      const privateJwk = JSON.parse(storedPrivate);
-      const publicJwk = JSON.parse(storedPublic);
+type P2PKeyPair = { privateKey: CryptoKey; publicKey: CryptoKey };
 
-      const privateKey = await crypto.subtle.importKey(
-        "jwk",
-        privateJwk,
-        { name: "ECDSA", namedCurve: "P-256" },
-        true,
-        ["sign"]
-      );
+type P2PKeyStorage = {
+  load: () => Promise<P2PKeyPair | null>;
+  save: (privateKey: CryptoKey, publicKey: CryptoKey) => Promise<void>;
+};
 
-      const publicKey = await crypto.subtle.importKey(
-        "jwk",
-        publicJwk,
-        { name: "ECDSA", namedCurve: "P-256" },
-        true,
-        ["verify"]
-      );
+let p2pKeyStorage: P2PKeyStorage | null = null;
+let cachedP2PKeys: P2PKeyPair | null = null;
 
-      return { privateKey, publicKey };
-    } catch (err) {
-      console.warn("Failed to load stored P2P keys, generating new ones:", err);
-    }
-  }
+/**
+ * Registers the IndexedDB-backed persistence for the P2P signing keypair.
+ * Called by offline-db.ts during module initialization; kept behind a
+ * registration hook so encryption.ts never imports the Dexie module directly
+ * (avoiding a circular dependency).
+ */
+export function registerP2PKeyStorage(storage: P2PKeyStorage): void {
+  p2pKeyStorage = storage;
+}
 
-  // Generate new ECDSA P-256 keypair
+// Generates an ECDSA P-256 keypair whose *private* half is non-extractable.
+// `crypto.subtle.generateKey` applies one extractability flag to the whole
+// pair, so the private JWK is exported in memory only and immediately
+// re-imported with `extractable: false`. The public half stays extractable so
+// its JWK can be attached to broadcast alerts for signature verification.
+async function generateNonExtractableP2PKeyPair(): Promise<P2PKeyPair> {
   const keyPair = await crypto.subtle.generateKey(
     {
       name: "ECDSA",
@@ -709,15 +719,54 @@ export async function getP2PSigningKeys(): Promise<{ privateKey: CryptoKey; publ
   );
 
   const privateJwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);
-  const publicJwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+  const privateKey = await crypto.subtle.importKey(
+    "jwk",
+    privateJwk,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"]
+  );
 
-  localStorage.setItem("symptom_scribe_p2p_private_key", JSON.stringify(privateJwk));
-  localStorage.setItem("symptom_scribe_p2p_public_key", JSON.stringify(publicJwk));
+  return { privateKey, publicKey: keyPair.publicKey };
+}
 
-  return {
-    privateKey: keyPair.privateKey,
-    publicKey: keyPair.publicKey,
-  };
+export async function getP2PSigningKeys(): Promise<P2PKeyPair> {
+  // Remove any plaintext JWK copies left behind by the pre-#1085
+  // implementation. Nothing reads them anymore, and the private key must
+  // never live in localStorage.
+  localStorage.removeItem("symptom_scribe_p2p_private_key");
+  localStorage.removeItem("symptom_scribe_p2p_public_key");
+
+  // 1. Prefer the IndexedDB-persisted keypair (survives reloads; other tabs
+  //    of the same origin share it). If IndexedDB access fails (e.g. private
+  //    browsing / disabled storage), fall back to cache or a fresh pair so an
+  //    emergency alert can still be signed.
+  if (p2pKeyStorage) {
+    try {
+      const stored = await p2pKeyStorage.load();
+      if (stored) {
+        cachedP2PKeys = stored;
+        return stored;
+      }
+    } catch (err) {
+      console.warn("Failed to load P2P signing keys from IndexedDB; using in-memory keys:", err);
+    }
+  }
+
+  // 2. Fall back to the in-memory cache (used when no store is registered).
+  if (cachedP2PKeys) return cachedP2PKeys;
+
+  // 3. Generate a fresh non-extractable pair and persist it.
+  const keys = await generateNonExtractableP2PKeyPair();
+  cachedP2PKeys = keys;
+  if (p2pKeyStorage) {
+    try {
+      await p2pKeyStorage.save(keys.privateKey, keys.publicKey);
+    } catch (err) {
+      console.warn("Failed to persist P2P signing keys to IndexedDB:", err);
+    }
+  }
+  return keys;
 }
 
 export async function signPayload(payload: string, privateKey: CryptoKey): Promise<string> {

--- a/src/lib/offline-db.ts
+++ b/src/lib/offline-db.ts
@@ -6,6 +6,7 @@ import {
   decryptText,
   whenEncryptionReady,
   registerEncryptionHooks,
+  registerP2PKeyStorage,
   getSearchKey,
   generateSearchTokens,
 } from "./encryption";
@@ -54,10 +55,27 @@ export interface MeshAlert {
   pending_sync: number;
 }
 
+/**
+ * Persisted P2P emergency-signing keypair (issue #1085).
+ *
+ * The private key is generated as *non-extractable*, so it can never be
+ * exported (e.g. as a JWK) and exfiltrated by a script with localStorage
+ * access. IndexedDB's structured-clone algorithm can still persist such
+ * CryptoKey objects, which is how the key survives reloads without ever
+ * leaving the browser as key material.
+ */
+export interface P2PKeyRecord {
+  id: string;
+  privateKey: CryptoKey;
+  publicKey: CryptoKey;
+  createdAt: string;
+}
+
 class OfflineDatabase extends Dexie {
   healthMetrics!: Table<OfflineMetric>;
   symptomHistory!: Table<OfflineSymptom>;
   pendingEmergencyMesh!: Table<MeshAlert>;
+  p2pKeys!: Table<P2PKeyRecord>;
 
   constructor() {
     super("SymptomScribeOfflineDB");
@@ -69,6 +87,12 @@ class OfflineDatabase extends Dexie {
       healthMetrics: "id, user_id, metric_type, recorded_at, pending_sync, pending_delete",
       symptomHistory: "id, user_id, severity_level, created_at, pending_sync, pending_update, pending_delete",
       pendingEmergencyMesh: "id, sender_id, timestamp, pending_sync",
+    });
+    this.version(3).stores({
+      healthMetrics: "id, user_id, metric_type, recorded_at, pending_sync, pending_delete",
+      symptomHistory: "id, user_id, severity_level, created_at, pending_sync, pending_update, pending_delete",
+      pendingEmergencyMesh: "id, sender_id, timestamp, pending_sync",
+      p2pKeys: "id",
     });
   }
 }
@@ -336,6 +360,32 @@ registerEncryptionHooks({
     } catch (err) {
       console.error("Failed to re-encrypt server-side data after key rotation:", err);
     }
+  },
+});
+
+// ─── P2P signing-key persistence (issue #1085) ───────────────────────────────
+// The P2P emergency-signing keypair is generated as non-extractable (the
+// private half can never be exported) and persisted in IndexedDB via
+// structured clone — mirroring how the rest of the app treats key material.
+// A compromised script with localStorage access can no longer read the
+// signing key as a plaintext JWK.
+const P2P_KEY_STORE_ID = "p2p-signing-key";
+
+registerP2PKeyStorage({
+  load: async () => {
+    const record = await db.p2pKeys.get(P2P_KEY_STORE_ID);
+    if (record?.privateKey && record?.publicKey) {
+      return { privateKey: record.privateKey, publicKey: record.publicKey };
+    }
+    return null;
+  },
+  save: async (privateKey, publicKey) => {
+    await db.p2pKeys.put({
+      id: P2P_KEY_STORE_ID,
+      privateKey,
+      publicKey,
+      createdAt: new Date().toISOString(),
+    });
   },
 });
 


### PR DESCRIPTION
…dexedDB

## **Pull Request Description**
A clear and concise description of the changes introduced by this pull request.

Fixes a security issue where the ECDSA P-256 private key used to sign P2P emergency mesh alerts was stored as a **plaintext, extractable JWK in localStorage** (`symptom_scribe_p2p_private_key`). Any XSS, browser extension, or compromised third-party script with localStorage access could exfiltrate the signing key and forge emergency alerts / relayed broadcasts under the victim's identity.
### **3. Changes Made**
 
1. **`src/lib/encryption.ts`** — `getP2PSigningKeys()` rewritten:
   - The private key is now **non-extractable** (`extractable: false`, usages `["sign"]`). WebCrypto's `generateKey` applies one extractability flag to the whole pair, so the code generates the pair, exports the private JWK **in memory only**, and immediately re-imports it with `extractable: false`. The **public** key stays extractable (`["verify"]`) so its JWK can still be attached to broadcast alerts for peer verification.
   - Persistence is delegated to a new `registerP2PKeyStorage()` hook (injected by `offline-db.ts`, avoiding a circular import) → the keypair is stored in **IndexedDB** via structured clone, which can persist non-extractable `CryptoKey` objects. The key survives reloads and is shared across same-origin tabs **without ever existing as portable key material**.
   - **Legacy plaintext JWKs are scrubbed from localStorage** on every call.
   - IndexedDB load/save failures fall back to in-memory keys so an emergency alert can always be signed.
 
2. **`src/lib/offline-db.ts`** — new `p2pKeys` Dexie table (**version 3**, re-declaring all stores for a correct migration) storing `P2PKeyRecord { id, privateKey, publicKey, createdAt }`, plus registration of the load/save callbacks.
 
3. **`src/lib/encryption.test.ts`** — regression test covering: private key non-extractable / public extractable, keypair handed to the registered store, legacy localStorage JWKs removed, reload returning the same persisted pair, and `exportKey` on the private key rejecting.
 
---
 
### **4. Impact / Verification**
 
**Security posture**
- **Deliberate key rotation:** the legacy localStorage key is presumed compromised (it sat as a plaintext JWK), so the code generates a fresh pair instead of migrating it — a stolen old key becomes useless for new alerts.
- **No verification breakage:** every mesh alert embeds its own `publicKeyJwk`, so existing broadcast alerts verify independently of the local key identity.
- **`mesh-network.ts` required zero changes** — verified it only exports the *public* JWK for broadcasting and signs with the private key; the non-extractable private key is never exported anywhere.
 

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [x] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #1085 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).


---

### **4. Visual Verification (If applicable)**
If this PR includes frontend or layout changes, please add screenshots, GIFs, or video recordings showing the before/after behavior.

| Before | After |
| :--- | :--- |
| (Insert image/GIF here) | (Insert image/GIF here) |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
