### PR TITLE
Feat #1222: Blood Pressure Diary with hypertension classification

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ const BlogPostPage = lazy(() => import("@/pages/Blog/BlogPostPage.tsx"));
 const ResetPassword = lazy(() => import("./pages/User/ResetPassword.tsx"));
 const GamificationPage = lazy(() => import("@/pages/Gamification"));
 const Reminders = lazy(() => import("./pages/Reminders/index.tsx"));
+const BloodPressureDiary = lazy(() => import("./pages/Health/BloodPressure.tsx"));
 
 // Loading spinner fallback component
 const LoadingScreen = () => (
@@ -166,6 +167,16 @@ const App = () => {
                   <ProtectedRoute>
                     <Layout>
                       <Metrics />
+                    </Layout>
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/blood-pressure"
+                element={
+                  <ProtectedRoute>
+                    <Layout>
+                      <BloodPressureDiary />
                     </Layout>
                   </ProtectedRoute>
                 }

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -15,6 +15,7 @@ import {
   PanelLeftClose,
   Check,
   Bell,
+  HeartPulse,
 } from "lucide-react";
 
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
@@ -54,6 +55,7 @@ const menuItems = [
   { titleKey: "sidebar.items.dashboard", url: "/dashboard", icon: LayoutDashboard },
   { titleKey: "sidebar.items.aiHealthAssistant", url: "/ai-health-assistant", icon: Bot },
   { titleKey: "sidebar.items.healthMetrics", url: "/metrics", icon: Activity },
+  { titleKey: "sidebar.items.bloodPressureDiary", url: "/blood-pressure", icon: HeartPulse },
   { titleKey: "sidebar.items.history", url: "/history", icon: History },
   { titleKey: "sidebar.items.challenges", url: "/gamification", icon: Trophy },
   { titleKey: "sidebar.items.profile", url: "/profile", icon: User },

--- a/src/lib/hypertension.test.ts
+++ b/src/lib/hypertension.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyBloodPressure,
+  summarizeBloodPressure,
+  readingsWithinLastDays,
+  isSystolicValid,
+  isDiastolicValid,
+  type BloodPressureReading,
+} from "./hypertension";
+
+describe("classifyBloodPressure", () => {
+  it("classifies normal readings below 120/80", () => {
+    expect(classifyBloodPressure(110, 70).category).toBe("normal");
+  });
+
+  it("classifies elevated when systolic is 120-129 and diastolic under 80", () => {
+    expect(classifyBloodPressure(120, 75).category).toBe("elevated");
+    expect(classifyBloodPressure(128, 79).category).toBe("elevated");
+  });
+
+  it("classifies stage 1 when systolic is 130-139 or diastolic 80-89", () => {
+    expect(classifyBloodPressure(130, 75).category).toBe("stage1");
+    expect(classifyBloodPressure(135, 85).category).toBe("stage1");
+    expect(classifyBloodPressure(118, 85).category).toBe("stage1");
+  });
+
+  it("classifies stage 2 when systolic >= 140 or diastolic >= 90", () => {
+    expect(classifyBloodPressure(140, 80).category).toBe("stage2");
+    expect(classifyBloodPressure(120, 95).category).toBe("stage2");
+  });
+
+  it("classifies crisis when systolic > 180 or diastolic > 120", () => {
+    expect(classifyBloodPressure(181, 90).category).toBe("crisis");
+    expect(classifyBloodPressure(120, 121).category).toBe("crisis");
+  });
+});
+
+describe("isSystolicValid / isDiastolicValid", () => {
+  it("accepts values within the supported range", () => {
+    expect(isSystolicValid(120)).toBe(true);
+    expect(isSystolicValid(50)).toBe(true);
+    expect(isSystolicValid(300)).toBe(true);
+    expect(isDiastolicValid(80)).toBe(true);
+    expect(isDiastolicValid(30)).toBe(true);
+    expect(isDiastolicValid(200)).toBe(true);
+  });
+
+  it("rejects out-of-range and non-finite values", () => {
+    expect(isSystolicValid(49)).toBe(false);
+    expect(isSystolicValid(301)).toBe(false);
+    expect(isSystolicValid(NaN)).toBe(false);
+    expect(isDiastolicValid(29)).toBe(false);
+    expect(isDiastolicValid(201)).toBe(false);
+    expect(isDiastolicValid(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});
+
+describe("summarizeBloodPressure", () => {
+  it("returns a null summary when there are no readings", () => {
+    const summary = summarizeBloodPressure([]);
+    expect(summary.readingCount).toBe(0);
+    expect(summary.averageSystolic).toBeNull();
+    expect(summary.averageDiastolic).toBeNull();
+    expect(summary.mostRecentCategory).toBeNull();
+  });
+
+  it("computes averages and latest category from readings", () => {
+    const readings: BloodPressureReading[] = [
+      { systolic: 120, diastolic: 80, recordedAt: "2026-08-01T09:00:00Z" },
+      { systolic: 130, diastolic: 85, recordedAt: "2026-08-02T09:00:00Z" },
+      { systolic: 140, diastolic: 90, recordedAt: "2026-08-03T09:00:00Z" },
+    ];
+
+    const summary = summarizeBloodPressure(readings);
+
+    expect(summary.readingCount).toBe(3);
+    expect(summary.averageSystolic).toBe(130);
+    expect(summary.averageDiastolic).toBe(85);
+    expect(summary.mostRecentCategory?.category).toBe("stage2");
+  });
+
+  it("falls back to the first reading when timestamps are missing", () => {
+    const summary = summarizeBloodPressure([
+      { systolic: 110, diastolic: 70 },
+      { systolic: 125, diastolic: 80 },
+    ]);
+
+    expect(summary.averageSystolic).toBe(118);
+    expect(summary.mostRecentCategory?.category).toBe("normal");
+  });
+});
+
+describe("readingsWithinLastDays", () => {
+  const now = new Date("2026-08-15T12:00:00Z");
+  const readings: BloodPressureReading[] = [
+    { systolic: 110, diastolic: 70, recordedAt: "2026-08-14T09:00:00Z" },
+    { systolic: 120, diastolic: 80, recordedAt: "2026-08-01T09:00:00Z" },
+    { systolic: 130, diastolic: 85, recordedAt: "2026-07-01T09:00:00Z" },
+  ];
+
+  it("only keeps readings within the requested window", () => {
+    const recent = readingsWithinLastDays(readings, 7, now);
+    expect(recent).toHaveLength(1);
+    expect(recent[0].systolic).toBe(110);
+  });
+
+  it("excludes readings without a timestamp", () => {
+    const mixed = [...readings, { systolic: 100, diastolic: 60 }];
+    const recent = readingsWithinLastDays(mixed, 7, now);
+    expect(recent.some((r) => r.recordedAt === undefined)).toBe(false);
+  });
+});

--- a/src/lib/hypertension.ts
+++ b/src/lib/hypertension.ts
@@ -1,0 +1,125 @@
+export type HypertensionCategory =
+  | "normal"
+  | "elevated"
+  | "stage1"
+  | "stage2"
+  | "crisis";
+
+export interface HypertensionClassification {
+  category: HypertensionCategory;
+  label: string;
+  description: string;
+}
+
+export interface BloodPressureReading {
+  systolic: number;
+  diastolic: number;
+  recordedAt?: string;
+  notes?: string | null;
+}
+
+const CATEGORY_META: Record<HypertensionCategory, HypertensionClassification> = {
+  normal: {
+    category: "normal",
+    label: "Normal",
+    description: "Less than 120/80 mmHg",
+  },
+  elevated: {
+    category: "elevated",
+    label: "Elevated",
+    description: "Systolic 120-129 and diastolic below 80",
+  },
+  stage1: {
+    category: "stage1",
+    label: "Stage 1",
+    description: "Systolic 130-139 or diastolic 80-89",
+  },
+  stage2: {
+    category: "stage2",
+    label: "Stage 2",
+    description: "Systolic 140 or higher or diastolic 90 or higher",
+  },
+  crisis: {
+    category: "crisis",
+    label: "Hypertensive Crisis",
+    description: "Systolic over 180 or diastolic over 120 — seek care",
+  },
+};
+
+export function classifyBloodPressure(
+  systolic: number,
+  diastolic: number,
+): HypertensionClassification {
+  if (systolic > 180 || diastolic > 120) {
+    return CATEGORY_META.crisis;
+  }
+  if (systolic >= 140 || diastolic >= 90) {
+    return CATEGORY_META.stage2;
+  }
+  if (systolic >= 130 || diastolic >= 80) {
+    return CATEGORY_META.stage1;
+  }
+  if (systolic >= 120 && diastolic < 80) {
+    return CATEGORY_META.elevated;
+  }
+  return CATEGORY_META.normal;
+}
+
+export function isSystolicValid(systolic: number): boolean {
+  return Number.isFinite(systolic) && systolic >= 50 && systolic <= 300;
+}
+
+export function isDiastolicValid(diastolic: number): boolean {
+  return Number.isFinite(diastolic) && diastolic >= 30 && diastolic <= 200;
+}
+
+export interface BloodPressureSummary {
+  averageSystolic: number | null;
+  averageDiastolic: number | null;
+  readingCount: number;
+  mostRecentCategory: HypertensionClassification | null;
+}
+
+export function summarizeBloodPressure(
+  readings: BloodPressureReading[],
+): BloodPressureSummary {
+  if (readings.length === 0) {
+    return {
+      averageSystolic: null,
+      averageDiastolic: null,
+      readingCount: 0,
+      mostRecentCategory: null,
+    };
+  }
+
+  const totalSystolic = readings.reduce((sum, r) => sum + r.systolic, 0);
+  const totalDiastolic = readings.reduce((sum, r) => sum + r.diastolic, 0);
+
+  const latest = readings.reduce((a, b) =>
+    (b.recordedAt ?? "") > (a.recordedAt ?? "")
+      ? b
+      : a,
+  );
+
+  return {
+    averageSystolic: Math.round(totalSystolic / readings.length),
+    averageDiastolic: Math.round(totalDiastolic / readings.length),
+    readingCount: readings.length,
+    mostRecentCategory: classifyBloodPressure(
+      latest.systolic,
+      latest.diastolic,
+    ),
+  };
+}
+
+export function readingsWithinLastDays(
+  readings: BloodPressureReading[],
+  days: number,
+  now: Date = new Date(),
+): BloodPressureReading[] {
+  const cutoff = now.getTime() - days * 24 * 60 * 60 * 1000;
+  return readings.filter((r) => {
+    if (!r.recordedAt) return false;
+    return new Date(r.recordedAt).getTime() >= cutoff;
+  });
+}

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -187,6 +187,7 @@
       "dashboard": "Dashboard",
       "aiHealthAssistant": "AI Health Assistant",
       "healthMetrics": "Health Metrics",
+      "bloodPressureDiary": "Blood Pressure Diary",
       "history": "History",
       "challenges": "Challenges",
       "profile": "Profile",

--- a/src/lib/i18n/locales/hi.json
+++ b/src/lib/i18n/locales/hi.json
@@ -187,6 +187,7 @@
       "dashboard": "डैशबोर्ड",
       "aiHealthAssistant": "एआई हेल्थ असिस्टेंट",
       "healthMetrics": "स्वास्थ्य मेट्रिक्स",
+      "bloodPressureDiary": "ब्लड प्रेशर डायरी",
       "history": "इतिहास",
       "challenges": "चुनौतियाँ",
       "profile": "प्रोफ़ाइल",

--- a/src/lib/i18n/locales/te.json
+++ b/src/lib/i18n/locales/te.json
@@ -187,6 +187,7 @@
       "dashboard": "డాష్‌బోర్డ్",
       "aiHealthAssistant": "AI హెల్త్ అసిస్టెంట్",
       "healthMetrics": "ఆరోగ్య మెట్రిక్‌లు",
+      "bloodPressureDiary": "బ్లడ్ ప్రెజర్ డైరీ",
       "history": "చరిత్ర",
       "challenges": "సవాళ్లు",
       "profile": "ప్రొఫైల్",

--- a/src/pages/Health/BloodPressure.test.tsx
+++ b/src/pages/Health/BloodPressure.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { render } from "@/test/utils";
+import BloodPressureDiary from "@/pages/Health/BloodPressure";
+import { showError } from "@/lib/toast-helpers";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn(),
+    },
+    from: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/toast-helpers", () => ({
+  showError: vi.fn(),
+  showInfo: vi.fn(),
+  showSuccess: vi.fn(),
+  showWarning: vi.fn(),
+  showLoading: vi.fn(),
+}));
+
+vi.mock("@/lib/cached-queries", () => ({
+  getCachedData: vi.fn(),
+  invalidateCache: vi.fn(),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  whenEncryptionReady: vi.fn().mockResolvedValue({}),
+  whenKeysReady: vi.fn().mockResolvedValue({ encryptionKey: {}, searchKey: {} }),
+  whenSearchReady: vi.fn().mockResolvedValue({}),
+  generateSearchTokens: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/offline-db", () => ({
+  db: {
+    healthMetrics: {
+      clear: vi.fn(),
+      toArray: vi.fn().mockResolvedValue([]),
+      bulkPut: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+      update: vi.fn(),
+      where: vi.fn(),
+    },
+    symptomHistory: {
+      clear: vi.fn(),
+      toArray: vi.fn().mockResolvedValue([]),
+      bulkPut: vi.fn(),
+      put: vi.fn(),
+    },
+  },
+  decryptSymptom: vi.fn((s) => s),
+  decryptMetric: vi.fn((m) => m),
+  encryptSymptom: vi.fn((s) => s),
+  encryptMetric: vi.fn((m) => m),
+  syncOfflineData: vi.fn().mockResolvedValue(false),
+}));
+
+import { supabase } from "@/integrations/supabase/client";
+import { db } from "@/lib/offline-db";
+
+const mockUser = { id: "test-user-id", email: "test@example.com" };
+
+function mockAuthUser(user: typeof mockUser | null = mockUser) {
+  (supabase.auth.getUser as Mock).mockResolvedValue({ data: { user } });
+}
+
+const sampleRecords = [
+  {
+    id: "bp-1",
+    user_id: mockUser.id,
+    metric_type: "blood_pressure",
+    value: { systolic: 118, diastolic: 76 },
+    notes: null,
+    recorded_at: new Date().toISOString(),
+    pending_sync: 0,
+    pending_delete: 0,
+  },
+  {
+    id: "bp-2",
+    user_id: mockUser.id,
+    metric_type: "blood_pressure",
+    value: { systolic: 142, diastolic: 92 },
+    notes: "Morning reading",
+    recorded_at: "2026-08-01T09:00:00Z",
+    pending_sync: 0,
+    pending_delete: 0,
+  },
+  {
+    id: "hr-1",
+    user_id: mockUser.id,
+    metric_type: "heart_rate",
+    value: { value: 72 },
+    notes: null,
+    recorded_at: "2026-08-01T09:05:00Z",
+    pending_sync: 0,
+    pending_delete: 0,
+  },
+];
+
+describe("BloodPressureDiary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthUser();
+    (db.healthMetrics.where as Mock).mockReturnValue({
+      equals: vi.fn().mockReturnValue({
+        filter: vi.fn().mockReturnValue({
+          toArray: vi.fn().mockResolvedValue(sampleRecords),
+        }),
+        toArray: vi.fn().mockResolvedValue(sampleRecords),
+      }),
+    });
+  });
+
+  it("renders the page title", async () => {
+    render(<BloodPressureDiary />);
+    expect(
+      screen.getByRole("heading", { name: /Blood Pressure Diary/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the weekly summary with data from the last 7 days", async () => {
+    render(<BloodPressureDiary />);
+    await waitFor(() => {
+      // Only bp-1 (today) falls within the 7-day window
+      expect(screen.getByText("118")).toBeInTheDocument();
+      expect(screen.getByText("76")).toBeInTheDocument();
+      expect(screen.getByText("1")).toBeInTheDocument();
+    });
+  });
+
+  it("renders the most recent classification badge", async () => {
+    render(<BloodPressureDiary />);
+    await waitFor(() => {
+      expect(screen.getAllByText("Normal").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("renders history rows and classifies each reading", async () => {
+    render(<BloodPressureDiary />);
+    await waitFor(() => {
+      expect(screen.getByText("118/76 mmHg")).toBeInTheDocument();
+      expect(screen.getByText("142/92 mmHg")).toBeInTheDocument();
+      expect(screen.getAllByText(/Stage 2/i).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("rejects out-of-range readings and shows an error", async () => {
+    const user = userEvent.setup();
+    render(<BloodPressureDiary />);
+
+    await user.type(screen.getByLabelText(/Systolic \(mmHg\)/i), "400");
+    await user.type(screen.getByLabelText(/Diastolic \(mmHg\)/i), "500");
+    await user.click(screen.getByRole("button", { name: /Record Reading/i }));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(
+        "Invalid Reading",
+        expect.stringContaining("Systolic must be 50-300"),
+      );
+    });
+  });
+
+  it("shows the empty state when there are no blood pressure readings", async () => {
+    (db.healthMetrics.where as Mock).mockReturnValue({
+      equals: vi.fn().mockReturnValue({
+        filter: vi.fn().mockReturnValue({
+          toArray: vi.fn().mockResolvedValue([]),
+        }),
+        toArray: vi.fn().mockResolvedValue([]),
+      }),
+    });
+    render(<BloodPressureDiary />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No blood pressure readings yet/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/Health/BloodPressure.tsx
+++ b/src/pages/Health/BloodPressure.tsx
@@ -1,0 +1,460 @@
+import { useEffect, useMemo, useState } from "react";
+import { Activity, HeartPulse, TrendingUp, Trash2, Zap } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useToast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import type { Json } from "@/integrations/supabase/types";
+import { showSuccess, showError } from "@/lib/toast-helpers";
+import { useMetricsHistory } from "@/hooks/useMetricsHistory";
+import { db, type OfflineMetric, encryptMetric } from "@/lib/offline-db";
+import { whenKeysReady } from "@/lib/encryption";
+import { invalidateCache } from "@/lib/cached-queries";
+import {
+  classifyBloodPressure,
+  summarizeBloodPressure,
+  readingsWithinLastDays,
+  isSystolicValid,
+  isDiastolicValid,
+  type BloodPressureReading,
+  type HypertensionClassification,
+} from "@/lib/hypertension";
+
+const CATEGORY_BADGE: Record<string, string> = {
+  normal: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30",
+  elevated: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-400 border-yellow-500/30",
+  stage1: "bg-orange-500/15 text-orange-700 dark:text-orange-400 border-orange-500/30",
+  stage2: "bg-red-500/15 text-red-700 dark:text-red-400 border-red-500/30",
+  crisis: "bg-purple-600/15 text-purple-700 dark:text-purple-400 border-purple-600/30",
+};
+
+function toReading(record: OfflineMetric): BloodPressureReading | null {
+  const value = record.value as
+    | { systolic?: number; diastolic?: number }
+    | null;
+  if (
+    !value ||
+    typeof value.systolic !== "number" ||
+    typeof value.diastolic !== "number"
+  ) {
+    return null;
+  }
+  return {
+    systolic: value.systolic,
+    diastolic: value.diastolic,
+    recordedAt: record.recorded_at,
+    notes: record.notes,
+  };
+}
+
+const BloodPressureDiary = () => {
+  const [systolic, setSystolic] = useState("");
+  const [diastolic, setDiastolic] = useState("");
+  const [notes, setNotes] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [historyUserId, setHistoryUserId] = useState("");
+  const { toast } = useToast();
+
+  const { records, loading: historyLoading, refresh, deleteRecord } =
+    useMetricsHistory(historyUserId);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (user) {
+        setHistoryUserId(user.id);
+      }
+    };
+    fetchUser();
+  }, []);
+
+  const bpReadings = useMemo(
+    () =>
+      records
+        .filter((record) => record.metric_type === "blood_pressure")
+        .map(toReading)
+        .filter((r): r is BloodPressureReading => r !== null),
+    [records],
+  );
+
+  const weeklyReadings = useMemo(
+    () => readingsWithinLastDays(bpReadings, 7),
+    [bpReadings],
+  );
+  const weeklySummary = useMemo(
+    () => summarizeBloodPressure(weeklyReadings),
+    [weeklyReadings],
+  );
+
+  const latestCategory = useMemo(
+    () =>
+      bpReadings.length > 0
+        ? classifyBloodPressure(
+            bpReadings[0].systolic,
+            bpReadings[0].diastolic,
+          )
+        : null,
+    [bpReadings],
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const sys = Number(systolic);
+    const dia = Number(diastolic);
+
+    if (!isSystolicValid(sys) || !isDiastolicValid(dia)) {
+      showError(
+        "Invalid Reading",
+        "Systolic must be 50-300 and diastolic 30-200 mmHg.",
+      );
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error("Not authenticated");
+      setHistoryUserId(user.id);
+
+      const recordId = crypto.randomUUID();
+      const recordedAt = new Date().toISOString();
+      const keys = await whenKeysReady();
+
+      const record = {
+        id: recordId,
+        user_id: user.id,
+        metric_type: "blood_pressure",
+        value: { systolic: sys, diastolic: dia } as Json,
+        notes: notes || null,
+        recorded_at: recordedAt,
+        pending_sync: navigator.onLine ? 0 : 1,
+        pending_delete: 0,
+      };
+
+      const encryptedRecord = await encryptMetric(record, keys.encryptionKey, keys.searchKey);
+
+      if (navigator.onLine) {
+        const { pending_sync, pending_delete, ...supabaseData } = encryptedRecord;
+        const { error } = await supabase
+          .from("health_metrics")
+          .insert(supabaseData);
+        if (error) throw error;
+        await invalidateCache("health_metrics");
+        await db.healthMetrics.put(encryptedRecord);
+        showSuccess("Reading Recorded", "Blood pressure saved successfully.");
+      } else {
+        await db.healthMetrics.put(encryptedRecord);
+        showSuccess(
+          "Reading Saved Offline",
+          "No internet connection. Saved locally and will sync once online.",
+        );
+      }
+
+      setSystolic("");
+      setDiastolic("");
+      setNotes("");
+      refresh();
+    } catch (error) {
+      console.error("Error saving blood pressure:", error);
+      showError("Failed to Save", "Could not record your blood pressure reading");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatDate = (date: string) =>
+    new Date(date).toLocaleString([], {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+  const CategoryBadge = ({ classification }: { classification: HypertensionClassification }) => (
+    <Badge className={CATEGORY_BADGE[classification.category]}>
+      {classification.label}
+    </Badge>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground flex items-center gap-3">
+          <HeartPulse className="w-8 h-8 text-primary" />
+          Blood Pressure Diary
+        </h1>
+        <p className="text-muted-foreground">
+          Log systolic and diastolic readings and track hypertension trends
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Record New Reading</CardTitle>
+            <CardDescription>
+              Enter your latest blood pressure measurement
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="systolic">Systolic (mmHg)</Label>
+                  <Input
+                    id="systolic"
+                    type="number"
+                    placeholder="120"
+                    value={systolic}
+                    onChange={(e) => setSystolic(e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="diastolic">Diastolic (mmHg)</Label>
+                  <Input
+                    id="diastolic"
+                    type="number"
+                    placeholder="80"
+                    value={diastolic}
+                    onChange={(e) => setDiastolic(e.target.value)}
+                    required
+                  />
+                </div>
+              </div>
+
+              {systolic && diastolic && isSystolicValid(Number(systolic)) && isDiastolicValid(Number(diastolic)) && (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Activity className="w-4 h-4" />
+                  Classification:
+                  <CategoryBadge
+                    classification={classifyBloodPressure(
+                      Number(systolic),
+                      Number(diastolic),
+                    )}
+                  />
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="notes">Notes (Optional)</Label>
+                <Input
+                  id="notes"
+                  type="text"
+                  placeholder="e.g. After morning walk, resting"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                />
+              </div>
+
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading ? "Saving..." : "Record Reading"}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <TrendingUp className="w-5 h-5 text-primary" />
+                Weekly Trend Summary
+              </CardTitle>
+              <CardDescription>
+                Average readings from the last 7 days
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {weeklySummary.readingCount === 0 ? (
+                <div className="text-sm text-muted-foreground py-4 text-center">
+                  No readings in the last 7 days yet.
+                </div>
+              ) : (
+                <div className="grid grid-cols-3 gap-4">
+                  <div className="text-center">
+                    <p className="text-2xl font-bold">
+                      {weeklySummary.averageSystolic}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Avg Systolic
+                    </p>
+                  </div>
+                  <div className="text-center">
+                    <p className="text-2xl font-bold">
+                      {weeklySummary.averageDiastolic}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Avg Diastolic
+                    </p>
+                  </div>
+                  <div className="text-center">
+                    <p className="text-2xl font-bold">
+                      {weeklySummary.readingCount}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Readings (7d)
+                    </p>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Zap className="w-5 h-5 text-primary" />
+                Latest Classification
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {latestCategory ? (
+                <div className="flex items-center justify-between">
+                  <div>
+                    <CategoryBadge classification={latestCategory} />
+                    <p className="text-sm text-muted-foreground mt-2">
+                      {latestCategory.description}
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-sm text-muted-foreground py-4 text-center">
+                  Record your first reading to see a classification.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Reading History</CardTitle>
+          <CardDescription>
+            Your timestamped blood pressure readings
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {historyLoading ? (
+            <div className="py-10 text-center text-muted-foreground">
+              Loading readings...
+            </div>
+          ) : bpReadings.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <p className="text-lg font-medium">No blood pressure readings yet</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                Record your first reading above to start tracking your trends.
+              </p>
+            </div>
+          ) : (
+            <div className="rounded-xl border overflow-x-auto">
+              <Table className="min-w-[600px]">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Reading</TableHead>
+                    <TableHead>Classification</TableHead>
+                    <TableHead>Notes</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {bpReadings.map((reading) => {
+                    const classification = classifyBloodPressure(
+                      reading.systolic,
+                      reading.diastolic,
+                    );
+                    const record = records.find(
+                      (r) =>
+                        r.recorded_at === reading.recordedAt &&
+                        (r.value as { systolic?: number }).systolic === reading.systolic,
+                    );
+                    return (
+                      <TableRow key={reading.recordedAt}>
+                        <TableCell>
+                          {reading.recordedAt ? formatDate(reading.recordedAt) : "-"}
+                        </TableCell>
+                        <TableCell className="font-medium">
+                          {reading.systolic}/{reading.diastolic} mmHg
+                        </TableCell>
+                        <TableCell>
+                          <CategoryBadge classification={classification} />
+                        </TableCell>
+                        <TableCell>{reading.notes || "-"}</TableCell>
+                        <TableCell>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button variant="destructive" size="icon">
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Delete Reading?</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  This action cannot be undone. The selected blood
+                                  pressure reading will be permanently removed.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction
+                                  onClick={() => {
+                                    if (record) deleteRecord(record.id);
+                                  }}
+                                >
+                                  Delete
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default BloodPressureDiary;


### PR DESCRIPTION
## Summary

Implements the **Blood Pressure Diary** feature requested in #1222.

### What's included
- **Systolic / diastolic input** with range validation (50-300 / 30-200 mmHg) and live classification preview
- **Hypertension classification** per ACC/AHA guidelines: Normal, Elevated, Stage 1, Stage 2, and Hypertensive Crisis
- **Weekly trend summary card**: average systolic/diastolic and reading count over the last 7 days
- **Timestamped reading history** table with per-row classification and delete (with confirm dialog)
- **Offline-first**: reuses the app's existing encrypted Dexie/Supabase pipeline (`encryptMetric`, `useMetricsHistory`), so readings persist and sync exactly like other health metrics
- **Routing + navigation**: new `/blood-pressure` route (protected) and sidebar entry, with EN/HI/TE translations

### Files
- `src/lib/hypertension.ts` — pure classification/summary/validation logic
- `src/lib/hypertension.test.ts` — 12 unit tests
- `src/pages/Health/BloodPressure.tsx` — the page
- `src/pages/Health/BloodPressure.test.tsx` — 6 component tests
- `src/App.tsx`, `src/components/layout/AppSidebar.tsx`, `src/lib/i18n/locales/{en,hi,te}.json`

### Acceptance criteria
- [x] Systolic and diastolic reading input
- [x] Hypertension classification (Normal, Elevated, Stage 1, Stage 2)
- [x] Weekly trend summary card
- [x] Timestamped reading history log with delete
- [x] TypeScript and Vitest compliance

### Verification
- `tsc -b`: no new errors (baseline 14 pre-existing errors in `Metrics/index.tsx` unchanged, tracked in #1053)
- `vitest run`: 18 new tests pass; no new failures (10 pre-existing `encryption.test.ts` failures unchanged, caused by upstream revert commits)
- `npm run build`: ✓
- `eslint` on all touched files: ✓

Fixes #1222