### PR TITLE
Feat #1228: Hydration Tracker with daily goal progress

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ const BlogPostPage = lazy(() => import("@/pages/Blog/BlogPostPage.tsx"));
 const ResetPassword = lazy(() => import("./pages/User/ResetPassword.tsx"));
 const GamificationPage = lazy(() => import("@/pages/Gamification"));
 const Reminders = lazy(() => import("./pages/Reminders/index.tsx"));
+const HydrationTracker = lazy(() => import("./pages/Health/Hydration.tsx"));
 
 // Loading spinner fallback component
 const LoadingScreen = () => (
@@ -166,6 +167,16 @@ const App = () => {
                   <ProtectedRoute>
                     <Layout>
                       <Metrics />
+                    </Layout>
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/hydration"
+                element={
+                  <ProtectedRoute>
+                    <Layout>
+                      <HydrationTracker />
                     </Layout>
                   </ProtectedRoute>
                 }

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -15,6 +15,7 @@ import {
   PanelLeftClose,
   Check,
   Bell,
+  Droplet,
 } from "lucide-react";
 
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
@@ -54,6 +55,7 @@ const menuItems = [
   { titleKey: "sidebar.items.dashboard", url: "/dashboard", icon: LayoutDashboard },
   { titleKey: "sidebar.items.aiHealthAssistant", url: "/ai-health-assistant", icon: Bot },
   { titleKey: "sidebar.items.healthMetrics", url: "/metrics", icon: Activity },
+  { titleKey: "sidebar.items.hydrationTracker", url: "/hydration", icon: Droplet },
   { titleKey: "sidebar.items.history", url: "/history", icon: History },
   { titleKey: "sidebar.items.challenges", url: "/gamification", icon: Trophy },
   { titleKey: "sidebar.items.profile", url: "/profile", icon: User },

--- a/src/lib/hydration.test.ts
+++ b/src/lib/hydration.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_DAILY_GOAL_ML,
+  QUICK_ADD_OPTIONS_ML,
+  summarizeDay,
+  intakesOnSameDay,
+  isAmountValid,
+  isDailyGoalValid,
+  type HydrationIntake,
+} from "./hydration";
+
+describe("isAmountValid", () => {
+  it("accepts positive amounts up to 5000 ml", () => {
+    expect(isAmountValid(200)).toBe(true);
+    expect(isAmountValid(1)).toBe(true);
+    expect(isAmountValid(5000)).toBe(true);
+  });
+
+  it("rejects zero, negatives, out-of-range, and non-finite values", () => {
+    expect(isAmountValid(0)).toBe(false);
+    expect(isAmountValid(-100)).toBe(false);
+    expect(isAmountValid(5001)).toBe(false);
+    expect(isAmountValid(NaN)).toBe(false);
+  });
+});
+
+describe("isDailyGoalValid", () => {
+  it("accepts goals between 250 and 20000 ml", () => {
+    expect(isDailyGoalValid(250)).toBe(true);
+    expect(isDailyGoalValid(2000)).toBe(true);
+    expect(isDailyGoalValid(20000)).toBe(true);
+  });
+
+  it("rejects goals outside the supported range", () => {
+    expect(isDailyGoalValid(249)).toBe(false);
+    expect(isDailyGoalValid(20001)).toBe(false);
+    expect(isDailyGoalValid(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});
+
+describe("summarizeDay", () => {
+  it("returns zeros when there are no intakes", () => {
+    const summary = summarizeDay([]);
+    expect(summary.totalMl).toBe(0);
+    expect(summary.remainingMl).toBe(DEFAULT_DAILY_GOAL_ML);
+    expect(summary.percentComplete).toBe(0);
+    expect(summary.entries).toBe(0);
+  });
+
+  it("computes total, remaining, and percent against the default goal", () => {
+    const summary = summarizeDay([
+      { amountMl: 1000 },
+      { amountMl: 500 },
+    ]);
+    expect(summary.totalMl).toBe(1500);
+    expect(summary.remainingMl).toBe(500);
+    expect(summary.percentComplete).toBe(75);
+    expect(summary.entries).toBe(2);
+  });
+
+  it("caps percent at 100 when over the goal", () => {
+    const summary = summarizeDay([
+      { amountMl: 2500 },
+      { amountMl: 500 },
+    ]);
+    expect(summary.percentComplete).toBe(100);
+    expect(summary.remainingMl).toBe(0);
+  });
+
+  it("respects a custom daily goal", () => {
+    const summary = summarizeDay([{ amountMl: 1500 }], 3000);
+    expect(summary.percentComplete).toBe(50);
+    expect(summary.remainingMl).toBe(1500);
+  });
+});
+
+describe("intakesOnSameDay", () => {
+  const now = new Date("2026-08-15T12:00:00Z");
+
+  it("only keeps intakes recorded on the same calendar day", () => {
+    // Built from local Date components so the assertion is timezone-independent.
+    const sameDayMorning = new Date(2026, 7, 15, 8, 0, 0).toISOString();
+    const sameDayEvening = new Date(2026, 7, 15, 22, 0, 0).toISOString();
+    const previousDay = new Date(2026, 7, 14, 8, 0, 0).toISOString();
+
+    const intakes: HydrationIntake[] = [
+      { amountMl: 250, recordedAt: sameDayMorning },
+      { amountMl: 500, recordedAt: sameDayEvening },
+      { amountMl: 1000, recordedAt: previousDay },
+    ];
+
+    const today = intakesOnSameDay(intakes, now);
+    expect(today).toHaveLength(2);
+    expect(today.reduce((s, i) => s + i.amountMl, 0)).toBe(750);
+  });
+
+  it("excludes intakes without a timestamp", () => {
+    const mixed = [{ amountMl: 250, recordedAt: "2026-08-15T09:00:00Z" }, { amountMl: 500 }];
+    const today = intakesOnSameDay(mixed, now);
+    expect(today.some((i) => i.recordedAt === undefined)).toBe(false);
+  });
+});
+
+describe("QUICK_ADD_OPTIONS_ML", () => {
+  it("exposes sensible quick-add amounts", () => {
+    expect(QUICK_ADD_OPTIONS_ML).toEqual([200, 250, 500, 1000]);
+  });
+});

--- a/src/lib/hydration.ts
+++ b/src/lib/hydration.ts
@@ -1,0 +1,55 @@
+export const DEFAULT_DAILY_GOAL_ML = 2000;
+
+export const QUICK_ADD_OPTIONS_ML = [200, 250, 500, 1000];
+
+export interface HydrationIntake {
+  amountMl: number;
+  recordedAt?: string;
+  notes?: string | null;
+}
+
+export function isAmountValid(amountMl: number): boolean {
+  return Number.isFinite(amountMl) && amountMl > 0 && amountMl <= 5000;
+}
+
+export function isDailyGoalValid(goalMl: number): boolean {
+  return Number.isFinite(goalMl) && goalMl >= 250 && goalMl <= 20000;
+}
+
+export interface HydrationDaySummary {
+  totalMl: number;
+  remainingMl: number;
+  percentComplete: number;
+  entries: number;
+}
+
+export function summarizeDay(
+  intakes: HydrationIntake[],
+  dailyGoalMl: number = DEFAULT_DAILY_GOAL_ML,
+): HydrationDaySummary {
+  const totalMl = intakes.reduce((sum, i) => sum + i.amountMl, 0);
+  const percentComplete =
+    dailyGoalMl > 0 ? Math.min(100, Math.round((totalMl / dailyGoalMl) * 100)) : 0;
+
+  return {
+    totalMl,
+    remainingMl: Math.max(0, dailyGoalMl - totalMl),
+    percentComplete,
+    entries: intakes.length,
+  };
+}
+
+export function intakesOnSameDay(
+  intakes: HydrationIntake[],
+  now: Date = new Date(),
+): HydrationIntake[] {
+  return intakes.filter((i) => {
+    if (!i.recordedAt) return false;
+    const d = new Date(i.recordedAt);
+    return (
+      d.getFullYear() === now.getFullYear() &&
+      d.getMonth() === now.getMonth() &&
+      d.getDate() === now.getDate()
+    );
+  });
+}

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -194,7 +194,8 @@
       "reminders": "Reminders",
       "brainGames": "Brain Games",
       "healthFacts": "Health Facts",
-      "settings": "Settings"
+      "settings": "Settings",
+      "hydrationTracker": "Hydration Tracker"
     },
     "themeOptions": {
       "light": "Light",

--- a/src/lib/i18n/locales/hi.json
+++ b/src/lib/i18n/locales/hi.json
@@ -194,7 +194,8 @@
       "reminders": "रिमाइंडर",
       "brainGames": "ब्रेन गेम्स",
       "healthFacts": "स्वास्थ्य तथ्य",
-      "settings": "सेटिंग्स"
+      "settings": "सेटिंग्स",
+      "hydrationTracker": "हाइड्रेशन ट्रैकर"
     },
     "themeOptions": {
       "light": "लाइट",

--- a/src/lib/i18n/locales/te.json
+++ b/src/lib/i18n/locales/te.json
@@ -194,7 +194,8 @@
       "reminders": "రిమైండర్‌లు",
       "brainGames": "బ్రెయిన్ గేమ్స్",
       "healthFacts": "ఆరోగ్య వాస్తవాలు",
-      "settings": "సెట్టింగ్‌లు"
+      "settings": "సెట్టింగ్‌లు",
+      "hydrationTracker": "హైడ్రేషన్ ట్రాకర్"
     },
     "themeOptions": {
       "light": "లైట్",

--- a/src/pages/Health/Hydration.test.tsx
+++ b/src/pages/Health/Hydration.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { render } from "@/test/utils";
+import HydrationTracker from "@/pages/Health/Hydration";
+import { showError } from "@/lib/toast-helpers";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn(),
+    },
+    from: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/toast-helpers", () => ({
+  showError: vi.fn(),
+  showInfo: vi.fn(),
+  showSuccess: vi.fn(),
+  showWarning: vi.fn(),
+  showLoading: vi.fn(),
+}));
+
+vi.mock("@/lib/cached-queries", () => ({
+  getCachedData: vi.fn(),
+  invalidateCache: vi.fn(),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  whenEncryptionReady: vi.fn().mockResolvedValue({}),
+  whenKeysReady: vi.fn().mockResolvedValue({ encryptionKey: {}, searchKey: {} }),
+  whenSearchReady: vi.fn().mockResolvedValue({}),
+  generateSearchTokens: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/offline-db", () => ({
+  db: {
+    healthMetrics: {
+      clear: vi.fn(),
+      toArray: vi.fn().mockResolvedValue([]),
+      bulkPut: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+      update: vi.fn(),
+      where: vi.fn(),
+    },
+    symptomHistory: {
+      clear: vi.fn(),
+      toArray: vi.fn().mockResolvedValue([]),
+      bulkPut: vi.fn(),
+      put: vi.fn(),
+    },
+  },
+  decryptSymptom: vi.fn((s) => s),
+  decryptMetric: vi.fn((m) => m),
+  encryptSymptom: vi.fn((s) => s),
+  encryptMetric: vi.fn((m) => m),
+  syncOfflineData: vi.fn().mockResolvedValue(false),
+}));
+
+import { supabase } from "@/integrations/supabase/client";
+import { db } from "@/lib/offline-db";
+
+const mockUser = { id: "test-user-id", email: "test@example.com" };
+
+function mockAuthUser(user: typeof mockUser | null = mockUser) {
+  (supabase.auth.getUser as Mock).mockResolvedValue({ data: { user } });
+}
+
+const sampleRecords = [
+  {
+    id: "hyd-1",
+    user_id: mockUser.id,
+    metric_type: "hydration",
+    value: { value: 1000 },
+    notes: null,
+    recorded_at: new Date().toISOString(),
+    pending_sync: 0,
+    pending_delete: 0,
+  },
+  {
+    id: "hyd-2",
+    user_id: mockUser.id,
+    metric_type: "hydration",
+    value: { value: 500 },
+    notes: "After lunch",
+    recorded_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    pending_sync: 0,
+    pending_delete: 0,
+  },
+  {
+    id: "steps-1",
+    user_id: mockUser.id,
+    metric_type: "steps",
+    value: { value: 8000 },
+    notes: null,
+    recorded_at: new Date().toISOString(),
+    pending_sync: 0,
+    pending_delete: 0,
+  },
+];
+
+function mockWhereRecords(records: unknown[]) {
+  (db.healthMetrics.where as Mock).mockReturnValue({
+    equals: vi.fn().mockReturnValue({
+      filter: vi.fn().mockReturnValue({
+        toArray: vi.fn().mockResolvedValue(records),
+      }),
+      toArray: vi.fn().mockResolvedValue(records),
+    }),
+  });
+}
+
+describe("HydrationTracker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthUser();
+    mockWhereRecords(sampleRecords);
+  });
+
+  it("renders the page title", async () => {
+    render(<HydrationTracker />);
+    expect(
+      screen.getByRole("heading", { name: /Hydration Tracker/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows today's total and percent complete", async () => {
+    render(<HydrationTracker />);
+    await waitFor(() => {
+      expect(screen.getByText(/1500 \/ 2000 ml/i)).toBeInTheDocument();
+      expect(screen.getByText("75%")).toBeInTheDocument();
+      expect(screen.getByText("500 ml remaining to hit today's goal")).toBeInTheDocument();
+    });
+  });
+
+  it("shows today's summary card totals", async () => {
+    render(<HydrationTracker />);
+    await waitFor(() => {
+      expect(screen.getByText("ml today")).toBeInTheDocument();
+      expect(screen.getByText("intakes today")).toBeInTheDocument();
+    });
+  });
+
+  it("renders history rows with amounts and notes", async () => {
+    render(<HydrationTracker />);
+    await waitFor(() => {
+      expect(screen.getByRole("cell", { name: "1000 ml" })).toBeInTheDocument();
+      expect(screen.getByRole("cell", { name: "500 ml" })).toBeInTheDocument();
+      expect(screen.getByRole("cell", { name: "After lunch" })).toBeInTheDocument();
+    });
+  });
+
+  it("pre-fills the amount when a quick-add option is clicked", async () => {
+    const user = userEvent.setup();
+    render(<HydrationTracker />);
+
+    await user.click(screen.getByRole("button", { name: /250 ml/i }));
+    expect(screen.getByLabelText(/Amount \(ml\)/i)).toHaveValue(250);
+  });
+
+  it("rejects invalid amounts with an error toast", async () => {
+    const user = userEvent.setup();
+    render(<HydrationTracker />);
+
+    await user.type(screen.getByLabelText(/Amount \(ml\)/i), "0");
+    await user.click(screen.getByRole("button", { name: /Log Intake/i }));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(
+        "Invalid Amount",
+        expect.stringContaining("between 1 and 5000 ml"),
+      );
+    });
+  });
+
+  it("shows the empty state when there are no hydration intakes", async () => {
+    mockWhereRecords([]);
+    render(<HydrationTracker />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No water intakes logged yet/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/Health/Hydration.tsx
+++ b/src/pages/Health/Hydration.tsx
@@ -1,0 +1,406 @@
+import { useEffect, useMemo, useState } from "react";
+import { Droplet, Plus, Target, Trash2, TrendingUp } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useToast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import type { Json } from "@/integrations/supabase/types";
+import { showSuccess, showError } from "@/lib/toast-helpers";
+import { useMetricsHistory } from "@/hooks/useMetricsHistory";
+import { db, type OfflineMetric, encryptMetric } from "@/lib/offline-db";
+import { whenKeysReady } from "@/lib/encryption";
+import { invalidateCache } from "@/lib/cached-queries";
+import {
+  DEFAULT_DAILY_GOAL_ML,
+  QUICK_ADD_OPTIONS_ML,
+  summarizeDay,
+  intakesOnSameDay,
+  isAmountValid,
+  isDailyGoalValid,
+  type HydrationIntake,
+} from "@/lib/hydration";
+
+function toIntake(record: OfflineMetric): HydrationIntake | null {
+  const value = record.value as { value?: number } | null;
+  if (!value || typeof value.value !== "number") return null;
+  return {
+    amountMl: value.value,
+    recordedAt: record.recorded_at,
+    notes: record.notes,
+  };
+}
+
+const HydrationTracker = () => {
+  const [amount, setAmount] = useState("");
+  const [notes, setNotes] = useState("");
+  const [dailyGoal, setDailyGoal] = useState(DEFAULT_DAILY_GOAL_ML.toString());
+  const [loading, setLoading] = useState(false);
+  const [historyUserId, setHistoryUserId] = useState("");
+  const { toast } = useToast();
+
+  const { records, loading: historyLoading, refresh, deleteRecord } =
+    useMetricsHistory(historyUserId);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (user) {
+        setHistoryUserId(user.id);
+      }
+    };
+    fetchUser();
+  }, []);
+
+  const allIntakes = useMemo(
+    () =>
+      records
+        .filter((record) => record.metric_type === "hydration")
+        .map(toIntake)
+        .filter((i): i is HydrationIntake => i !== null),
+    [records],
+  );
+
+  const todayIntakes = useMemo(() => intakesOnSameDay(allIntakes), [allIntakes]);
+
+  const parsedGoal = Number(dailyGoal);
+  const goalMl = isDailyGoalValid(parsedGoal)
+    ? parsedGoal
+    : DEFAULT_DAILY_GOAL_ML;
+
+  const summary = useMemo(
+    () => summarizeDay(todayIntakes, goalMl),
+    [todayIntakes, goalMl],
+  );
+
+  const handleAddIntake = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const amountMl = Number(amount);
+    if (!isAmountValid(amountMl)) {
+      showError(
+        "Invalid Amount",
+        "Please enter a water amount between 1 and 5000 ml.",
+      );
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error("Not authenticated");
+      setHistoryUserId(user.id);
+
+      const recordId = crypto.randomUUID();
+      const recordedAt = new Date().toISOString();
+      const keys = await whenKeysReady();
+
+      const record = {
+        id: recordId,
+        user_id: user.id,
+        metric_type: "hydration",
+        value: { value: amountMl } as Json,
+        notes: notes || null,
+        recorded_at: recordedAt,
+        pending_sync: navigator.onLine ? 0 : 1,
+        pending_delete: 0,
+      };
+
+      const encryptedRecord = await encryptMetric(
+        record,
+        keys.encryptionKey,
+        keys.searchKey,
+      );
+
+      if (navigator.onLine) {
+        const { pending_sync, pending_delete, ...supabaseData } = encryptedRecord;
+        const { error } = await supabase
+          .from("health_metrics")
+          .insert(supabaseData);
+        if (error) throw error;
+        await invalidateCache("health_metrics");
+        await db.healthMetrics.put(encryptedRecord);
+        showSuccess("Water Logged", "Your intake has been saved.");
+      } else {
+        await db.healthMetrics.put(encryptedRecord);
+        showSuccess(
+          "Saved Offline",
+          "No internet connection. Saved locally and will sync once online.",
+        );
+      }
+
+      setAmount("");
+      setNotes("");
+      refresh();
+    } catch (error) {
+      console.error("Error saving hydration:", error);
+      showError("Failed to Save", "Could not record your water intake");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatDate = (date: string) =>
+    new Date(date).toLocaleString([], {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground flex items-center gap-3">
+          <Droplet className="w-8 h-8 text-primary" />
+          Hydration Tracker
+        </h1>
+        <p className="text-muted-foreground">
+          Log your water intake and work toward your daily goal
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Log Water Intake</CardTitle>
+            <CardDescription>
+              Quick-add a glass or enter a custom amount
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleAddIntake} className="space-y-4">
+              <div className="flex flex-wrap gap-2">
+                {QUICK_ADD_OPTIONS_ML.map((ml) => (
+                  <Button
+                    key={ml}
+                    type="button"
+                    variant="outline"
+                    onClick={() => setAmount(ml.toString())}
+                    className="gap-1"
+                  >
+                    <Plus className="h-4 w-4" />
+                    {ml} ml
+                  </Button>
+                ))}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="amount">Amount (ml)</Label>
+                <Input
+                  id="amount"
+                  type="number"
+                  placeholder="e.g. 250"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="notes">Notes (Optional)</Label>
+                <Input
+                  id="notes"
+                  type="text"
+                  placeholder="e.g. Glass of water after lunch"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                />
+              </div>
+
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading ? "Saving..." : "Log Intake"}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Target className="w-5 h-5 text-primary" />
+                Today's Goal
+              </CardTitle>
+              <CardDescription>
+                Daily hydration target (ml)
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center gap-2">
+                <Input
+                  id="dailyGoal"
+                  type="number"
+                  value={dailyGoal}
+                  onChange={(e) => setDailyGoal(e.target.value)}
+                  min={250}
+                  max={20000}
+                  className="max-w-[160px]"
+                />
+                <span className="text-sm text-muted-foreground">ml</span>
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">
+                    {summary.totalMl} / {goalMl} ml
+                  </span>
+                  <span className="font-medium">{summary.percentComplete}%</span>
+                </div>
+                <Progress value={summary.percentComplete} className="h-3" />
+              </div>
+
+              {summary.remainingMl > 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  {summary.remainingMl} ml remaining to hit today's goal
+                </p>
+              ) : (
+                <p className="text-sm text-emerald-600 dark:text-emerald-400">
+                  Daily goal reached — well done!
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <TrendingUp className="w-5 h-5 text-primary" />
+                Today's Summary
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="text-center">
+                  <p className="text-2xl font-bold">{summary.totalMl}</p>
+                  <p className="text-xs text-muted-foreground">ml today</p>
+                </div>
+                <div className="text-center">
+                  <p className="text-2xl font-bold">{summary.entries}</p>
+                  <p className="text-xs text-muted-foreground">intakes today</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Intake History</CardTitle>
+          <CardDescription>
+            Your timestamped water intake log
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {historyLoading ? (
+            <div className="py-10 text-center text-muted-foreground">
+              Loading intake history...
+            </div>
+          ) : allIntakes.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <p className="text-lg font-medium">No water intakes logged yet</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                Log your first glass above to start tracking your hydration.
+              </p>
+            </div>
+          ) : (
+            <div className="rounded-xl border overflow-x-auto">
+              <Table className="min-w-[600px]">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Amount</TableHead>
+                    <TableHead>Notes</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {allIntakes.map((intake) => {
+                    const record = records.find(
+                      (r) =>
+                        r.recorded_at === intake.recordedAt &&
+                        (r.value as { value?: number }).value === intake.amountMl,
+                    );
+                    return (
+                      <TableRow key={intake.recordedAt}>
+                        <TableCell>
+                          {intake.recordedAt ? formatDate(intake.recordedAt) : "-"}
+                        </TableCell>
+                        <TableCell className="font-medium">
+                          {intake.amountMl} ml
+                        </TableCell>
+                        <TableCell>{intake.notes || "-"}</TableCell>
+                        <TableCell>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button variant="destructive" size="icon">
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Delete Intake?</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  This action cannot be undone. The selected water
+                                  intake entry will be permanently removed.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction
+                                  onClick={() => {
+                                    if (record) deleteRecord(record.id);
+                                  }}
+                                >
+                                  Delete
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default HydrationTracker;


### PR DESCRIPTION
## Summary

Implements the **Hydration Tracker** feature requested in #1228.

### What's included
- **Quick-add input** for water volume: 200/250/500/1000 ml presets plus a custom ml input (validated 1-5000 ml)
- **Daily total progress bar** with a personalised editable daily goal (250-20000 ml) and % complete
- **Timestamped intake log** with per-row delete (confirm dialog)
- **Summary card** with today's total ml and intake count
- **Offline-first**: reuses the app's encrypted Dexie/Supabase pipeline (`encryptMetric`, `useMetricsHistory`, metric_type `hydration`), consistent with the existing Metrics page
- **Routing + navigation**: new `/hydration` route (protected) and sidebar entry, with EN/HI/TE translations

### Files
- `src/lib/hydration.ts` — pure validation/summary logic
- `src/lib/hydration.test.ts` — 12 unit tests
- `src/pages/Health/Hydration.tsx` — the page
- `src/pages/Health/Hydration.test.tsx` — 6 component tests
- `src/App.tsx`, `src/components/layout/AppSidebar.tsx`, `src/lib/i18n/locales/{en,hi,te}.json`

### Acceptance criteria
- [x] Quick-add input for water volume in ml
- [x] Daily total progress bar
- [x] Timestamped intake log
- [x] Summary card with total for the day
- [x] TypeScript and Vitest compliance

### Verification
- `tsc -b`: no new errors (14 pre-existing errors in `Metrics/index.tsx` unchanged, tracked in #1053)
- `vitest run`: 18 new tests pass; no new failures
- `npm run build`: ✓
- `eslint` on all touched files: ✓

Fixes #1228