### PR TITLE
feat: Add Retry Policy and Exponential Backoff for Offline Data Synch…

### DIFF
--- a/src/lib/offline-db.test.ts
+++ b/src/lib/offline-db.test.ts
@@ -1,0 +1,188 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/ban-ts-comment */
+import { describe, it, beforeEach, vi, expect } from "vitest";
+
+// Mock supabase client
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user1" } } }) },
+    from: vi.fn(() => ({ insert: vi.fn(), delete: vi.fn(), update: vi.fn() })),
+  },
+}));
+
+// Mock encryption readiness
+vi.mock("./encryption", () => ({
+  whenEncryptionReady: vi.fn().mockResolvedValue({}),
+  registerEncryptionHooks: vi.fn(() => {}),
+  registerP2PKeyStorage: vi.fn(() => {}),
+  encryptMetric: (r: any) => r,
+  decryptMetric: (r: any) => r,
+  encryptSymptom: (r: any) => r,
+  decryptSymptom: (r: any) => r,
+  getSearchKey: () => null,
+  generateSearchTokens: async () => [],
+}));
+
+// Import the module under test after mocks are registered
+import * as offline from "./offline-db";
+
+describe("syncOfflineData retry behavior", () => {
+  let originalNavigator: any;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // ensure online by default
+    originalNavigator = global.navigator;
+    // @ts-ignore
+    global.navigator = { onLine: true };
+
+    // Replace DB tables with spies (where() will be configured per-test)
+    (offline.db as any).healthMetrics = {
+      where: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      put: vi.fn(),
+      clear: vi.fn(),
+      toArray: vi.fn(),
+    };
+
+    (offline.db as any).symptomHistory = {
+      where: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      put: vi.fn(),
+      clear: vi.fn(),
+      toArray: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    // restore navigator
+    // @ts-ignore
+    global.navigator = originalNavigator;
+  });
+
+  it("skips sync when offline", async () => {
+    // @ts-ignore
+    global.navigator = { onLine: false };
+    const res = await offline.syncOfflineData();
+    expect(res).toBe(false);
+  });
+
+  it("schedules retry on network failure for inserts", async () => {
+    const record = { id: "m1", pending_sync: 1, retry_attempts: 0 } as any;
+    // make where(...).equals(1).toArray return our record
+    (offline.db as any).healthMetrics.where.mockImplementation((field: string) => ({ equals: vi.fn((val: any) => ({ toArray: vi.fn().mockResolvedValue(field === "pending_sync" ? [record] : []) })) }));
+
+    const supabase = (await import("@/integrations/supabase/client")).supabase;
+    const insertMock = vi.fn().mockResolvedValue({ error: { message: "Network failure" } });
+    supabase.from.mockReturnValue({
+      insert: insertMock,
+      delete: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+      update: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+    });
+
+    await offline.syncOfflineData();
+
+    // First update call should mark an attempt
+    expect((offline.db as any).healthMetrics.update).toHaveBeenCalled();
+    // The update after failure should write last_sync_error and next_retry_at
+    const calls = (offline.db as any).healthMetrics.update.mock.calls;
+    const lastCallArgs = calls[calls.length - 1][1];
+    expect(lastCallArgs).toHaveProperty("last_sync_error");
+    expect(lastCallArgs).toHaveProperty("next_retry_at");
+  });
+
+  it("treats 5xx as retryable and schedules next_retry_at", async () => {
+    const record = { id: "m2", pending_sync: 1, retry_attempts: 1 } as any;
+    (offline.db as any).healthMetrics.where.mockImplementation((field: string) => ({ equals: vi.fn((val: any) => ({ toArray: vi.fn().mockResolvedValue(field === "pending_sync" ? [record] : []) })) }));
+
+    const supabase = (await import("@/integrations/supabase/client")).supabase;
+    const insertMock = vi.fn().mockResolvedValue({ error: { status: 502, message: "Bad gateway" } });
+    supabase.from.mockReturnValue({
+      insert: insertMock,
+      delete: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+      update: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+    });
+
+    await offline.syncOfflineData();
+
+    const lastCallArgs = (offline.db as any).healthMetrics.update.mock.calls.pop()[1];
+    expect(lastCallArgs).toHaveProperty("next_retry_at");
+  });
+
+  it("treats 4xx as permanent and clears next_retry_at", async () => {
+    const record = { id: "m3", pending_sync: 1, retry_attempts: 2 } as any;
+    (offline.db as any).healthMetrics.where.mockImplementation((field: string) => ({ equals: vi.fn((val: any) => ({ toArray: vi.fn().mockResolvedValue(field === "pending_sync" ? [record] : []) })) }));
+
+    const supabase = (await import("@/integrations/supabase/client")).supabase;
+    const insertMock = vi.fn().mockResolvedValue({ error: { status: 400, message: "Bad request" } });
+    supabase.from.mockReturnValue({
+      insert: insertMock,
+      delete: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+      update: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+    });
+
+    await offline.syncOfflineData();
+
+    const lastCallArgs = (offline.db as any).healthMetrics.update.mock.calls.pop()[1];
+    expect(lastCallArgs.next_retry_at).toBeNull();
+    expect(lastCallArgs).toHaveProperty("last_sync_error");
+  });
+
+  it("resets retry metadata on success", async () => {
+    const record = { id: "m4", pending_sync: 1, retry_attempts: 3, last_sync_error: "err" } as any;
+    (offline.db as any).healthMetrics.where.mockImplementation((field: string) => ({ equals: vi.fn((val: any) => ({ toArray: vi.fn().mockResolvedValue(field === "pending_sync" ? [record] : []) })) }));
+
+    const supabase = (await import("@/integrations/supabase/client")).supabase;
+    const insertMock = vi.fn().mockResolvedValue({ error: null });
+    supabase.from.mockReturnValue({
+      insert: insertMock,
+      delete: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+      update: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+    });
+
+    await offline.syncOfflineData();
+
+    const lastCallArgs = (offline.db as any).healthMetrics.update.mock.calls.pop()[1];
+    expect(lastCallArgs.pending_sync).toBe(0);
+    expect(lastCallArgs.retry_attempts).toBe(0);
+    expect(lastCallArgs.next_retry_at).toBeNull();
+    expect(lastCallArgs.last_sync_error).toBeNull();
+  });
+
+  it("skips records whose next_retry_at is in the future", async () => {
+    const future = Date.now() + 1000000;
+    const record = { id: "m5", pending_sync: 1, next_retry_at: future } as any;
+    (offline.db as any).healthMetrics.where.mockImplementation((field: string) => ({ equals: vi.fn((val: any) => ({ toArray: vi.fn().mockResolvedValue(field === "pending_sync" ? [record] : []) })) }));
+
+    const supabase = (await import("@/integrations/supabase/client")).supabase;
+    const insertMock = vi.fn().mockResolvedValue({ error: null });
+    supabase.from.mockReturnValue({ insert: insertMock });
+
+    await offline.syncOfflineData();
+
+    // insert should not be called because record is skipped
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("ensures single-flight: concurrent calls only trigger one sync pass", async () => {
+    const record = { id: "m6", pending_sync: 1 } as any;
+    (offline.db as any).healthMetrics.where.mockReturnValue({ equals: vi.fn(() => ({ toArray: vi.fn().mockResolvedValue([record]) })) });
+
+    const supabase = (await import("@/integrations/supabase/client")).supabase;
+    // insert returns a promise that resolves after a tick
+    const insertMock = vi.fn().mockImplementation(() => new Promise((res) => setTimeout(() => res({ error: null }), 10)));
+    supabase.from.mockReturnValue({
+      insert: insertMock,
+      delete: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+      update: vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) })),
+    });
+
+    const p1 = offline.syncOfflineData();
+    const p2 = offline.syncOfflineData();
+
+    await Promise.all([p1, p2]);
+
+    // insert should be called only once
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/offline-db.ts
+++ b/src/lib/offline-db.ts
@@ -11,6 +11,11 @@ import {
   generateSearchTokens,
 } from "./encryption";
 import { invalidateCache } from "@/lib/cached-queries";
+import {
+  isRetryableError,
+  calculateNextRetryDelayMs,
+  MAX_RETRY_ATTEMPTS,
+} from "./sync-retry";
 
 export interface OfflineMetric {
   id: string;
@@ -22,6 +27,11 @@ export interface OfflineMetric {
   pending_sync: number;
   pending_delete: number;
   search_tokens?: string[] | null;
+  // Retry metadata (local-only)
+  retry_attempts?: number;
+  last_attempt_at?: number | null;
+  next_retry_at?: number | null;
+  last_sync_error?: string | null;
 }
 
 export interface OfflineSymptom {
@@ -40,6 +50,11 @@ export interface OfflineSymptom {
   ai_analysis?: string;
   search_tokens?: string[] | null;
   images?: string[] | null;
+  // Retry metadata (local-only)
+  retry_attempts?: number;
+  last_attempt_at?: number | null;
+  next_retry_at?: number | null;
+  last_sync_error?: string | null;
 }
 
 export interface MeshAlert {
@@ -95,10 +110,28 @@ class OfflineDatabase extends Dexie {
       pendingEmergencyMesh: "id, sender_id, timestamp, pending_sync",
       p2pKeys: "id",
     });
+    // Version 4: add retry metadata fields to records (fields are optional
+    // so existing records continue to work). Keep same indexes/stores.
+    this.version(4).stores({
+      healthMetrics: "id, user_id, metric_type, recorded_at, pending_sync, pending_delete",
+      symptomHistory: "id, user_id, severity_level, created_at, pending_sync, pending_update, pending_delete",
+      pendingEmergencyMesh: "id, sender_id, timestamp, pending_sync",
+      p2pKeys: "id",
+    });
   }
 }
 
 export const db = new OfflineDatabase();
+
+let syncInFlight: Promise<boolean> | null = null;
+
+function stripLocalFields<T extends Record<string, unknown>>(record: T, fields: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(record)) {
+    if (!fields.includes(k)) out[k] = v as unknown;
+  }
+  return out;
+}
 
 // Encryption and Decryption Mappers
 export async function encryptSymptom(
@@ -134,6 +167,12 @@ export async function encryptSymptom(
       `enc:json:${await encryptText(JSON.stringify(record.recommendations), key)}`,
     ];
   }
+  // Ensure retry metadata defaults for new records (local-only)
+  if (encrypted.retry_attempts === undefined) encrypted.retry_attempts = 0;
+  if (encrypted.last_attempt_at === undefined) encrypted.last_attempt_at = null;
+  if (encrypted.next_retry_at === undefined) encrypted.next_retry_at = null;
+  if (encrypted.last_sync_error === undefined) encrypted.last_sync_error = null;
+
   return encrypted;
 }
 
@@ -183,6 +222,12 @@ export async function encryptMetric(
       encrypted.search_tokens = await generateSearchTokens(record.notes, actualSearchKey);
     }
   }
+  // Ensure retry metadata defaults for new records (local-only)
+  if (encrypted.retry_attempts === undefined) encrypted.retry_attempts = 0;
+  if (encrypted.last_attempt_at === undefined) encrypted.last_attempt_at = null;
+  if (encrypted.next_retry_at === undefined) encrypted.next_retry_at = null;
+  if (encrypted.last_sync_error === undefined) encrypted.last_sync_error = null;
+
   return encrypted;
 }
 
@@ -393,113 +438,243 @@ registerP2PKeyStorage({
 export const syncOfflineData = async (): Promise<boolean> => {
   if (!navigator.onLine) return false;
 
-  try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return false;
+  if (syncInFlight) return syncInFlight;
 
-    const key = await whenEncryptionReady();
-    let syncedAny = false;
+  syncInFlight = (async () => {
+    try {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) return false;
 
-    // 1. Sync pending health metrics deletions
-    const pendingMetricsDeletes = await db.healthMetrics
-      .where("pending_delete")
-      .equals(1)
-      .toArray();
+        const key = await whenEncryptionReady();
+        let syncedAny = false;
 
-    for (const record of pendingMetricsDeletes) {
-      const { error } = await supabase
-        .from("health_metrics")
-        .delete()
-        .eq("id", record.id);
+        // Helper to extract safe error message
+        const safeMessage = (err: unknown) => {
+          try {
+            if (!err) return "";
+            if (err instanceof Error) return err.message;
+            const asObj = err as Record<string, unknown>;
+            const msg = asObj?.["message"];
+            if (typeof msg === "string") return msg;
+            return String(asObj);
+          } catch (e) {
+            return String(err);
+          }
+        };
 
-      if (!error || error.code === "PGRST116") {
-        await db.healthMetrics.delete(record.id);
-        syncedAny = true;
+        // 1. Sync pending health metrics deletions
+        const pendingMetricsDeletes = await db.healthMetrics
+          .where("pending_delete")
+          .equals(1)
+          .toArray();
+
+        for (const record of pendingMetricsDeletes) {
+          // Skip if waiting for next retry
+          if (record.next_retry_at && Date.now() < record.next_retry_at) continue;
+
+          // mark attempt
+          const attempts = (record.retry_attempts ?? 0) + 1;
+          const now = Date.now();
+          await db.healthMetrics.update(record.id, { retry_attempts: attempts, last_attempt_at: now });
+
+          const { error } = await supabase
+            .from("health_metrics")
+            .delete()
+            .eq("id", record.id);
+
+          if (!error || error.code === "PGRST116") {
+            await db.healthMetrics.delete(record.id);
+            syncedAny = true;
+          } else {
+            const msg = safeMessage(error);
+            if (isRetryableError(error) && attempts < MAX_RETRY_ATTEMPTS) {
+              const delay = calculateNextRetryDelayMs(attempts);
+              await db.healthMetrics.update(record.id, {
+                last_sync_error: msg,
+                next_retry_at: Date.now() + delay,
+              });
+            } else {
+              // Permanent failure: record error and stop retrying for now.
+              await db.healthMetrics.update(record.id, { last_sync_error: msg, next_retry_at: null });
+            }
+          }
+        }
+
+        // 2. Sync pending health metrics insertions
+        const pendingMetricsInserts = await db.healthMetrics
+          .where("pending_sync")
+          .equals(1)
+          .toArray();
+
+        for (const record of pendingMetricsInserts) {
+          if (record.next_retry_at && Date.now() < record.next_retry_at) continue;
+
+          const attempts = (record.retry_attempts ?? 0) + 1;
+          const now = Date.now();
+          await db.healthMetrics.update(record.id, { retry_attempts: attempts, last_attempt_at: now });
+
+          const supabaseData = stripLocalFields(record as Record<string, unknown>, [
+            "pending_sync",
+            "pending_delete",
+            "retry_attempts",
+            "last_attempt_at",
+            "next_retry_at",
+            "last_sync_error",
+          ]) as unknown as TablesInsert<"health_metrics">;
+          const { error } = await supabase.from("health_metrics").insert(supabaseData);
+
+          if (!error) {
+            await db.healthMetrics.update(record.id, {
+              pending_sync: 0,
+              retry_attempts: 0,
+              last_attempt_at: null,
+              next_retry_at: null,
+              last_sync_error: null,
+            });
+            syncedAny = true;
+          } else {
+            const msg = safeMessage(error);
+            if (isRetryableError(error) && attempts < MAX_RETRY_ATTEMPTS) {
+              const delay = calculateNextRetryDelayMs(attempts);
+              await db.healthMetrics.update(record.id, { last_sync_error: msg, next_retry_at: Date.now() + delay });
+            } else {
+              await db.healthMetrics.update(record.id, { last_sync_error: msg, next_retry_at: null });
+            }
+          }
+        }
+
+        // 3. Sync pending symptom history deletions
+        const pendingSymptomDeletes = await db.symptomHistory
+          .where("pending_delete")
+          .equals(1)
+          .toArray();
+
+        for (const record of pendingSymptomDeletes) {
+          if (record.next_retry_at && Date.now() < record.next_retry_at) continue;
+
+          const attempts = (record.retry_attempts ?? 0) + 1;
+          const now = Date.now();
+          await db.symptomHistory.update(record.id, { retry_attempts: attempts, last_attempt_at: now });
+
+          const { error } = await supabase
+            .from("symptom_history")
+            .delete()
+            .eq("id", record.id);
+
+          if (!error || error.code === "PGRST116") {
+            await db.symptomHistory.delete(record.id);
+            syncedAny = true;
+          } else {
+            const msg = safeMessage(error);
+            if (isRetryableError(error) && attempts < MAX_RETRY_ATTEMPTS) {
+              const delay = calculateNextRetryDelayMs(attempts);
+              await db.symptomHistory.update(record.id, { last_sync_error: msg, next_retry_at: Date.now() + delay });
+            } else {
+              await db.symptomHistory.update(record.id, { last_sync_error: msg, next_retry_at: null });
+            }
+          }
+        }
+
+        // 4. Sync pending symptom history insertions
+        const pendingSymptomInserts = await db.symptomHistory
+          .where("pending_sync")
+          .equals(1)
+          .toArray();
+
+        for (const record of pendingSymptomInserts) {
+          if (record.next_retry_at && Date.now() < record.next_retry_at) continue;
+
+          const attempts = (record.retry_attempts ?? 0) + 1;
+          const now = Date.now();
+          await db.symptomHistory.update(record.id, { retry_attempts: attempts, last_attempt_at: now });
+
+          const supabaseData = stripLocalFields(record as Record<string, unknown>, [
+            "pending_sync",
+            "pending_delete",
+            "pending_update",
+            "images",
+            "retry_attempts",
+            "last_attempt_at",
+            "next_retry_at",
+            "last_sync_error",
+          ]) as unknown as TablesInsert<"symptom_history">;
+          const { error } = await supabase.from("symptom_history").insert(supabaseData);
+
+          if (!error) {
+            await db.symptomHistory.update(record.id, {
+              pending_sync: 0,
+              retry_attempts: 0,
+              last_attempt_at: null,
+              next_retry_at: null,
+              last_sync_error: null,
+            });
+            syncedAny = true;
+          } else {
+            const msg = safeMessage(error);
+            if (isRetryableError(error) && attempts < MAX_RETRY_ATTEMPTS) {
+              const delay = calculateNextRetryDelayMs(attempts);
+              await db.symptomHistory.update(record.id, { last_sync_error: msg, next_retry_at: Date.now() + delay });
+            } else {
+              await db.symptomHistory.update(record.id, { last_sync_error: msg, next_retry_at: null });
+            }
+          }
+        }
+
+        // 5. Sync pending symptom history updates (resolve/reopen)
+        const pendingSymptomUpdates = await db.symptomHistory
+          .where("pending_update")
+          .equals(1)
+          .toArray();
+
+        for (const record of pendingSymptomUpdates) {
+          if (record.next_retry_at && Date.now() < record.next_retry_at) continue;
+
+          const attempts = (record.retry_attempts ?? 0) + 1;
+          const now = Date.now();
+          await db.symptomHistory.update(record.id, { retry_attempts: attempts, last_attempt_at: now });
+
+          const { error } = await supabase
+            .from("symptom_history")
+            .update({ resolved: record.resolved })
+            .eq("id", record.id);
+
+          if (!error) {
+            await db.symptomHistory.update(record.id, {
+              pending_update: 0,
+              retry_attempts: 0,
+              last_attempt_at: null,
+              next_retry_at: null,
+              last_sync_error: null,
+            });
+            syncedAny = true;
+          } else {
+            const msg = safeMessage(error);
+            if (isRetryableError(error) && attempts < MAX_RETRY_ATTEMPTS) {
+              const delay = calculateNextRetryDelayMs(attempts);
+              await db.symptomHistory.update(record.id, { last_sync_error: msg, next_retry_at: Date.now() + delay });
+            } else {
+              await db.symptomHistory.update(record.id, { last_sync_error: msg, next_retry_at: null });
+            }
+          }
+        }
+
+        if (syncedAny) {
+          await Promise.all([
+            invalidateCache("health_metrics").catch(() => {}),
+            invalidateCache("symptom_history").catch(() => {}),
+          ]);
+        }
+
+        return syncedAny;
+      } catch (error) {
+        console.error("Error during offline synchronization:", error);
+        return false;
       }
+    } finally {
+      syncInFlight = null;
     }
+  })();
 
-    // 2. Sync pending health metrics insertions
-    const pendingMetricsInserts = await db.healthMetrics
-      .where("pending_sync")
-      .equals(1)
-      .toArray();
-
-    for (const record of pendingMetricsInserts) {
-      const { pending_sync, pending_delete, ...supabaseData } = record;
-      const { error } = await supabase
-        .from("health_metrics")
-        .insert(supabaseData as unknown as TablesInsert<"health_metrics">);
-
-      if (!error) {
-        await db.healthMetrics.update(record.id, { pending_sync: 0 });
-        syncedAny = true;
-      }
-    }
-
-    // 3. Sync pending symptom history deletions
-    const pendingSymptomDeletes = await db.symptomHistory
-      .where("pending_delete")
-      .equals(1)
-      .toArray();
-
-    for (const record of pendingSymptomDeletes) {
-      const { error } = await supabase
-        .from("symptom_history")
-        .delete()
-        .eq("id", record.id);
-
-      if (!error || error.code === "PGRST116") {
-        await db.symptomHistory.delete(record.id);
-        syncedAny = true;
-      }
-    }
-
-    // 4. Sync pending symptom history insertions
-    const pendingSymptomInserts = await db.symptomHistory
-      .where("pending_sync")
-      .equals(1)
-      .toArray();
-
-    for (const record of pendingSymptomInserts) {
-      const { pending_sync, pending_delete, pending_update, images, ...supabaseData } = record;
-      const { error } = await supabase
-        .from("symptom_history")
-        .insert(supabaseData as unknown as TablesInsert<"symptom_history">);
-
-      if (!error) {
-        await db.symptomHistory.update(record.id, { pending_sync: 0 });
-        syncedAny = true;
-      }
-    }
-
-    // 5. Sync pending symptom history updates (resolve/reopen)
-    const pendingSymptomUpdates = await db.symptomHistory
-      .where("pending_update")
-      .equals(1)
-      .toArray();
-
-    for (const record of pendingSymptomUpdates) {
-      const { error } = await supabase
-        .from("symptom_history")
-        .update({ resolved: record.resolved })
-        .eq("id", record.id);
-
-      if (!error) {
-        await db.symptomHistory.update(record.id, { pending_update: 0 });
-        syncedAny = true;
-      }
-    }
-
-    if (syncedAny) {
-      await Promise.all([
-        invalidateCache("health_metrics").catch(() => {}),
-        invalidateCache("symptom_history").catch(() => {}),
-      ]);
-    }
-
-    return syncedAny;
-  } catch (error) {
-    console.error("Error during offline synchronization:", error);
-    return false;
-  }
+  return syncInFlight;
 };

--- a/src/lib/sync-retry.test.ts
+++ b/src/lib/sync-retry.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { calculateNextRetryDelayMs, MAX_RETRY_ATTEMPTS, isRetryableError } from "./sync-retry";
+
+describe("sync-retry policy", () => {
+  it("calculates exponential backoff and caps at 30s", () => {
+    expect(calculateNextRetryDelayMs(1)).toBe(1000);
+    expect(calculateNextRetryDelayMs(2)).toBe(2000);
+    expect(calculateNextRetryDelayMs(3)).toBe(4000);
+    expect(calculateNextRetryDelayMs(4)).toBe(8000);
+    expect(calculateNextRetryDelayMs(5)).toBe(16000);
+    expect(calculateNextRetryDelayMs(6)).toBe(30000);
+    expect(calculateNextRetryDelayMs(10)).toBe(30000);
+  });
+
+  it("classifies typical errors as retryable or not", () => {
+    const err5xx = { status: 502, message: "Bad gateway" };
+    const err4xx = { status: 400, message: "Bad request" };
+    const netErr = new TypeError("Failed to fetch");
+
+    expect(isRetryableError(err5xx)).toBe(true);
+    expect(isRetryableError(err4xx)).toBe(false);
+    expect(isRetryableError(netErr)).toBe(true);
+    expect(isRetryableError(null)).toBe(false);
+  });
+});

--- a/src/lib/sync-retry.ts
+++ b/src/lib/sync-retry.ts
@@ -1,0 +1,53 @@
+export const MAX_RETRY_ATTEMPTS = 6;
+const MAX_BACKOFF_MS = 30_000;
+
+export function calculateNextRetryDelayMs(attempt: number): number {
+  if (attempt <= 0) return 1000;
+  // attempt 1 -> 1s, 2 -> 2s, 3 -> 4s, 4 -> 8s, 5 -> 16s, 6+ -> 30s
+  const base = 1000 * Math.pow(2, attempt - 1);
+  if (attempt >= 6) return MAX_BACKOFF_MS;
+  return Math.min(base, MAX_BACKOFF_MS);
+}
+
+export function isRetryableError(err: unknown): boolean {
+  // Network/fetch failures: those often come as TypeError or have no "status"
+  if (!err) return false;
+  // If it's a plain Error with no status, assume network/fetch -> retryable
+  if (err instanceof Error) {
+    const anyErr = err as unknown as Record<string, unknown>;
+    const name = anyErr["name"] as unknown as string | undefined;
+    const statusField = anyErr["status"] ?? anyErr["statusCode"] ?? anyErr["status_code"];
+    const codeField = anyErr["code"] as unknown as string | undefined;
+    const messageField = anyErr["message"] as unknown as string | undefined;
+
+    if (name === "TypeError" && statusField === undefined) return true;
+    if (typeof codeField === "string" && codeField.startsWith("PGRST5")) return true;
+    // Supabase client sometimes surfaces status/statusCode
+    if (typeof statusField === "number") {
+      if (statusField >= 500 && statusField < 600) return true;
+      if (statusField === 408) return true;
+      return false;
+    }
+    // Fallback: if error message contains typical 5xx text, retry
+    if (typeof messageField === "string") {
+      if (/5\d{2}/.test(messageField)) return true;
+      if (/timeout|timed out|network/i.test(messageField)) return true;
+    }
+    return false;
+  }
+
+  // Non-Error objects: inspect common shapes
+  try {
+    const asObj = err as unknown as Record<string, unknown>;
+    const status = asObj["status"] ?? asObj["statusCode"] ?? asObj["code"];
+    if (typeof status === "number") return status >= 500 && status < 600;
+    if (typeof status === "string") {
+      if (status.startsWith("5")) return true;
+      return false;
+    }
+  } catch (e) {
+    return false;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## **Pull Request Description**

This PR implements retry policy and exponential backoff for offline data synchronization (issue #1167). It adds local retry metadata to offline records, bounded exponential backoff with retryable vs permanent error classification, single-flight protection for sync operations, and focused test coverage.

The existing `pending_sync` / `pending_update` / `pending_delete` architecture is preserved. No additional database tables or retry queues were introduced.

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [x] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #1167

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.

- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` — no errors; warnings only).
- [x] **Unit Tests**: All tests passed (`npm test`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Verified `syncOfflineData()` exits early when offline and does not attempt server calls.
  2. Verified records with `next_retry_at` in the future are skipped.
  3. Verified retry metadata is updated on failure and reset after successful synchronization.
  4. Verified network/HTTP 5xx errors are retryable with exponential backoff, while HTTP 4xx errors are treated as permanent.
  5. Verified concurrent `syncOfflineData()` calls use single-flight behavior without duplicate server operations.

---

### **4. Visual Verification (If applicable)**
Not applicable — this PR contains offline synchronization and database logic changes only.

| Before | After |
| :--- | :--- |
| N/A | N/A |

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.

---

### Changed Files
- `offline-db.ts` — added retry metadata handling, single-flight `syncOfflineData()`, local-field stripping, and retry-aware synchronization flows.
- `sync-retry.ts` — added bounded exponential backoff and retryable/permanent error classification.
- `sync-retry.test.ts` — added tests for backoff and error classification.
- `offline-db.test.ts` — added tests for retry behavior, skipped retries, successful cleanup, offline behavior, and single-flight synchronization.

### Notes for Reviewers
- Existing `pending_sync` / `pending_update` / `pending_delete` semantics are preserved.
- No new failed-sync table or separate retry queue was introduced.
- Retry metadata remains local to IndexedDB and is stripped before payloads are sent to Supabase.
- Backoff sequence: **1s → 2s → 4s → 8s → 16s → 30s cap**.
- Concurrent sync calls await the same in-progress synchronization instead of performing duplicate work.

### Verification
- `npm test` — all tests passed
- `npm run lint` — passed, no errors
- `npm run build` — production build succeeded