### PR TITLE
fix: prevent offline fallback by stripping images property before Sup…

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -401,7 +401,7 @@ const ChatInterface = () => {
           );
 
           // Strip offline-only fields so we match the Supabase table schema
-          const { pending_sync, pending_update, pending_delete, ...supabaseRecord } =
+          const { pending_sync, pending_update, pending_delete, images, ...supabaseRecord } =
             encryptedRecord;
 
           const { error: insertError } = await supabase

--- a/src/lib/offline-db.ts
+++ b/src/lib/offline-db.ts
@@ -39,6 +39,7 @@ export interface OfflineSymptom {
   pending_delete: number;
   ai_analysis?: string;
   search_tokens?: string[] | null;
+  images?: string[] | null;
 }
 
 export interface MeshAlert {
@@ -460,7 +461,7 @@ export const syncOfflineData = async (): Promise<boolean> => {
       .toArray();
 
     for (const record of pendingSymptomInserts) {
-      const { pending_sync, pending_delete, pending_update, ...supabaseData } = record;
+      const { pending_sync, pending_delete, pending_update, images, ...supabaseData } = record;
       const { error } = await supabase
         .from("symptom_history")
         .insert(supabaseData as unknown as TablesInsert<"symptom_history">);


### PR DESCRIPTION
## **Pull Request Description**
Fixes an issue where submitting a symptom analysis with attached images caused the server request to fail (due to an undefined `images` column in the `symptom_history` table) and forced the application to fall back to an offline state. The fix adds `images` to the `OfflineSymptom` type definition and properly strips it from the payload before inserting records into Supabase, resolving the data persistence issue and ensuring successful server sync.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes the data persistence/offline fallback issue reported by the maintainer.

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Verified that the `images` property is successfully isolated and stripped from the payload sent to `supabase.from("symptom_history").insert()`.
  2. Verified that the background `syncOfflineData` loop correctly strips the `images` property before syncing pending local insertions, preventing recurring background sync errors.

---



### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
