### PR TITLE
Fix: remove partial assistant response on chat stream failure

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -200,8 +200,24 @@ const ChatInterface = () => {
     streamAbortRef.current = abortController;
 
     let assistantContent = "";
+    let assistantMessageCreated = false;
+
+    const removeCurrentAssistant = () => {
+      if (!assistantMessageCreated) return;
+
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+
+        if (last?.role === "assistant") {
+          return prev.slice(0, -1);
+        }
+
+        return prev;
+      });
+    };
 
     const upsertAssistant = (chunk: string) => {
+      assistantMessageCreated = true;
       assistantContent += chunk;
       setMessages((prev) => {
         const last = prev[prev.length - 1];
@@ -439,6 +455,7 @@ const ChatInterface = () => {
         }
       }
     } catch (error) {
+      removeCurrentAssistant();
       if (error instanceof DOMException && error.name === "AbortError") {
         dismissLoading();
         return;


### PR DESCRIPTION
## **Pull Request Description**

### Summary

- Fixes an issue where a partially streamed assistant response remained in the chat UI when the streaming request failed or was aborted.

### Implementation Details

- Added a local `assistantMessageCreated` flag to track whether the current request has created an assistant message.
- Added `removeCurrentAssistant()` to remove the partially streamed assistant response when the request fails.
- Called the cleanup helper at the beginning of the catch block so it handles both regular errors and `AbortError`.
- Preserved the existing successful streaming and persistence flow.

---

### **1. Type of Change**
- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Refactoring / Performance** (non-breaking code improvements)
- [ ] **Documentation Update** (changes to README, guides, or comments)
- [ ] **Other** (please specify): _________

---

### **2. Related Issue**
- Fixes #882 

---

### **3. How Has This Been Tested?**
Describe the tests/verification steps you ran to verify your changes.
- [x] **Local Build**: The application builds successfully locally (`npm run build`).
- [x] **Lint/Format Checks**: Local checks passed (`npm run lint` / `npm run format:check`).

---

### **5. Contributor Quality Checklist**
- [x] My code follows the code style and formatting guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There is no commented-out code or debug logs left in the codebase.
