### PR TITLE
feat: add Reminder feature icon to sidebar

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -14,6 +14,7 @@ import {
   Palette,
   PanelLeftClose,
   Check,
+  Bell,
 } from "lucide-react";
 
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
@@ -57,6 +58,7 @@ const menuItems = [
   { titleKey: "sidebar.items.challenges", url: "/gamification", icon: Trophy },
   { titleKey: "sidebar.items.profile", url: "/profile", icon: User },
   { titleKey: "sidebar.items.emergency", url: "/emergency", icon: Phone },
+  { titleKey: "sidebar.items.reminders", url: "/reminders", icon: Bell },
   { titleKey: "sidebar.items.brainGames", url: "/brain-games", icon: Brain },
   { titleKey: "sidebar.items.healthFacts", url: "/health-facts", icon: Sparkles },
   { titleKey: "sidebar.items.settings", url: "/settings", icon: Settings },

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -191,6 +191,7 @@
       "challenges": "Challenges",
       "profile": "Profile",
       "emergency": "Emergency",
+      "reminders": "Reminders",
       "brainGames": "Brain Games",
       "healthFacts": "Health Facts",
       "settings": "Settings"

--- a/src/lib/i18n/locales/hi.json
+++ b/src/lib/i18n/locales/hi.json
@@ -191,6 +191,7 @@
       "challenges": "चुनौतियाँ",
       "profile": "प्रोफ़ाइल",
       "emergency": "आपातकाल",
+      "reminders": "रिमाइंडर",
       "brainGames": "ब्रेन गेम्स",
       "healthFacts": "स्वास्थ्य तथ्य",
       "settings": "सेटिंग्स"

--- a/src/lib/i18n/locales/te.json
+++ b/src/lib/i18n/locales/te.json
@@ -191,6 +191,7 @@
       "challenges": "సవాళ్లు",
       "profile": "ప్రొఫైల్",
       "emergency": "అత్యవసరం",
+      "reminders": "రిమైండర్‌లు",
       "brainGames": "బ్రెయిన్ గేమ్స్",
       "healthFacts": "ఆరోగ్య వాస్తవాలు",
       "settings": "సెట్టింగ్‌లు"


### PR DESCRIPTION
## **Pull Request Description**
This PR adds the missing "Reminders" feature icon to the main application sidebar, exposing the existing functionality so users can easily navigate to the reminders page (`/reminders`). It also includes the necessary internationalization (i18n) translation keys for English, Hindi, and Telugu. 

---

### **1. Type of Change**
- [ ] **Bug Fix** (non-breaking change which fixes an issue)
- [x] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
-- Fixes #817 (Health record statistics dashboard)


---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).
- [x] **Manual Verification**: Briefly list the steps/features verified manually.
  1. Verified that the `Reminders` menu item renders properly in `AppSidebar.tsx` utilizing the `Bell` icon.
  2. Verified that the translation keys for the sidebar item work correctly across English (`en.json`), Hindi (`hi.json`), and Telugu (`te.json`).

---


### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
