### PR TITLE
Fix #1192: Dashboard loading and auth redirect

### DIFF
--- a/src/components/auth/AuthProvider.test.tsx
+++ b/src/components/auth/AuthProvider.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for the AuthProvider (issue #1192).
+ *
+ * The provider initializes by subscribing to auth events first and using the
+ * listener as the single source of truth for the session, with getSession()
+ * kept only as a fallback for persisted sessions. These tests verify that:
+ *
+ *  1. `loading` resolves and the session is published when INITIAL_SESSION
+ *     arrives (normal restore path).
+ *  2. A persisted session is published through the getSession() fallback even
+ *     when the initial event has not been delivered yet.
+ *  3. A sign-out clears the session and resolves loading.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@/test/utils";
+import { AuthProvider, useAuth } from "./AuthProvider";
+
+// ---------------------------------------------------------------------------
+// Mock the Supabase client. The onAuthStateChange callback is captured so
+// tests can simulate auth events directly.
+// ---------------------------------------------------------------------------
+const { supabaseMock } = vi.hoisted(() => ({
+  supabaseMock: {
+    authStateChange: undefined as
+      | ((event: string, session: unknown) => void)
+      | undefined,
+    getSession: vi.fn(),
+  },
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      onAuthStateChange: vi.fn((callback) => {
+        supabaseMock.authStateChange = callback;
+        return { data: { subscription: { unsubscribe: vi.fn() } } };
+      }),
+      getSession: supabaseMock.getSession,
+    },
+    from: vi.fn(),
+  },
+}));
+
+// A consumer that exposes the auth state so tests can assert on it.
+const AuthStateProbe = () => {
+  const { session, user, loading, initialized } = useAuth();
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="initialized">{String(initialized)}</span>
+      <span data-testid="session">{session?.access_token ?? "none"}</span>
+      <span data-testid="user">{user?.id ?? "none"}</span>
+    </div>
+  );
+};
+
+const mockSession = {
+  access_token: "mock-token",
+  refresh_token: "mock-refresh",
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  user: { id: "user-1", email: "user@example.com" },
+};
+
+describe("AuthProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    supabaseMock.authStateChange = undefined;
+    supabaseMock.getSession.mockResolvedValue({ data: { session: null }, error: null });
+  });
+
+  // 1. Normal restore path: loading resolves once INITIAL_SESSION arrives.
+  it("publishes the session and resolves loading when INITIAL_SESSION arrives", async () => {
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+
+    // Auth is initializing — no session yet.
+    expect(screen.getByTestId("loading")).toHaveTextContent("true");
+    expect(screen.getByTestId("session")).toHaveTextContent("none");
+
+    supabaseMock.authStateChange?.("INITIAL_SESSION", mockSession);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+      expect(screen.getByTestId("initialized")).toHaveTextContent("true");
+      expect(screen.getByTestId("session")).toHaveTextContent("mock-token");
+      expect(screen.getByTestId("user")).toHaveTextContent("user-1");
+    });
+  });
+
+  // 2. Fallback: a persisted session is published via getSession() even when
+  //    the initial event is delayed (edge case from issue #1192).
+  it("publishes a persisted session via getSession() when the initial event is delayed", async () => {
+    supabaseMock.getSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+      expect(screen.getByTestId("session")).toHaveTextContent("mock-token");
+      expect(screen.getByTestId("user")).toHaveTextContent("user-1");
+    });
+  });
+
+  // 3. The stale-snapshot race from issue #1192: getSession() must never
+  //    overwrite a session the listener already published with a null value.
+  it("does not clobber a published session with a stale getSession() snapshot", async () => {
+    // The sign-in event arrives first and publishes the session...
+    supabaseMock.getSession.mockResolvedValue({ data: { session: null }, error: null });
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+
+    supabaseMock.authStateChange?.("SIGNED_IN", mockSession);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session")).toHaveTextContent("mock-token");
+    });
+  });
+
+  // 4. Sign-out clears the session.
+  it("clears the session when SIGNED_OUT is emitted", async () => {
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>
+    );
+
+    supabaseMock.authStateChange?.("INITIAL_SESSION", mockSession);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session")).toHaveTextContent("mock-token");
+    });
+
+    supabaseMock.authStateChange?.("SIGNED_OUT", null);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+      expect(screen.getByTestId("session")).toHaveTextContent("none");
+      expect(screen.getByTestId("user")).toHaveTextContent("none");
+    });
+  });
+});

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -32,26 +32,12 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   useEffect(() => {
     let isMounted = true;
 
-    const initializeAuth = async () => {
-      // Get initial session
-      const { data, error } = await supabase.auth.getSession();
-
-      if (!isMounted) return;
-
-      if (error) {
-        console.warn("Failed to get initial session:", error);
-      } else {
-        setSession(data.session);
-        setUser(data.session?.user ?? null);
-      }
-
-      setLoading(false);
-      setInitialized(true);
-    };
-
-    initializeAuth();
-
-    // Listen for auth changes
+    // Subscribe to auth events BEFORE resolving the initial session so no
+    // event (INITIAL_SESSION / SIGNED_IN / ...) can be missed while the
+    // snapshot is being loaded. The listener is the single source of truth
+    // for the session state; relying on a getSession() snapshot alone can
+    // leave the provider with a stale (null) session right after sign-in,
+    // which bounces ProtectedRoute back to /auth (issue #1192).
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, nextSession) => {
@@ -60,6 +46,20 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       setSession(nextSession);
       setUser(nextSession?.user ?? null);
       setLoading(false);
+      setInitialized(true);
+    });
+
+    // Fallback for the edge case where the initial event has not been
+    // delivered yet (e.g. a session restored from storage). Publishes the
+    // persisted session so `loading` resolves promptly, and never writes a
+    // stale `null` over state the listener has already published.
+    supabase.auth.getSession().then(({ data }) => {
+      if (!isMounted || !data.session) return;
+
+      setSession(data.session);
+      setUser(data.session.user ?? null);
+      setLoading(false);
+      setInitialized(true);
     });
 
     return () => {

--- a/src/pages/Auth.test.tsx
+++ b/src/pages/Auth.test.tsx
@@ -319,7 +319,59 @@ describe("Auth", () => {
     authStateChangeHolder.current?.("SIGNED_IN", { user: { id: "user-1" } });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
+      expect(mockNavigate).toHaveBeenCalledWith("/dashboard", { replace: true });
+    });
+  });
+
+  // 14. Successful sign-in navigates directly — key setup (seed persisted)
+  //     completes before the redirect, so the dashboard never mounts with
+  //     pending encryption state (issue #1192).
+  it("navigates directly to /dashboard after a successful sign-in", async () => {
+    const user = userEvent.setup();
+    (supabase.auth.signInWithPassword as Mock).mockResolvedValue({
+      data: { user: { id: "user-1" } },
+      error: null,
+    });
+
+    render(<Auth />);
+
+    await user.type(screen.getByLabelText("Email"), "user@example.com");
+    await user.type(screen.getByLabelText("Password"), "correct-password");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/dashboard", { replace: true });
+    });
+  });
+
+  // 15. The auth-event listener defers its navigation while a password
+  //     sign-in is in flight, so it cannot double-navigate.
+  it("does not navigate from the auth event while a sign-in is in progress", async () => {
+    const user = userEvent.setup();
+    let resolveSignIn: (value: unknown) => void = () => {};
+    (supabase.auth.signInWithPassword as Mock).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSignIn = resolve;
+      })
+    );
+
+    render(<Auth />);
+
+    await user.type(screen.getByLabelText("Email"), "user@example.com");
+    await user.type(screen.getByLabelText("Password"), "correct-password");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    // Simulate the SIGNED_IN event arriving while the flow is in progress.
+    authStateChangeHolder.current?.("SIGNED_IN", { user: { id: "user-1" } });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    // Complete the sign-in; the handler performs exactly one navigation.
+    resolveSignIn({ data: { user: { id: "user-1" } }, error: null });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith("/dashboard", { replace: true });
     });
   });
 

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { supabase } from "@/integrations/supabase/client";
@@ -56,6 +56,21 @@ const Auth = () => {
   const { toast } = useToast();
   const { t } = useTranslation();
 
+  // While a password sign-in / MFA flow is finishing its encryption key
+  // setup, the auth-state listener defers navigation. The handler navigates
+  // itself only after the keys are persisted, so the dashboard mounts with a
+  // usable encryption context instead of hanging in its loading state or
+  // briefly flashing the "unlock your data" dialog (issue #1192).
+  const pendingSignInRef = useRef(false);
+  // Ensures a session triggers exactly one dashboard navigation.
+  const redirectHandledRef = useRef(false);
+
+  const goToDashboard = () => {
+    if (redirectHandledRef.current) return;
+    redirectHandledRef.current = true;
+    navigate("/dashboard", { replace: true });
+  };
+
   const fieldIconClass =
     "pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-cyan-200/70 transition-colors duration-200";
   const fieldClass =
@@ -74,13 +89,13 @@ const Auth = () => {
       return;
       }
 
-      if (session) {
+      if (session && !pendingSignInRef.current) {
         const { data: aalData } = (await supabase.auth.mfa?.getAuthenticatorAssuranceLevel()) ?? { data: null };
         if (aalData && aalData.nextLevel === "aal2" && aalData.currentLevel !== aalData.nextLevel) {
           // 2FA verification still pending — don't navigate yet
           return;
         }
-        navigate("/dashboard");
+        goToDashboard();
       }
    });
 
@@ -115,6 +130,9 @@ const Auth = () => {
     if (!validateSignIn()) return;
 
     setLoading(true);
+    // Defer the auth-event redirect: the handler navigates only after the
+    // encryption keys have been derived and persisted for this session.
+    pendingSignInRef.current = true;
 
     const { data: signInData, error } = await supabase.auth.signInWithPassword({
       email: signInEmail,
@@ -123,6 +141,7 @@ const Auth = () => {
 
     if (error) {
       showError(t("auth.signInFailedTitle"), error.message);
+      pendingSignInRef.current = false;
       setLoading(false);
     } else {
       const { data: aalData } = (await supabase.auth.mfa?.getAuthenticatorAssuranceLevel()) ?? { data: null };
@@ -134,6 +153,7 @@ const Auth = () => {
           setMfaFactorId(totpFactor.id);
           setMfaRequired(true);
         }
+        pendingSignInRef.current = false;
         setLoading(false);
         return;
       }
@@ -147,6 +167,8 @@ const Auth = () => {
       }
       setLoading(false);
       setRedirecting(true);
+      pendingSignInRef.current = false;
+      goToDashboard();
     }
   };
 
@@ -156,6 +178,8 @@ const Auth = () => {
       return;
     }
     setMfaSubmitting(true);
+    // Defer the auth-event redirect until the keys are derived below.
+    pendingSignInRef.current = true;
 
     const { data: challengeData, error: challengeError } = await supabase.auth.mfa.challenge({
       factorId: mfaFactorId,
@@ -163,6 +187,7 @@ const Auth = () => {
 
     if (challengeError) {
       showError(t("auth.verificationFailedTitle"), challengeError.message);
+      pendingSignInRef.current = false;
       setMfaSubmitting(false);
       return;
     }
@@ -175,6 +200,7 @@ const Auth = () => {
 
     if (verifyError) {
       showError(t("auth.incorrectCodeTitle"), t("auth.incorrectCodeDesc"));
+      pendingSignInRef.current = false;
       setMfaSubmitting(false);
       return;
     }
@@ -190,6 +216,8 @@ const Auth = () => {
 
     setMfaSubmitting(false);
     setRedirecting(true);
+    pendingSignInRef.current = false;
+    goToDashboard();
   };
 
 const handleForgotPassword= async () => {

--- a/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/pages/Dashboard/Dashboard.test.tsx
@@ -23,6 +23,8 @@ import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { render } from "@/test/utils";
 import Dashboard from "@/pages/Dashboard/";
+import { AuthContext } from "@/components/auth/AuthProvider";
+import type { Session, User } from "@supabase/supabase-js";
 
 // ---------------------------------------------------------------------------
 // Mock the Supabase client
@@ -110,18 +112,46 @@ import { getCachedData } from "@/lib/cached-queries";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-const mockUser = { id: "test-user-id", email: "test@example.com" };
+const mockUser: User = {
+  id: "test-user-id",
+  email: "test@example.com",
+  app_metadata: {},
+  user_metadata: {},
+  aud: "authenticated",
+  created_at: new Date().toISOString(),
+};
+const mockSession: Session = {
+  access_token: "mock-token",
+  refresh_token: "mock-refresh",
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  expires_in: 3600,
+  token_type: "bearer",
+  user: mockUser,
+};
+
+/**
+ * Renders the Dashboard with a fake AuthContext session. The Dashboard reads
+ * the user id from the auth context (it is guaranteed by ProtectedRoute in
+ * production), so tests must provide it here.
+ */
+function renderDashboard(session: Session | null = mockSession) {
+  return render(
+    <AuthContext.Provider
+      value={{
+        session,
+        user: session?.user ?? null,
+        loading: false,
+        initialized: true,
+      }}
+    >
+      <Dashboard />
+    </AuthContext.Provider>
+  );
+}
 
 /** Returns a fully resolved cached query stub. */
 function mockCachedSymptoms(data: unknown[] | null, error: unknown = null) {
   (getCachedData as Mock).mockResolvedValue({ data, error });
-}
-
-function mockAuthUser(user: typeof mockUser | null = mockUser) {
-  (supabase.auth.getUser as Mock).mockResolvedValue({ data: { user } });
-  (supabase.auth.getSession as Mock).mockResolvedValue({
-    data: { session: user ? { access_token: "mock-token" } : null },
-  });
 }
 (supabase.from as Mock).mockReturnValue({
     select: () => ({
@@ -178,21 +208,18 @@ describe("Dashboard", () => {
 
   // 1. Loading state
   it("shows a loading state before data resolves", () => {
-    mockAuthUser();
     // Never resolve the query during this test
     (getCachedData as Mock).mockReturnValue(new Promise(() => {}));
 
-    render(<Dashboard />);
+    renderDashboard();
     // The loading skeleton should be present while awaiting the query
     expect(document.querySelector(".animate-pulse")).toBeInTheDocument();
   });
 
   // 2. Empty state
   it("renders the empty-state prompt when the user has no history", async () => {
-    mockAuthUser();
     mockCachedSymptoms([]);
-
-    render(<Dashboard />);
+    renderDashboard();
 
     await waitFor(() => {
       expect(
@@ -203,10 +230,8 @@ describe("Dashboard", () => {
 
   // 3. Stat cards render correct labels
   it("renders all four stat card labels", async () => {
-    mockAuthUser();
     mockCachedSymptoms(sampleSymptoms);
-
-    render(<Dashboard />);
+    renderDashboard();
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: /Total Consultations/i })).toBeInTheDocument();
@@ -218,10 +243,8 @@ describe("Dashboard", () => {
 
   // 4. Stat values are calculated correctly
   it("calculates and displays the correct stat values from symptom data", async () => {
-    mockAuthUser();
     mockCachedSymptoms(sampleSymptoms);
-
-    render(<Dashboard />);
+    renderDashboard();
 
     await waitFor(() => {
       // Check that "2" appears somewhere near "Lifetime symptom checks"
@@ -235,10 +258,8 @@ describe("Dashboard", () => {
 
   // 5. Recent history items are rendered
   it("renders recent symptom history items", async () => {
-    mockAuthUser();
     mockCachedSymptoms(sampleSymptoms);
-
-    render(<Dashboard />);
+    renderDashboard();
 
     await waitFor(() => {
       // Use a function matcher to find text across elements
@@ -254,10 +275,8 @@ describe("Dashboard", () => {
 
   // 6. Severity colour logic – "high" severity items use the destructive class
   it("applies the correct severity colour for high-severity items", async () => {
-    mockAuthUser();
     mockCachedSymptoms(sampleSymptoms);
-
-    render(<Dashboard />);
+    renderDashboard();
 
     await waitFor(() => {
       // Find the element containing "high" and check its class
@@ -269,10 +288,8 @@ describe("Dashboard", () => {
 
   // 7. Supabase error is handled gracefully
   it("handles Supabase fetch errors without crashing", async () => {
-    mockAuthUser();
     mockCachedSymptoms(null, { message: "Network error" });
-
-    render(<Dashboard />);
+    renderDashboard();
 
     // The component should still load (not throw)
     await waitFor(() => {
@@ -282,9 +299,7 @@ describe("Dashboard", () => {
 
   // 8. Unauthenticated user – no crash, no data fetch
   it("renders without crashing when no user session exists", async () => {
-    mockAuthUser(null);
-
-    render(<Dashboard />);
+    renderDashboard(null);
 
     await waitFor(() => {
       expect(screen.getByText("Health Dashboard")).toBeInTheDocument();
@@ -293,10 +308,8 @@ describe("Dashboard", () => {
 
   // 9. AI Health Predictions rendering
   it("renders the AI Health Predictions card on the dashboard", async () => {
-    mockAuthUser();
     mockCachedSymptoms([]);
-
-    render(<Dashboard />);
+    renderDashboard();
 
     await waitFor(() => {
       expect(screen.getByText("AI Health Predictions")).toBeInTheDocument();
@@ -307,10 +320,8 @@ describe("Dashboard", () => {
 
   // 10. Weekly Health Score card rendering
   it("renders weekly health score card and streak badge", async () => {
-    mockAuthUser();
     mockCachedSymptoms([]);
-
-    render(<Dashboard />);
+    renderDashboard();
 
     await waitFor(() => {
       expect(screen.getByText("Weekly Health Score")).toBeInTheDocument();
@@ -321,10 +332,8 @@ describe("Dashboard", () => {
 
   // 11. Accessibility: Radial gauge role="img" and Health Trends screen reader summary
   it("renders accessible ARIA attributes on radial gauge and health trends chart", async () => {
-    mockAuthUser();
     mockCachedSymptoms(sampleSymptoms);
-
-    render(<Dashboard />);
+    renderDashboard();
 
     await waitFor(() => {
       expect(screen.getByRole("img", { name: /Wellness Score:/i })).toBeInTheDocument();

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -18,6 +18,7 @@ import CardSkeleton from "@/components/ui/CardSkeleton";
 import { WeeklyHealthScoreCard } from "@/components/dashboard/WeeklyHealthScoreCard";
 import { useNavigate } from "react-router-dom";
 import { EmptyState } from "@/components/common/EmptyState";
+import { useAuth } from "@/components/auth/AuthProvider";
 
 interface Stats {
   totalSymptoms: number;
@@ -159,6 +160,7 @@ const RadialWellnessGauge = ({ score }: { score: number }) => {
 
 const Dashboard = () => {
   const navigate = useNavigate();
+  const { session } = useAuth();
   const { t } = useTranslation();
   const [stats, setStats] = useState<Stats>({
     totalSymptoms: 0,
@@ -169,7 +171,10 @@ const Dashboard = () => {
   const [recentHistory, setRecentHistory] = useState<SymptomHistoryRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [userName, setUserName] = useState("User");
-  const [userId, setUserId] = useState<string | null>(null);
+  // The session is guaranteed by ProtectedRoute, so the user id is available
+  // synchronously — no extra auth round trip (and no empty-dashboard flash
+  // while a second getUser() call resolves) is needed.
+  const [userId, setUserId] = useState<string | null>(session?.user?.id ?? null);
   const [symptoms, setSymptoms] = useState<OfflineSymptom[]>([]);
   const [decryptedSymptomsList, setDecryptedSymptomsList] = useState<string[]>([]);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -180,18 +185,16 @@ const Dashboard = () => {
 
   const fetchDashboardData = async () => {
     try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) {
+      // ProtectedRoute redirects unauthenticated users to /auth; this is a
+      // defensive no-op so the dashboard never renders an empty shell.
+      if (!userId) {
         setLoading(false);
         return;
       }
-      setUserId(user.id);
       const { data: profile, error: profileError } = await supabase
         .from("profiles")
         .select("*")
-        .eq("user_id", user.id)
+        .eq("user_id", userId)
         .maybeSingle();
 
       if (profile?.full_name) {
@@ -211,7 +214,7 @@ const Dashboard = () => {
 
 
 
-      const { data: rawSymptoms, source } = await fetchSymptomHistory(user.id);
+      const { data: rawSymptoms, source } = await fetchSymptomHistory(userId);
 
       if (rawSymptoms && rawSymptoms.length > 0) {
         const key = await whenEncryptionReady();


### PR DESCRIPTION
## Summary

Fixes the dashboard loading and authentication redirect problems described in #1192 (stuck rotating spinner after sign-in, redirect requiring a hard refresh, and dashboard content not loading until another refresh).

### Root causes addressed

1. **Stale session snapshot in `AuthProvider`** — the provider initialized from a `getSession()` snapshot while also writing state from the `onAuthStateChange` listener. After sign-in the provider could publish `session: null` / remain `loading: true` while the `SIGNED_IN` event was propagating, so `ProtectedRoute` either kept the spinner up or bounced `/dashboard` → `/auth` until a hard refresh.
   - Fix: subscribe to `onAuthStateChange` **first** and treat the listener (incl. `INITIAL_SESSION`) as the single source of truth; `getSession()` is kept only as a fallback to publish an already-persisted session, and can never clobber listener state with a stale `null`.

2. **Event-only redirect on the Auth page** — `handleSignIn` only set `redirecting = true` and waited for the auth event (whose MFA check is a network call) to navigate, so the redirect could stall on the "Redirecting…" spinner.
   - Fix: the sign-in and MFA handlers now navigate directly to `/dashboard` (with `replace`) **after** the encryption keys are derived and persisted, so the dashboard mounts with a usable encryption context. The event listener stays as a catch-all (OAuth / magic link / recovery) but defers while a password sign-in is in flight and a guard ensures exactly one navigation.

3. **Dashboard re-fetched the session via `supabase.auth.getUser()`** (a redundant network round trip) and silently rendered an empty shell when the user was momentarily absent.
   - Fix: the dashboard reads the user id from the auth context (guaranteed by `ProtectedRoute`) — no extra round trip, no empty-dashboard flash, no dependency on a second session fetch.

## Verification

- `npm test` (vitest run): **180 passed**; the only failures are 10 pre-existing `src/lib/encryption.test.ts` failures that also fail identically on pristine `upstream/main` (environment issue: `localStorage` undefined) — unrelated to this change.
- New tests: `src/components/auth/AuthProvider.test.tsx` (session published via INITIAL_SESSION, getSession fallback, stale-snapshot protection, SIGNED_OUT); updated `src/pages/Auth.test.tsx` (direct navigation after sign-in, no double navigation, listener still handles events); updated `src/pages/Dashboard/Dashboard.test.tsx` (context-provided session).
- `npm run build` (vite build): succeeds. `tsc --noEmit` reports only the 14 pre-existing errors (identical to baseline on `upstream/main`).
- `eslint`: 0 errors.

Fixes #1192